### PR TITLE
Update to use pre_makeinstall_target()

### DIFF
--- a/packages/libretro/libretro-database/package.mk
+++ b/packages/libretro/libretro-database/package.mk
@@ -34,11 +34,10 @@ PKG_LONGDESC="Repository containing cheatcode files, content data files, etc."
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
-make_target() {
-  :
+configure_target() {
+  cd $ROOT/$PKG_BUILD
 }
 
-makeinstall_target() {
-  mkdir -p $INSTALL/usr/share/libretro-database
-  cp -r * $INSTALL/usr/share/libretro-database
+pre_makeinstall_target() {
+  export DESTDIR="$INSTALL/usr/share/libretro-database"
 }

--- a/packages/libretro/retroarch-assets/package.mk
+++ b/packages/libretro/retroarch-assets/package.mk
@@ -38,11 +38,6 @@ configure_target() {
   cd $ROOT/$PKG_BUILD
 }
 
-make_target() {
-  :
-}
-
-makeinstall_target() {
-  mkdir -p $INSTALL/usr/share/retroarch-assets
-  cp -r * $INSTALL/usr/share/retroarch-assets
+pre_makeinstall_target() {
+  export DESTDIR="$INSTALL/usr/share/retroarch-assets"
 }

--- a/packages/libretro/retroarch-joypad-autoconfig/package.mk
+++ b/packages/libretro/retroarch-joypad-autoconfig/package.mk
@@ -34,11 +34,10 @@ PKG_LONGDESC="RetroArch joypad autoconfig files"
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
-make_target() {
-  :
+configure_target() {
+  cd $ROOT/$PKG_BUILD
 }
 
-makeinstall_target() {
-  mkdir -p $INSTALL/etc/retroarch-joypad-autoconfig
-  cp -r * $INSTALL/etc/retroarch-joypad-autoconfig
+pre_makeinstall_target() {
+  export DESTDIR="$INSTALL/etc/retroarch-joypad-autoconfig"
 }


### PR DESCRIPTION
**DONT MERGE YET**

This fixes libretro-database, retroarch-assets and retroarch-joypad-autoconfig. Testing still.