### PR TITLE
Makefile: clean only specific BUILD_DIRS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,19 @@
-BUILD_DIRS=build.*
+ifeq ($(DISTRO),)
+	_D := *
+else
+	_D := ${DISTRO}
+endif
+ifeq ($(PROJECT)$(DEVICE),)
+	_P := *
+else
+	ifeq ($(DEVICE),)
+		_P := ${PROJECT}
+	else
+		_P := ${DEVICE}
+	endif
+endif
+
+BUILD_DIRS=build.${_D}-${_P}.*
 
 all: release
 


### PR DESCRIPTION
This change allows doing clean and distclean only for specific PROJECT or DEVICE, e.g. `PROJECT=RPi2 make clean` will clean (.stamps and *) only in RPi2 build folder.