### PR TITLE
safeguarding libretro_update.sh

### DIFF
--- a/libretro_update.sh
+++ b/libretro_update.sh
@@ -2,12 +2,21 @@
 FILES=packages/libretro/*/package.mk
 for f in $FILES
 do
-  source $f
+  PKG_VERSION=`cat $f | sed -En "s/PKG_VERSION=\"(.*)\"/\1/p"`
+  PKG_SITE=`cat $f | sed -En "s/PKG_SITE=\"(.*)\"/\1/p"`
+  PKG_NAME=`cat $f | sed -En "s/PKG_NAME=\"(.*)\"/\1/p"`
+  if [ -z "$PKG_VERSION" ] || [ -z "$PKG_SITE" ] ; then
+    echo "$f: does not have PKG_VERSION or PKG_SITE"
+    echo "PKG_VERSION: $PKG_VERSION"
+    echo "PKG_SITE: $PKG_SITE"
+    echo "Skipping update."
+    continue
+  fi
   UPS_VERSION=`git ls-remote $PKG_SITE | grep HEAD | awk '{ print substr($1,1,7) }'`
   if [ "$UPS_VERSION" == "$PKG_VERSION" ]; then
-    echo "$PKG_NAME is up to date"
+    echo "$PKG_NAME is up to date (local: $PKG_VERSION / remote: $UPS_VERSION)"
   else
-    echo "$PKG_NAME is outdated"
+  echo "$PKG_NAME is outdated (local: $PKG_VERSION / remote: $UPS_VERSION)"
     sed -i "s/$PKG_VERSION/$UPS_VERSION/" $f
   fi
 done


### PR DESCRIPTION
corrected libretro_update.sh script to skip packages that don't have PKG_VERSION or PKG_SITE defined in package.mk.
substituted "source $f" with cat $f | sed .., as "source $f" tried to execute "foo" when "foo" was used in form of "X=$(foo bar)"
for example you have output like:
get_build_dir: command not found
when sourcing packages/libretro/citra/package.mk
-vudiq