### PR TITLE
retroarch: Patch to fix keyboard typing

### DIFF
--- a/packages/libretro/retroarch/patches/retroarch-01-xkb-fix.patch
+++ b/packages/libretro/retroarch/patches/retroarch-01-xkb-fix.patch
@@ -1,0 +1,22 @@
+diff --git a/input/drivers/udev_input.c b/input/drivers/udev_input.c
+index bcdacb60a6..d2f00114bd 100644
+--- a/input/drivers/udev_input.c
++++ b/input/drivers/udev_input.c
+@@ -72,7 +72,7 @@
+
+ #include "../../verbosity.h"
+
+-#if defined(HAVE_XKBCOMMON) && defined(HAVE_KMS)
++#if defined(HAVE_XKBCOMMON)
+ #define UDEV_XKB_HANDLING
+ #endif
+
+@@ -1157,7 +1157,7 @@ static void *udev_input_init(const char *joypad_driver)
+       goto error;
+
+    video_context_driver_get_ident(&ctx_ident);
+-   udev->xkb_handling = string_is_equal(ctx_ident.ident, "kms");
++   udev->xkb_handling = true; //string_is_equal(ctx_ident.ident, "kms");
+ #endif
+
+ #if defined(HAVE_EPOLL)


### PR DESCRIPTION
Tested on RPi3. The diff is straightforward.

Fixes #238
Fixes #239