### PR TITLE
sameboy: bump version

### DIFF
--- a/packages/libretro/sameboy/package.mk
+++ b/packages/libretro/sameboy/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="sameboy"
-PKG_VERSION="a5e6868"
+PKG_VERSION="666ea63"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
bumped the version due to:
```
error: pathspec 'a5e6868' did not match any file(s) known to git.
```
