### PR TITLE
Add dockerfile to build lakka anywhere

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build.Lakka*
+sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+from ubuntu:xenial
+
+RUN \
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get install -y \
+    build-essential make wget bash bc gcc sed patch patchutils tar bzip2 gzip perl gawk gperf zip unzip diffutils texinfo lzop \
+    g++ xfonts-utils xfonts-utils xfonts-utils xsltproc libncurses5-dev libjson-perl xz-utils && \
+  rm -rf /var/lib/apt/lists/*
+
+ENV HOME /root
+ENV DISTRO Lakka
+
+COPY . /root
+
+VOLUME /root
+
+WORKDIR /root
+
+CMD make image


### PR DESCRIPTION
On OSX, I use it this way:

    docker build -t lakka .
    docker run -it -v /Users/kivutar/Lakka-LibreELEC:/root lakka

This will build Generic.x86_64 and the build and source folders will be persistent.

You can also pass all the usual env vars and target:

    docker run -ti -v /Users/kivutar/Lakka-LibreELEC:/root -e PROJECT=RPi2 -e ARCH=arm lakka make image

