### PR TITLE
Update mame2010

### DIFF
--- a/packages/libretro/mame2010/package.mk
+++ b/packages/libretro/mame2010/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame2010"
-PKG_VERSION="1f6e65a"
+PKG_VERSION="7be26ce"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"


### PR DESCRIPTION
I just noticed this PR: https://github.com/libretro/Lakka-LibreELEC/pull/395

This week I worked on a two-PR update to mame2010 that fixes some longstanding path issues. The git version that make it into that PR #395 was only the first half. I would suggest updating all the way to `7be26ce` instead.
