### PR TITLE
fix: sources/unpack - when using PKG_GIT_URL

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -60,7 +60,7 @@ fi
 
 [ -f "$STAMP" ] && exit 0
 
-if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
+if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
   printf "%${BUILD_INDENT}c ${boldcyan}UNPACK${endcolor}   $1\n" ' '>&$SILENT_OUT
   export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 


### PR DESCRIPTION
when using PKG_GIT_URL and no PKG_URL, scripts/get exits with 0 (PKG_URL is empty) and hence no $SOURCES/$1 folder exists. So enhancing the condition in scripts/build with PKG_GIT_URL check - if not empty, continue with the unpack.
Please test, my daily builds are running, cannot test on my side.
Affected citra when building from clean repository. This should fix it.