### PR TITLE
retroarch-joypad-autoconfig: update to e317703

### DIFF
--- a/packages/libretro/retroarch-joypad-autoconfig/package.mk
+++ b/packages/libretro/retroarch-joypad-autoconfig/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch-joypad-autoconfig"
-PKG_VERSION="d907d13"
+PKG_VERSION="e317703"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
Brings in the needed Makefile and configure files.