### PR TITLE
S905/S912: add missing bttty.conf

### DIFF
--- a/projects/S905/filesystem/usr/share/bttty.conf
+++ b/projects/S905/filesystem/usr/share/bttty.conf
@@ -1,0 +1,1 @@
+BTTTY="/dev/ttyS1"


### PR DESCRIPTION
This file is needed by `/lib/systemd/system/brcmfmac_sdio-firmware-aml.service` to load the bluetooth firmware.
Note: adding only to project S905 `filesystem` folder, as S912 has a symlink to S905 folder.