### PR TITLE
chailove: Update to ChaiLove 0.25.1

### DIFF
--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="25fa00f"
+PKG_VERSION="d87e919"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
This updates to [ChaiLove 0.25.1](https://github.com/libretro/libretro-chailove/releases/tag/0.25.1).

### Fixes
- Fix Windows build
- Fix Android build ([#305](https://github.com/libretro/libretro-chailove/issues/305))
  - By [@bparker06](https://github.com/bparker06)