### PR TITLE
chailove: Update to 0.28.0

### DIFF
--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="6ba89d2"
+PKG_VERSION="bcbe88c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
Updates to ChaiLove 0.28.0 which fixes an undefined reference to 'process_sinc_neon_asm'.

References:
- https://github.com/libretro/libretro-chailove/issues/322
- https://github.com/libretro/libretro-chailove/releases/tag/0.28.0