### PR TITLE
package.mk: update retroarch

### DIFF
--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch"
-PKG_VERSION="29a057a"
+PKG_VERSION="1cfc8a5"
 PKG_REV="10"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"


### PR DESCRIPTION
Fix segfault on KMS launch. Fixes [issue 429](https://github.com/libretro/Lakka-LibreELEC/issues/429).