### PR TITLE
[WIP] mame2003-plus: switch to git

### DIFF
--- a/packages/libretro/mame2003-plus/package.mk
+++ b/packages/libretro/mame2003-plus/package.mk
@@ -24,7 +24,7 @@ PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2003-plus-libretro"
-PKG_URL="https://github.com/libretro/mame2003-plus-libretro/archive/$PKG_VERSION.tar.gz"
+PKG_GIT_URL="$PKG_SITE"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="libretro"
@@ -33,10 +33,6 @@ PKG_LONGDESC="MAME - Multiple Arcade Machine Emulator"
 
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
-
-post_unpack() {
-  mv $BUILD/mame2003_plus_libretro-$PKG_VERSION* $BUILD/$PKG_NAME-$PKG_VERSION
-}
 
 make_target() {
   make ARCH="" CC="$CC" NATIVE_CC="$CC" LD="$CC"


### PR DESCRIPTION
1) the original package uses tarball, all other libretro packages of Lakka use git.
2) removed redundant post_unpack() - is cloned into correct folder

However does not build (Generic, S905, RPi)
I will test newer versions and commit after success to this PR.
