### PR TITLE
lutro: update to 101ba08

### DIFF
--- a/packages/libretro/lutro/package.mk
+++ b/packages/libretro/lutro/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="lutro"
-PKG_VERSION="d11a593"
+PKG_VERSION="101ba08"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
@@ -39,7 +39,7 @@ make_target() {
   if [ "$ARCH" == "x86_64" ]; then
     PTR_SIZE="-m64"
   fi  
-  make WANT_JIT=1 HOST_CC="$HOST_CC" PTR_SIZE="$PTR_SIZE" CROSS="$TARGET_PREFIX" HAVE_COMPOSITION=1
+  make HOST_CC="$HOST_CC" PTR_SIZE="$PTR_SIZE" CROSS="$TARGET_PREFIX" HAVE_COMPOSITION=1
 }
 
 makeinstall_target() {


### PR DESCRIPTION
Also, let Lutro decide whether or not it wants LuaJIT. Regarding https://github.com/libretro/libretro-lutro/issues/113 .