### PR TITLE
chailove: Update to 0.20.1

### DIFF
--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="1a160e2"
+PKG_VERSION="e19269c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
ChaiLove 0.20.1 comes with a few updates since 0.18.0...

- No Game demo screen
- Version mismatch checking
- `love.data.hash()`
- `love.system.getUsername()`
- Better memory usage
- Fixed compilation warnings