### PR TITLE
Added patch for host make

### DIFF
--- a/packages/devel/make/patches/make-glibc_alloc_fix.patch
+++ b/packages/devel/make/patches/make-glibc_alloc_fix.patch
@@ -1,0 +1,13 @@
+diff --git a/glob/glob.c b/glob/glob.c
+index f3911bc..8adbde3 100644
+--- a/glob/glob.c
++++ b/glob/glob.c
+@@ -208,7 +208,7 @@ my_realloc (p, n)
+ #endif /* __GNU_LIBRARY__ || __DJGPP__ */
+
+
+-#if !defined __alloca && !defined __GNU_LIBRARY__
++#if !defined __alloca && defined __GNU_LIBRARY__
+
+ # ifdef __GNUC__
+ #  undef alloca


### PR DESCRIPTION
On newer Ubuntu releases, the host `make` package refused to build due to an error with `__alloca`. This patch addresses this issue.

The error is :

```
glob/libglob.a(glob.o): In function `glob_in_dir':
glob.c:(.text+0x2c1): undefined reference to `__alloca'
glob.c:(.text+0x43e): undefined reference to `__alloca'
glob.c:(.text+0x5f8): undefined reference to `__alloca'
glob.c:(.text+0x658): undefined reference to `__alloca'
glob/libglob.a(glob.o): In function `glob':
glob.c:(.text+0x95b): undefined reference to `__alloca'
glob/libglob.a(glob.o):glob.c:(.text+0x101a): more undefined references to `__alloca' follow
collect2: error: ld returned 1 exit status
```