### PR TITLE
add samba share for the core/game remapping folder

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -178,3 +178,11 @@
   public = yes
   writable = yes
   root preexec = mkdir -p /storage/thumbnails
+
+[Remappings]
+  path = /storage/remappings
+  available = yes
+  browsable = yes
+  public = yes
+  writable = yes
+  root preexec = mkdir -p /storage/remappings


### PR DESCRIPTION
This PR is inspired by a thread in the forums, where a Lakka user asked for help deleting a remapping file.

It seems like it makes some sense to share this folder as well, but I will leave that up to the Lakka team to decide! Here's the thread:
https://forums.libretro.com/t/how-to-delete-a-core-game-remapping-file-lakka/10977