### PR TITLE
Update most libretro cores

### DIFF
--- a/packages/libretro/2048/package.mk
+++ b/packages/libretro/2048/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="2048"
-PKG_VERSION="a40238a"
+PKG_VERSION="6b6451b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/4do/package.mk
+++ b/packages/libretro/4do/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="4do"
-PKG_VERSION="312f213"
+PKG_VERSION="12eba56"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL with additional notes"

--- a/packages/libretro/4do/package.mk
+++ b/packages/libretro/4do/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="4do"
-PKG_VERSION="12eba56"
+PKG_VERSION="1d5c6b7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL with additional notes"

--- a/packages/libretro/beetle-bsnes/package.mk
+++ b/packages/libretro/beetle-bsnes/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-bsnes"
-PKG_VERSION="c1e0c11"
+PKG_VERSION="df62d15"
 PKG_REV="1"
 PKG_ARCH="x86_64 i386"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-ngp/package.mk
+++ b/packages/libretro/beetle-ngp/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-ngp"
-PKG_VERSION="1932898"
+PKG_VERSION="9e33e1b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-pce/package.mk
+++ b/packages/libretro/beetle-pce/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-pce"
-PKG_VERSION="d3a1520"
+PKG_VERSION="20105f7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-pcfx/package.mk
+++ b/packages/libretro/beetle-pcfx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-pcfx"
-PKG_VERSION="111625e"
+PKG_VERSION="11be243"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-psx/package.mk
+++ b/packages/libretro/beetle-psx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-psx"
-PKG_VERSION="ad23401"
+PKG_VERSION="7a7ae88"
 PKG_REV="1"
 PKG_ARCH="x86_64 i386"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-psx/package.mk
+++ b/packages/libretro/beetle-psx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-psx"
-PKG_VERSION="7a7ae88"
+PKG_VERSION="791e7a3"
 PKG_REV="1"
 PKG_ARCH="x86_64 i386"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-saturn/package.mk
+++ b/packages/libretro/beetle-saturn/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-saturn"
-PKG_VERSION="b02642f"
+PKG_VERSION="672ef1c"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-saturn/package.mk
+++ b/packages/libretro/beetle-saturn/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-saturn"
-PKG_VERSION="672ef1c"
+PKG_VERSION="4d5edd6"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-vb/package.mk
+++ b/packages/libretro/beetle-vb/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-vb"
-PKG_VERSION="49eee8e"
+PKG_VERSION="857a4b2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-wswan/package.mk
+++ b/packages/libretro/beetle-wswan/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-wswan"
-PKG_VERSION="2343cf3"
+PKG_VERSION="93459f9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/bluemsx/package.mk
+++ b/packages/libretro/bluemsx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="bluemsx"
-PKG_VERSION="8268f7f"
+PKG_VERSION="997643b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/bnes/package.mk
+++ b/packages/libretro/bnes/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="bnes"
-PKG_VERSION="b3b740f"
+PKG_VERSION="cbdf063"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/bsnes-mercury/package.mk
+++ b/packages/libretro/bsnes-mercury/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="bsnes-mercury"
-PKG_VERSION="fea594b"
+PKG_VERSION="2aa1bc1"
 PKG_REV="1"
 PKG_ARCH="x86_64 i386"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="2fa61b7"
+PKG_VERSION="cc7edba"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="cc7edba"
+PKG_VERSION="e691703"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/libretro/core-info/package.mk
+++ b/packages/libretro/core-info/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="core-info"
-PKG_VERSION="9ae30ab"
+PKG_VERSION="d4c973c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/core-info/package.mk
+++ b/packages/libretro/core-info/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="core-info"
-PKG_VERSION="25055f2"
+PKG_VERSION="9ae30ab"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/craft/package.mk
+++ b/packages/libretro/craft/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="craft"
-PKG_VERSION="3513d34"
+PKG_VERSION="7421f79"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/libretro/easyrpg/package.mk
+++ b/packages/libretro/easyrpg/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="easyrpg"
-PKG_VERSION="05e2971"
+PKG_VERSION="80340d4"
 PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/fbalpha/package.mk
+++ b/packages/libretro/fbalpha/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fbalpha"
-PKG_VERSION="54ee769"
+PKG_VERSION="c77ad44"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/fbalpha/package.mk
+++ b/packages/libretro/fbalpha/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fbalpha"
-PKG_VERSION="c77ad44"
+PKG_VERSION="877d3c4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/fceumm/package.mk
+++ b/packages/libretro/fceumm/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fceumm"
-PKG_VERSION="94c2e08"
+PKG_VERSION="16170cd"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/fceumm/package.mk
+++ b/packages/libretro/fceumm/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fceumm"
-PKG_VERSION="71aa945"
+PKG_VERSION="94c2e08"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/freeintv/package.mk
+++ b/packages/libretro/freeintv/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="freeintv"
-PKG_VERSION="4c0e380"
+PKG_VERSION="1c49593"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/fuse-libretro/package.mk
+++ b/packages/libretro/fuse-libretro/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fuse-libretro"
-PKG_VERSION="a990e57"
+PKG_VERSION="58ec13f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/fuse-libretro/package.mk
+++ b/packages/libretro/fuse-libretro/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fuse-libretro"
-PKG_VERSION="58ec13f"
+PKG_VERSION="2edf7ac"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/gambatte/package.mk
+++ b/packages/libretro/gambatte/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="gambatte"
-PKG_VERSION="b1b25eb"
+PKG_VERSION="f946c6d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/gearboy/package.mk
+++ b/packages/libretro/gearboy/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="gearboy"
-PKG_VERSION="caca6cf"
+PKG_VERSION="02bb13d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/gearboy/package.mk
+++ b/packages/libretro/gearboy/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="gearboy"
-PKG_VERSION="02bb13d"
+PKG_VERSION="0ec8fad"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/genesis-plus-gx/package.mk
+++ b/packages/libretro/genesis-plus-gx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="genesis-plus-gx"
-PKG_VERSION="8e7db8d"
+PKG_VERSION="6ba9e05"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/genesis-plus-gx/package.mk
+++ b/packages/libretro/genesis-plus-gx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="genesis-plus-gx"
-PKG_VERSION="6ba9e05"
+PKG_VERSION="0aa222e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/glsl-shaders/package.mk
+++ b/packages/libretro/glsl-shaders/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="glsl-shaders"
-PKG_VERSION="403abc4"
+PKG_VERSION="dd9b3a4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/glsl-shaders/package.mk
+++ b/packages/libretro/glsl-shaders/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="glsl-shaders"
-PKG_VERSION="bee5b88"
+PKG_VERSION="403abc4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/gme/package.mk
+++ b/packages/libretro/gme/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="gme"
-PKG_VERSION="0876813"
+PKG_VERSION="111ca8f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/gw-libretro/package.mk
+++ b/packages/libretro/gw-libretro/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="gw-libretro"
-PKG_VERSION="52f0447"
+PKG_VERSION="9962b03"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/handy/package.mk
+++ b/packages/libretro/handy/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="handy"
-PKG_VERSION="b055dc6"
+PKG_VERSION="a3d88fe"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Zlib"

--- a/packages/libretro/hatari/package.mk
+++ b/packages/libretro/hatari/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="hatari"
-PKG_VERSION="c19b710"
+PKG_VERSION="eb3271d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/libretro-database/package.mk
+++ b/packages/libretro/libretro-database/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="libretro-database"
-PKG_VERSION="a80f0f0"
+PKG_VERSION="1a9d0b3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/libretro-database/package.mk
+++ b/packages/libretro/libretro-database/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="libretro-database"
-PKG_VERSION="22ef40e"
+PKG_VERSION="a80f0f0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/mame/package.mk
+++ b/packages/libretro/mame/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame"
-PKG_VERSION="213a9b4"
+PKG_VERSION="bee25da"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"

--- a/packages/libretro/mame/package.mk
+++ b/packages/libretro/mame/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame"
-PKG_VERSION="bee25da"
+PKG_VERSION="893f1ac"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"

--- a/packages/libretro/mame2003/package.mk
+++ b/packages/libretro/mame2003/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame2003"
-PKG_VERSION="1c89893"
+PKG_VERSION="9e39749"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"

--- a/packages/libretro/mame2010/package.mk
+++ b/packages/libretro/mame2010/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame2010"
-PKG_VERSION="b0f3613"
+PKG_VERSION="917453b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"

--- a/packages/libretro/mame2010/package.mk
+++ b/packages/libretro/mame2010/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame2010"
-PKG_VERSION="1f6e65a"
+PKG_VERSION="b0f3613"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"

--- a/packages/libretro/melonds/package.mk
+++ b/packages/libretro/melonds/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="melonds"
-PKG_VERSION="9440f3d"
+PKG_VERSION="d09e179"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/melonds/package.mk
+++ b/packages/libretro/melonds/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="melonds"
-PKG_VERSION="d09e179"
+PKG_VERSION="154197d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/meteor/package.mk
+++ b/packages/libretro/meteor/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="meteor"
-PKG_VERSION="bcb6235"
+PKG_VERSION="a052776"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/mgba/package.mk
+++ b/packages/libretro/mgba/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mgba"
-PKG_VERSION="848e95f"
+PKG_VERSION="b3c4ab2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2.0"

--- a/packages/libretro/mgba/package.mk
+++ b/packages/libretro/mgba/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mgba"
-PKG_VERSION="a434d82"
+PKG_VERSION="848e95f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2.0"

--- a/packages/libretro/mrboom/package.mk
+++ b/packages/libretro/mrboom/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mrboom"
-PKG_VERSION="e4c06f4"
+PKG_VERSION="e02fb2a"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/mrboom/package.mk
+++ b/packages/libretro/mrboom/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mrboom"
-PKG_VERSION="e02fb2a"
+PKG_VERSION="50ccc5b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/nestopia/package.mk
+++ b/packages/libretro/nestopia/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="nestopia"
-PKG_VERSION="f882362"
+PKG_VERSION="5ecea44"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/nxengine/package.mk
+++ b/packages/libretro/nxengine/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="nxengine"
-PKG_VERSION="3826092"
+PKG_VERSION="0d935ba"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/o2em/package.mk
+++ b/packages/libretro/o2em/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="o2em"
-PKG_VERSION="c3dbcfa"
+PKG_VERSION="84586bb"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Artistic License"

--- a/packages/libretro/parallel-n64/package.mk
+++ b/packages/libretro/parallel-n64/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="parallel-n64"
-PKG_VERSION="dbccb3f"
+PKG_VERSION="ed8b882"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/pcsx_rearmed/package.mk
+++ b/packages/libretro/pcsx_rearmed/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pcsx_rearmed"
-PKG_VERSION="f249ee4"
+PKG_VERSION="ea4f438"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/picodrive/package.mk
+++ b/packages/libretro/picodrive/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="picodrive"
-PKG_VERSION="4ad0087"
+PKG_VERSION="f5d7a8d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"

--- a/packages/libretro/pocketcdg/package.mk
+++ b/packages/libretro/pocketcdg/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pocketcdg"
-PKG_VERSION="2697897"
+PKG_VERSION="8f36c7c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/libretro/pokemini/package.mk
+++ b/packages/libretro/pokemini/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pokemini"
-PKG_VERSION="1bf6e54"
+PKG_VERSION="218bdd5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/ppsspp/package.mk
+++ b/packages/libretro/ppsspp/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="ppsspp"
-PKG_VERSION="7f30ab1"
+PKG_VERSION="dd73f91"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/ppsspp/package.mk
+++ b/packages/libretro/ppsspp/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="ppsspp"
-PKG_VERSION="dd73f91"
+PKG_VERSION="7f30ab1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/prboom/package.mk
+++ b/packages/libretro/prboom/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="prboom"
-PKG_VERSION="a907bcc"
+PKG_VERSION="494885c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/prosystem/package.mk
+++ b/packages/libretro/prosystem/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="prosystem"
-PKG_VERSION="f0268ad"
+PKG_VERSION="71a2d1d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/quicknes/package.mk
+++ b/packages/libretro/quicknes/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="quicknes"
-PKG_VERSION="8c4f63a"
+PKG_VERSION="b4598fd"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"

--- a/packages/libretro/quicknes/package.mk
+++ b/packages/libretro/quicknes/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="quicknes"
-PKG_VERSION="b4598fd"
+PKG_VERSION="75e5e10"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"

--- a/packages/libretro/reicast/package.mk
+++ b/packages/libretro/reicast/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="reicast"
-PKG_VERSION="74c4ddf"
+PKG_VERSION="fff2eb2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/retroarch-assets/package.mk
+++ b/packages/libretro/retroarch-assets/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch-assets"
-PKG_VERSION="40866a8"
+PKG_VERSION="505ad62"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/retroarch-joypad-autoconfig/package.mk
+++ b/packages/libretro/retroarch-joypad-autoconfig/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch-joypad-autoconfig"
-PKG_VERSION="397dc19"
+PKG_VERSION="6547e95"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/retroarch-joypad-autoconfig/package.mk
+++ b/packages/libretro/retroarch-joypad-autoconfig/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch-joypad-autoconfig"
-PKG_VERSION="7c478b0"
+PKG_VERSION="397dc19"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/retroarch-overlays/package.mk
+++ b/packages/libretro/retroarch-overlays/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch-overlays"
-PKG_VERSION="e2495dc"
+PKG_VERSION="218e12a"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/retroarch-overlays/package.mk
+++ b/packages/libretro/retroarch-overlays/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch-overlays"
-PKG_VERSION="218e12a"
+PKG_VERSION="9304e74"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch"
-PKG_VERSION="3a981e0"
+PKG_VERSION="b3d3cbd"
 PKG_REV="9"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch"
-PKG_VERSION="b3d3cbd"
+PKG_VERSION="29a057a"
 PKG_REV="9"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/sameboy/package.mk
+++ b/packages/libretro/sameboy/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="sameboy"
-PKG_VERSION="42e8b3b"
+PKG_VERSION="b00c775"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/libretro/snes9x/package.mk
+++ b/packages/libretro/snes9x/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x"
-PKG_VERSION="e0a5053"
+PKG_VERSION="2a15fe2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/snes9x/package.mk
+++ b/packages/libretro/snes9x/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x"
-PKG_VERSION="2a15fe2"
+PKG_VERSION="7a722f9"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/snes9x2002/package.mk
+++ b/packages/libretro/snes9x2002/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x2002"
-PKG_VERSION="a6cf15d"
+PKG_VERSION="d8084b0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/snes9x2005/package.mk
+++ b/packages/libretro/snes9x2005/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x2005"
-PKG_VERSION="ea47758"
+PKG_VERSION="8ca47fd"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/snes9x2005/package.mk
+++ b/packages/libretro/snes9x2005/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x2005"
-PKG_VERSION="e2ad3df"
+PKG_VERSION="ea47758"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/snes9x2005_plus/package.mk
+++ b/packages/libretro/snes9x2005_plus/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x2005_plus"
-PKG_VERSION="ea47758"
+PKG_VERSION="8ca47fd"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/snes9x2005_plus/package.mk
+++ b/packages/libretro/snes9x2005_plus/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x2005_plus"
-PKG_VERSION="e2ad3df"
+PKG_VERSION="ea47758"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/snes9x2010/package.mk
+++ b/packages/libretro/snes9x2010/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x2010"
-PKG_VERSION="989a48f"
+PKG_VERSION="b9be098"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/snes9x2010/package.mk
+++ b/packages/libretro/snes9x2010/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x2010"
-PKG_VERSION="b9be098"
+PKG_VERSION="35f6249"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/stella/package.mk
+++ b/packages/libretro/stella/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="stella"
-PKG_VERSION="5ac48d5"
+PKG_VERSION="3a79356"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/tgbdual/package.mk
+++ b/packages/libretro/tgbdual/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="tgbdual"
-PKG_VERSION="e1f8348"
+PKG_VERSION="bad6ae0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/tgbdual/package.mk
+++ b/packages/libretro/tgbdual/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="tgbdual"
-PKG_VERSION="4e111be"
+PKG_VERSION="e1f8348"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/tyrquake/package.mk
+++ b/packages/libretro/tyrquake/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="tyrquake"
-PKG_VERSION="0450638"
+PKG_VERSION="9db6a3b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/tyrquake/package.mk
+++ b/packages/libretro/tyrquake/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="tyrquake"
-PKG_VERSION="9db6a3b"
+PKG_VERSION="3031306"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/vba-next/package.mk
+++ b/packages/libretro/vba-next/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="vba-next"
-PKG_VERSION="6b4bbcb"
+PKG_VERSION="34e02e2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/vecx/package.mk
+++ b/packages/libretro/vecx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="vecx"
-PKG_VERSION="849e27d"
+PKG_VERSION="b78b3d1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2|LGPLv2.1"

--- a/packages/libretro/vice/package.mk
+++ b/packages/libretro/vice/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="vice"
-PKG_VERSION="928f2c9"
+PKG_VERSION="bea269d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/virtualjaguar/package.mk
+++ b/packages/libretro/virtualjaguar/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="virtualjaguar"
-PKG_VERSION="9b9ab23"
+PKG_VERSION="48739c2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"


### PR DESCRIPTION
This updates most of the cores except a few that were not building:

 - citra
 - sameboy

I'm building images with this change, I can tell so far that Generic and RPi2 are building.

I'm going to boot these images on a few computers and see if the cores are still working.