### PR TITLE
retroarch: xmb_show_* renamed to content_show_*

### DIFF
--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -161,9 +161,9 @@ makeinstall_target() {
   sed -i -e "s/# thumbnails_directory =/thumbnails_directory = \/storage\/thumbnails/" $INSTALL/etc/retroarch.cfg
   echo "menu_show_advanced_settings = \"false\"" >> $INSTALL/etc/retroarch.cfg
   echo "menu_wallpaper_opacity = \"1.0\"" >> $INSTALL/etc/retroarch.cfg
-  echo "xmb_show_images = \"false\"" >> $INSTALL/etc/retroarch.cfg
-  echo "xmb_show_music = \"false\"" >> $INSTALL/etc/retroarch.cfg
-  echo "xmb_show_video = \"false\"" >> $INSTALL/etc/retroarch.cfg
+  echo "content_show_images = \"false\"" >> $INSTALL/etc/retroarch.cfg
+  echo "content_show_music = \"false\"" >> $INSTALL/etc/retroarch.cfg
+  echo "content_show_video = \"false\"" >> $INSTALL/etc/retroarch.cfg
 
   # Updater
   if [ "$ARCH" == "arm" ]; then


### PR DESCRIPTION
This has changed in RetroArch - the `xmb_show_*` do not have any effect, the playlists are shown and in `Settings` -> `User Interface` -> `Views` these options are in on position. After changing these to `off` and saving config, found these new variables.

Also noticed that
```
xmb_theme = 3
xmb_menu_color_theme = 9
```
is probably ignored, as in the saved config file was following:
```
xmb_theme = "0"
xmb_menu_color_theme = "4"
```
I did not make any other changes to the settings besides the above.