### PR TITLE
Added udev rule for Terios T3 + typo

### DIFF
--- a/packages/libretro/retroarch/udev.d/99-ninteno-wii-remote.rules
+++ b/packages/libretro/retroarch/udev.d/99-ninteno-wii-remote.rules
@@ -1,2 +1,0 @@
-SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote", MODE="666", ENV{ID_INPUT_JOYSTICK}="1"
-SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote Classic Controller", MODE="666", ENV{ID_INPUT_JOYSTICK}="1"


### PR DESCRIPTION
[Source](https://forums.libretro.com/t/bluetooth-controller-connects-but-retroarch-doesnt-detect-input)