### PR TITLE
chaigame: Compile SDL and PhysFS directly

### DIFF
--- a/packages/libretro/chaigame/package.mk
+++ b/packages/libretro/chaigame/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chaigame"
-PKG_VERSION="73a84d3"
+PKG_VERSION="2ca4c1f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
This update removes the use of the SDL/PhysFS link file usage. It compiles SDL and PhysFS directly from within the parent Makefile.