### PR TITLE
chailove: update to 0.18.0

### DIFF
--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="e691703"
+PKG_VERSION="1a160e2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
ChaiLove 0.18.0 comes with a few updates...
https://github.com/libretro/libretro-chailove/releases/tag/0.18.0