### PR TITLE
mame2003-plus: bump version (fix build error)

### DIFF
--- a/packages/libretro/mame2003-plus/package.mk
+++ b/packages/libretro/mame2003-plus/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame2003-plus"
-PKG_VERSION="996a00e"
+PKG_VERSION="b33120b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"


### PR DESCRIPTION
previous version failed to build (at least here) with messages like:
```
src/mame2003/mame2003.c:148:10: error: 'struct GameOptions' has no member named 'retropad_layout'
```
Test: this version builds on **all** targets.