### PR TITLE
redream: remove core from the list of Lakka cores

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -253,7 +253,7 @@
 
   LAKKA_MIRROR="http://sources.lakka.tv"
 
-  LIBRETRO_CORES="2048 4do 81 atari800 beetle-bsnes beetle-lynx beetle-ngp beetle-pce beetle-pcfx beetle-psx beetle-saturn beetle-supergrafx beetle-vb beetle-wswan bluemsx bsnes bsnes-mercury cannonball cap32 chailove citra crocods desmume dinothawr dolphin dosbox easyrpg fbalpha fceumm freeintv fuse-libretro gambatte genesis-plus-gx gearboy gme gpsp gw-libretro handy hatari higan-sfc higan-sfc-balanced lutro mame2003 mame2003-plus mame2003-midway melonds meowpc98 mesen mgba mrboom mupen64plus nestopia nxengine o2em openlara parallel-n64 pcsx_rearmed picodrive pocketcdg ppsspp prboom prosystem puae px68k redream reicast reminiscence sameboy scummvm snes9x snes9x2002 snes9x2005 snes9x2005_plus snes9x2010 stella tgbdual tyrquake uae4arm uzem vbam vecx vice virtualjaguar xrick yabause"
+  LIBRETRO_CORES="2048 4do 81 atari800 beetle-bsnes beetle-lynx beetle-ngp beetle-pce beetle-pcfx beetle-psx beetle-saturn beetle-supergrafx beetle-vb beetle-wswan bluemsx bsnes bsnes-mercury cannonball cap32 chailove citra crocods desmume dinothawr dolphin dosbox easyrpg fbalpha fceumm freeintv fuse-libretro gambatte genesis-plus-gx gearboy gme gpsp gw-libretro handy hatari higan-sfc higan-sfc-balanced lutro mame2003 mame2003-plus mame2003-midway melonds meowpc98 mesen mgba mrboom mupen64plus nestopia nxengine o2em openlara parallel-n64 pcsx_rearmed picodrive pocketcdg ppsspp prboom prosystem puae px68k reicast reminiscence sameboy scummvm snes9x snes9x2002 snes9x2005 snes9x2005_plus snes9x2010 stella tgbdual tyrquake uae4arm uzem vbam vecx vice virtualjaguar xrick yabause"
 
   RA_PLAYLIST_NAMES=""\
 "Atari - 2600.lpl;"\


### PR DESCRIPTION
addresses #536 
removed only from the LIBRETRO_CORES list, the package is still there