### PR TITLE
Rockchip: MiQi & TinkerBoard: remove vulkan-loader

### DIFF
--- a/packages/libretro/beetle-psx/package.mk
+++ b/packages/libretro/beetle-psx/package.mk
@@ -35,11 +35,7 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 make_target() {
-  if [ "$OPENGLES" == "mali-rockchip" -o  "$DEVICE" == "TinkerBoard" -o "$DEVICE" == "MiQi" ]; then
-  make HAVE_VULKAN=1
-  else
   make HAVE_OPENGL=1
- fi
 }
 
 makeinstall_target() {

--- a/projects/Rockchip/devices/MiQi/options
+++ b/projects/Rockchip/devices/MiQi/options
@@ -35,7 +35,7 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS rfkill vulkan-loader"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS rfkill"
 
   # kernel serial console
     EXTRA_CMDLINE="console=uart8250,mmio32,0xff690000"

--- a/projects/Rockchip/devices/TinkerBoard/options
+++ b/projects/Rockchip/devices/TinkerBoard/options
@@ -34,7 +34,7 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS rfkill vulkan-loader"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS rfkill"
 
    # kernel serial console
     EXTRA_CMDLINE="console=uart8250,mmio32,0xff690000"


### PR DESCRIPTION
see https://github.com/libretro/Lakka-LibreELEC/issues/378 - Rockchip is not getting vulkan support (anytime soon at least)