### PR TITLE
scripts/unpack: save bandwidth/time using git pull [WIP]

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -41,7 +41,7 @@ STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME
 
 # Perform a wildcard match on the package to ensure old versions are cleaned too
 PKG_DEEPMD5=
-GIT_MUST_REBUILD=false
+GIT_MUST_REBUILD="no"
 for i in $BUILD/$1-*; do
   if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
     . "$i/.libreelec-unpack"
@@ -51,7 +51,7 @@ for i in $BUILD/$1-*; do
         if [ -z "$PKG_GIT_URL" ] ; then
         $SCRIPTS/clean $1
         else
-          GIT_MUST_REBUILD=true
+          GIT_MUST_REBUILD="yes"
         fi
       fi
     fi
@@ -63,7 +63,7 @@ if [ -d "$PKG_BUILD" -a ! -f "$STAMP" ]; then
   $SCRIPTS/clean $1
 fi
 
-[ -f "$STAMP" -a !$GIT_MUST_REBUILD ] && exit 0
+[ -f "$STAMP" -a "$GIT_MUST_REBUILD" = "no" ] && exit 0
 
 if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
   printf "%${BUILD_INDENT}c ${boldcyan}UNPACK${endcolor}   $1\n" ' '>&$SILENT_OUT
@@ -138,7 +138,9 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
     if [ -d "$GIT_ORIG_DIR" -a -n "$GIT_ORIG_DIR" ]; then
       # rename the original folder to match current version
       echo "**** debug: Rename '$GIT_ORIG_DIR' to '$BUILD/$PKG_NAME-$PKG_VERSION'"
-      mv $GIT_ORIG_DIR $BUILD/$PKG_NAME-$PKG_VERSION
+      if [ ! "$GIT_ORIG_DIR" = "$BUILD/$PKG_NAME-$PKG_VERSION" ]; then
+        mv $GIT_ORIG_DIR $BUILD/$PKG_NAME-$PKG_VERSION
+      fi
       cd $BUILD/$PKG_NAME-$PKG_VERSION
       # clean
       echo "**** debug: git clean -fdx"

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -119,6 +119,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
           echo "**** debug: STAMP_PKG_NAME=$STAMP_PKG_NAME"
           if [ "$PKG_NAME" = "$STAMP_PKG_NAME" ]; then
             echo "**** debug: NAME matched"
+            cd $f
             BUILD_GIT_URL=$(git remote get-url origin)
             echo "**** debug: BUILD_GIT_URL=$BUILD_GIT_URL | PKG_GIT_URL=$PKG_GIT_URL"
             if [ "$BUILD_GIT_URL" = "$PKG_GIT_URL" ]; then
@@ -133,6 +134,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
     if [ -d "$GIT_ORIG_DIR" -a -n "$GIT_ORIG_DIR" ]; then
       # rename the original folder to match current version
       echo "**** debug: Rename '$GIT_ORIG_DIR' to '$BUILD/$PKG_NAME-$PKG_VERSION'"
+      cd $BUILD
       mv $GIT_ORIG_DIR $BUILD/$PKG_NAME-$PKG_VERSION
       cd $BUILD/$PKG_NAME-$PKG_VERSION
       # clean
@@ -146,6 +148,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
       echo "**** debug: git pull"
       git pull
     else
+      cd $BUILD
       # clean
       $SCRIPTS/clean $1
       # clone

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -39,7 +39,11 @@ mkdir -p $BUILD
 STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
 [ -n "$DEVICE" ] && STAMP_DEPENDS="$STAMP_DEPENDS $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME"
 
+. $PKG_DIR/package.mk
+
 # Perform a wildcard match on the package to ensure old versions are cleaned too
+# But only in case when not using PKG_GIT_URL
+if [ -z "$PKG_GIT_URL" ]; then
 PKG_DEEPMD5=
 for i in $BUILD/$1-*; do
   if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
@@ -52,8 +56,9 @@ for i in $BUILD/$1-*; do
     fi
   fi
 done
+fi
 
-if [ -d "$PKG_BUILD" -a ! -f "$STAMP" ]; then
+if [ -z "$PKG_GIT_URL" -a -d "$PKG_BUILD" -a ! -f "$STAMP" ]; then
   # stale pkg build dir
   $SCRIPTS/clean $1
 fi
@@ -103,9 +108,55 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
   fi
 
   if [ -z "$PKG_URL" -a -n "$PKG_GIT_URL" ]; then
-    rm -rf $BUILD/$PKG_NAME-$PKG_VERSION
+    # int GIT_ORIG_DIR
+    GIT_ORIG_DIR=""
+    # cycle through folders that match $PKG_NAME in $BUILD until we find the right one
+    for f in $BUILD/$1-* ; do
+      echo "**** debug: checking folder '$f':"
+      if [ -d $f ]; then
+        echo "**** debug: '$f' is folder"
+        if [ -f $f/.libreelec-unpack ]; then
+          echo "**** debug: '.iibreelec-unpack' found"
+          source $f/.libreelec-unpack
+          echo "**** debug: STAMP_PKG_NAME=$STAMP_PKG_NAME"
+          if [ "$PKG_NAME" = "$STAMP_PKG_NAME" ]; then
+            echo "**** debug: NAME matched"
+            if [ -f $f/.git/config ]; then
+              echo "**** debug: .git/config found:"
+	      cat $f/.git/config
+              GIT_MATCH=$(grep "$PKG_GIT_URL" $f/.git/config | wc -l)
+              echo "**** debug: GIT_MATCH=$GIT_MATCH"
+	      if [ "$GIT_MATCH" = "1" ]; then
+                # we found the existing folder!
+                GIT_ORIG_DIR=$f
+		break
+              fi
+            fi
+          fi
+        fi
+      fi
+    done
+    if [ -d "$GIT_ORIG_DIR" -a -n "$GIT_ORIG_DIR" ]; then
+      # rename the original folder to match current version
+      mv $GIT_ORIG_DIR $BUILD/$PKG_NAME-$PKG_VERSION
+      cd $BUILD/$PKG_NAME-$PKG_VERSION
+      # clean
+      echo "**** debug: git clean -fdx"
+      git clean -fdx
+      echo "**** debug: git checkout -- ."
+      git checkout -- .
+      echo "**** debug: git checkout master"
+      git checkout master
+      # pull changes
+      echo "**** debug: git pull"
+      git pull
+    else
+      # clean
+      $SCRIPTS/clean $1
+      # clone
     git clone $PKG_GIT_URL $BUILD/$PKG_NAME-$PKG_VERSION/
     cd $BUILD/$PKG_NAME-$PKG_VERSION/
+    fi
     git checkout $PKG_VERSION
     git submodule update --init --recursive
     cd $ROOT

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -108,6 +108,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
   if [ -z "$PKG_URL" -a -n "$PKG_GIT_URL" ]; then
     # init GIT_ORIG_DIR
     GIT_ORIG_DIR=""
+    GIT_PREV_LOCATION=$(pwd)
     # cycle through folders that match $PKG_NAME in $BUILD until we find the right one
     for f in $BUILD/$1-* ; do
       echo "**** debug: checking folder '$f':"
@@ -131,10 +132,10 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
         fi
       fi
     done
+    cd $GIT_PREV_LOCATION
     if [ -d "$GIT_ORIG_DIR" -a -n "$GIT_ORIG_DIR" ]; then
       # rename the original folder to match current version
       echo "**** debug: Rename '$GIT_ORIG_DIR' to '$BUILD/$PKG_NAME-$PKG_VERSION'"
-      cd $BUILD
       mv $GIT_ORIG_DIR $BUILD/$PKG_NAME-$PKG_VERSION
       cd $BUILD/$PKG_NAME-$PKG_VERSION
       # clean
@@ -148,7 +149,6 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
       echo "**** debug: git pull"
       git pull
     else
-      cd $BUILD
       # clean
       $SCRIPTS/clean $1
       # clone

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -39,8 +39,6 @@ mkdir -p $BUILD
 STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
 [ -n "$DEVICE" ] && STAMP_DEPENDS="$STAMP_DEPENDS $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME"
 
-. $PKG_DIR/package.mk
-
 # Perform a wildcard match on the package to ensure old versions are cleaned too
 # But only in case when not using PKG_GIT_URL
 if [ -z "$PKG_GIT_URL" ]; then

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -108,7 +108,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
   fi
 
   if [ -z "$PKG_URL" -a -n "$PKG_GIT_URL" ]; then
-    # int GIT_ORIG_DIR
+    # init GIT_ORIG_DIR
     GIT_ORIG_DIR=""
     # cycle through folders that match $PKG_NAME in $BUILD until we find the right one
     for f in $BUILD/$1-* ; do

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -123,13 +123,13 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
             echo "**** debug: NAME matched"
             if [ -f $f/.git/config ]; then
               echo "**** debug: .git/config found:"
-	      cat $f/.git/config
+              cat $f/.git/config
               GIT_MATCH=$(grep "$PKG_GIT_URL" $f/.git/config | wc -l)
               echo "**** debug: GIT_MATCH=$GIT_MATCH"
-	      if [ "$GIT_MATCH" = "1" ]; then
+              if [ "$GIT_MATCH" = "1" ]; then
                 # we found the existing folder!
                 GIT_ORIG_DIR=$f
-		break
+                break
               fi
             fi
           fi

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -119,16 +119,12 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
           echo "**** debug: STAMP_PKG_NAME=$STAMP_PKG_NAME"
           if [ "$PKG_NAME" = "$STAMP_PKG_NAME" ]; then
             echo "**** debug: NAME matched"
-            if [ -f $f/.git/config ]; then
-              echo "**** debug: .git/config found:"
-              cat $f/.git/config
-              GIT_MATCH=$(grep "$PKG_GIT_URL" $f/.git/config | wc -l)
-              echo "**** debug: GIT_MATCH=$GIT_MATCH"
-              if [ "$GIT_MATCH" = "1" ]; then
-                # we found the existing folder!
-                GIT_ORIG_DIR=$f
-                break
-              fi
+            BUILD_GIT_URL=$(git remote get-url origin)
+            echo "**** debug: BUILD_GIT_URL=$BUILD_GIT_URL | PKG_GIT_URL=$PKG_GIT_URL"
+            if [ "$BUILD_GIT_URL" = "$PKG_GIT_URL" ]; then
+              # we found the existing folder!
+              GIT_ORIG_DIR=$f
+              break
             fi
           fi
         fi
@@ -136,6 +132,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
     done
     if [ -d "$GIT_ORIG_DIR" -a -n "$GIT_ORIG_DIR" ]; then
       # rename the original folder to match current version
+      echo "**** debug: Rename '$GIT_ORIG_DIR' to '$BUILD/$PKG_NAME-$PKG_VERSION'"
       mv $GIT_ORIG_DIR $BUILD/$PKG_NAME-$PKG_VERSION
       cd $BUILD/$PKG_NAME-$PKG_VERSION
       # clean

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -40,28 +40,30 @@ STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME
 [ -n "$DEVICE" ] && STAMP_DEPENDS="$STAMP_DEPENDS $PROJECT_DIR/$PROJECT/devices/$DEVICE/patches/$PKG_NAME"
 
 # Perform a wildcard match on the package to ensure old versions are cleaned too
-# But only in case when not using PKG_GIT_URL
-if [ -z "$PKG_GIT_URL" ]; then
 PKG_DEEPMD5=
+GIT_MUST_REBUILD=false
 for i in $BUILD/$1-*; do
   if [ -d $i -a -f "$i/.libreelec-unpack" ] ; then
     . "$i/.libreelec-unpack"
     if [ "$STAMP_PKG_NAME" = "$1" ]; then
       [ -z "${PKG_DEEPMD5}" ] && PKG_DEEPMD5=$(find $STAMP_DEPENDS -exec md5sum {} \; 2>/dev/null | sort | md5sum | cut -d" " -f1)
       if [ ! "$PKG_DEEPMD5" = "$STAMP_PKG_DEEPMD5" ] ; then
+        if [ -z "$PKG_GIT_URL" ] ; then
         $SCRIPTS/clean $1
+        else
+          GIT_MUST_REBUILD=true
+        fi
       fi
     fi
   fi
 done
-fi
 
-if [ -z "$PKG_GIT_URL" -a -d "$PKG_BUILD" -a ! -f "$STAMP" ]; then
+if [ -d "$PKG_BUILD" -a ! -f "$STAMP" ]; then
   # stale pkg build dir
   $SCRIPTS/clean $1
 fi
 
-[ -f "$STAMP" ] && exit 0
+[ -f "$STAMP" -a !$GIT_MUST_REBUILD ] && exit 0
 
 if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
   printf "%${BUILD_INDENT}c ${boldcyan}UNPACK${endcolor}   $1\n" ' '>&$SILENT_OUT
@@ -97,7 +99,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
         mv $BUILD/$PKG_NAME-$PKG_VERSION* $BUILD/$PKG_NAME-$PKG_VERSION
       fi
     fi
-  
+
     if [ -d "$PKG_DIR/sources" ]; then
       [ ! -d "$BUILD/${PKG_NAME}-${PKG_VERSION}" ] && mkdir -p $BUILD/${PKG_NAME}-${PKG_VERSION}
       cp -PRf $PKG_DIR/sources/* $BUILD/${PKG_NAME}-${PKG_VERSION}

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -116,7 +116,7 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
       if [ -d $f ]; then
         echo "**** debug: '$f' is folder"
         if [ -f $f/.libreelec-unpack ]; then
-          echo "**** debug: '.iibreelec-unpack' found"
+          echo "**** debug: '.libreelec-unpack' found"
           source $f/.libreelec-unpack
           echo "**** debug: STAMP_PKG_NAME=$STAMP_PKG_NAME"
           if [ "$PKG_NAME" = "$STAMP_PKG_NAME" ]; then


### PR DESCRIPTION
For packages where we use a git repository instead of sources archive, we do not need to clone the whole repository every time.

At the beginning we must source the package.mk to have a valid PKG_GIT_URL to skip the cleaning of the old version. Then, instead of doing a `git clone` we:
- find the previous package build folder in BUILD (by comparing PKG_NAME with STAMP_PKG_NAME in .libreelec-unpack and then checking if PKG_GIT_URL is in .git/config) -- this confirms that we are in the correct folder AND the folder is a cloned repository
- remove all changes in the folder - `git clean -fdx` cleans all untracked files and folders and `git checkout -- .` removes all changes to original files (e.g. when patching some files)
- then we must switch to an existing branch - `git checkout master` so we can
- pull the changes from the GitHub repository - `git pull`

If such folder is not found, we use the clean script to clean any old build folders of that package and clone the repository.

We checkout the commit which we want to compile using `git checkout $PKG_VERSION` as previously (this is not changed). The GIT_VERSION for each individual libretro core is parsed in one of the Makefiles of each core. This is also not changed, so cores will build with the GIT_VERSION information.

This is first concept with some debug messages and no indentation changes for easier tracking of the changes.