### PR TITLE
New libretro core: REminiscence

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -253,7 +253,7 @@
 
   LAKKA_MIRROR="http://sources.lakka.tv"
 
-  LIBRETRO_CORES="2048 4do 81 atari800 beetle-bsnes beetle-lynx beetle-ngp beetle-pce beetle-pcfx beetle-psx beetle-saturn beetle-supergrafx beetle-vb beetle-wswan bluemsx bsnes bsnes-mercury cannonball cap32 chailove citra crocods desmume dinothawr dolphin dosbox easyrpg fbalpha fceumm freeintv fuse-libretro gambatte genesis-plus-gx gearboy gme gpsp gw-libretro handy hatari higan-sfc higan-sfc-balanced lutro mame2003 mame2003-plus mame2003-midway melonds meowpc98 mgba mrboom mupen64plus nestopia nxengine o2em openlara parallel-n64 pcsx_rearmed picodrive pocketcdg ppsspp prboom prosystem puae px68k redream reicast sameboy scummvm snes9x snes9x2002 snes9x2005 snes9x2005_plus snes9x2010 stella tgbdual tyrquake uae4arm uzem vbam vecx vice virtualjaguar xrick yabause"
+  LIBRETRO_CORES="2048 4do 81 atari800 beetle-bsnes beetle-lynx beetle-ngp beetle-pce beetle-pcfx beetle-psx beetle-saturn beetle-supergrafx beetle-vb beetle-wswan bluemsx bsnes bsnes-mercury cannonball cap32 chailove citra crocods desmume dinothawr dolphin dosbox easyrpg fbalpha fceumm freeintv fuse-libretro gambatte genesis-plus-gx gearboy gme gpsp gw-libretro handy hatari higan-sfc higan-sfc-balanced lutro mame2003 mame2003-plus mame2003-midway melonds meowpc98 mgba mrboom mupen64plus nestopia nxengine o2em openlara parallel-n64 pcsx_rearmed picodrive pocketcdg ppsspp prboom prosystem puae px68k redream reicast reminiscence sameboy scummvm snes9x snes9x2002 snes9x2005 snes9x2005_plus snes9x2010 stella tgbdual tyrquake uae4arm uzem vbam vecx vice virtualjaguar xrick yabause"
 
   RA_PLAYLIST_NAMES=""\
 "Atari - 2600.lpl;"\
@@ -277,6 +277,7 @@
 "DOOM.lpl;"\
 "DOS.lpl;"\
 "FB Alpha - Arcade Games.lpl;"\
+"Flashback.lpl;"\
 "GCE - Vectrex.lpl;"\
 "Lutro.lpl;"\
 "Magnavox - Odyssey2.lpl;"\
@@ -338,6 +339,7 @@
 "/tmp/cores/prboom_libretro.so;"\
 "/tmp/cores/dosbox_libretro.so;"\
 "/tmp/cores/fbalpha_libretro.so;"\
+"/tmp/cores/reminiscence_libretro.so;"\
 "/tmp/cores/vecx_libretro.so;"\
 "/tmp/cores/lutro_libretro.so;"\
 "/tmp/cores/o2em_libretro.so;"\

--- a/packages/libretro/core-info/package.mk
+++ b/packages/libretro/core-info/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="core-info"
-PKG_VERSION="16e7a18"
+PKG_VERSION="889ae6c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/libretro-database/package.mk
+++ b/packages/libretro/libretro-database/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="libretro-database"
-PKG_VERSION="0ed1e38"
+PKG_VERSION="4177a08"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/reminiscence/package.mk
+++ b/packages/libretro/reminiscence/package.mk
@@ -1,0 +1,47 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="reminiscence"
+PKG_VERSION="57e2e2c"
+PKG_ARCH="any"
+PKG_SITE="https://github.com/libretro/REminiscence"
+PKG_GIT_URL="$PKG_SITE"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="libretro"
+PKG_SHORTDESC="Port of Gregory Montoir's Flashback emulator, running as a libretro core."
+PKG_LONGDESC="Port of Gregory Montoir's Flashback emulator, running as a libretro core."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+configure_target () {
+  : # nothing to do
+}
+
+make_target() {
+  cd $PKG_BUILD
+  make
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/libretro
+  cp reminiscence_libretro.so $INSTALL/usr/lib/libretro/
+}


### PR DESCRIPTION
# REminiscence
Port of Gregory Montoir's Flashback emulator, running as a libretro core.

Builds test successful for every target.

Runs on Generic.x86_64. Tried to run on S912, but got only black screen. I don't have other devices available to test.

[Images](http://nightly.builds.lakka.tv/special_builds/new-reminiscence/)