### PR TITLE
chailove: Update to ChaiLove 0.26.0

### DIFF
--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="268d940"
+PKG_VERSION="6ba89d2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="25fa00f"
+PKG_VERSION="268d940"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
### 0.27.0
#### Features
- Live updating of core options
- Mounts `/libretro/core` as the directory where the core was loaded from
- Adds `love.filesystem.getSaveDirectory()`
- Adds `love.filesystem.newFileData(contents, name)`
- Adds `love.filesystem.getExecutablePath()`
- Adds `love.filesystem.remove()`
 #### Fixes
- Fixed loading ChaiLove without active content

### 0.26.0
- Added a global `require()` function to load modules ([#308](https://github.com/libretro/libretro-chailove/pull/308))
- Added OEM-102 key support (sometimes `\` on EUR keyboard) ([#309](https://github.com/libretro/libretro-chailove/pull/309))

### 0.25.1
- Fix Windows build
- Fix Android build ([#305](https://github.com/libretro/libretro-chailove/issues/305))
  - By [@bparker06](https://github.com/bparker06)