### PR TITLE
Fix for Issue 113 [Compiling Lakka for Cubox fails @ Building Retroarch]

### DIFF
--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -60,7 +60,7 @@ elif [ "$OPENGLES" == "bcm2835-driver" ]; then
                   -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux"
 elif [ "$OPENGLES" == "sunxi-mali" ] || [ "$OPENGLES" == "odroidc1-mali" ] || [ "$OPENGLES" == "odroidxu3-mali" ] || [ "$OPENGLES" == "opengl-meson" ] || [ "$OPENGLES" == "opengl-meson8" ]; then
   RETROARCH_GL="--enable-opengles --disable-kms --disable-x11 --enable-mali_fbdev"
-elif [ "$OPENGLES" == "gpu-viv-bin-mx6q" ]; then
+elif [ "$OPENGLES" == "gpu-viv-bin-mx6q" ] || [ "$OPENGLES" == "imx-gpu-viv" ]; then
   RETROARCH_GL="--enable-opengles --disable-kms --disable-x11 --enable-vivante_fbdev"
   CFLAGS="$CFLAGS -DLINUX -DEGL_API_FB"
 fi


### PR DESCRIPTION
I dug a little deeper and I found a solution to issue #113
packages/libretro/retroarch/package.mk was missing the correct $OPENGLES param for the GPU on a Cubox.
"imx-gpu-viv" is the correct string in this case.
Maybe there should be a check here that informs someone that $OPENGLES is set to an unknown parameter?