### PR TITLE
Add RockChip device ROCK64 to build_all.sh

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -69,6 +69,8 @@ DISTRO=Lakka PROJECT=H3 SYSTEM=bpim2p ARCH=arm make image -j8
 DISTRO=Lakka PROJECT=H3 SYSTEM=bx2 ARCH=arm make image -j8
 >&2 echo "TinkerBoard.arm"
 #DISTRO=Lakka PROJECT=Rockchip DEVICE=TinkerBoard ARCH=arm make image -j8
+>&2 echo "ROCK64.arm"
+#DISTRO=Lakka PROJECT=Rockchip DEVICE=ROCK64 ARCH=arm make image -j8
 
 rm target/*.kernel
 rm target/*.system


### PR DESCRIPTION
The ROCK64 image builds and runs stable enough for use. I added it to the build_all.sh