### PR TITLE
gearboy: bump version to latest, 6b69f16 does not exist

### DIFF
--- a/packages/libretro/gearboy/package.mk
+++ b/packages/libretro/gearboy/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="gearboy"
-PKG_VERSION="6b69f16"
+PKG_VERSION="caca6cf"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
Tested only build, not the core behavior / urgent fix for being able to build.