### PR TITLE
beetle-psx: remove Rockchip make flags

### DIFF
--- a/packages/libretro/beetle-psx/package.mk
+++ b/packages/libretro/beetle-psx/package.mk
@@ -35,11 +35,7 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 make_target() {
-  if [ "$OPENGLES" == "mali-rockchip" -o  "$DEVICE" == "TinkerBoard" -o "$DEVICE" == "MiQi" ]; then
-  make HAVE_VULKAN=1
-  else
   make HAVE_OPENGL=1
- fi
 }
 
 makeinstall_target() {


### PR DESCRIPTION
Due to
https://github.com/libretro/Lakka-LibreELEC/blob/a2f526048ffbdea0972dfe0794346907df827f2d/packages/libretro/beetle-psx/package.mk#L24
there is no reason having specific make flags for Rockchip