### PR TITLE
create tarballs from cloned repositories

### DIFF
--- a/config/path
+++ b/config/path
@@ -158,7 +158,7 @@ SED="sed -i"
   #
   # Any $PKG_URL that references more than a single url will abort
   # the build as these are no longer supported - use mkpkg instead.
-  if [ -n "$PKG_URL" -a -z "$PKG_SOURCE_NAME" ]; then
+  if [ -n "$PKG_URL" -a -z "$PKG_SOURCE_NAME" -a -z "$PKG_GIT_URL" ]; then
     if [[ $PKG_URL =~ .*\ .* ]]; then
       echo "Error - packages with multiple urls are no longer supported, use mkpkg:"
       echo "$PKG_URL"
@@ -175,13 +175,17 @@ SED="sed -i"
       *.tar.bz2 | *.tar.gz | *.tar.xz)
         PKG_SOURCE_NAME=${PKG_NAME}-${PKG_VERSION}.tar.${PKG_SOURCE_NAME##*\.}
         ;;
-       *.diff | *.patch | *.diff.bz2 | *.patch.bz2 | patch-*.bz2 | *.diff.gz | *.patch.gz | patch-*.gz)
+      *.diff | *.patch | *.diff.bz2 | *.patch.bz2 | patch-*.bz2 | *.diff.gz | *.patch.gz | patch-*.gz)
         PKG_SOURCE_NAME=$PKG_SOURCE_NAME
         ;;
       *)
         PKG_SOURCE_NAME=${PKG_NAME}-${PKG_VERSION}.${PKG_SOURCE_NAME##*\.}
         ;;
     esac
+  fi
+
+  if [ -n "$PKG_GIT_URL" -a -z "$PKG_SOURCE_NAME" ]; then
+    PKG_SOURCE_NAME=${PKG_NAME}-${PKG_VERSION}.tar.xz
   fi
 
   PKG_BUILD="$BUILD/${PKG_NAME}-${PKG_VERSION}"

--- a/scripts/extract
+++ b/scripts/extract
@@ -25,7 +25,12 @@ if [ -z "$2" ]; then
   exit 1
 fi
 
-[ -z "$PKG_URL" -o -z "$PKG_SOURCE_NAME" ] && exit 1
+if [ -z "$PKG_URL" -o -z "$PKG_SOURCE_NAME" ]; then
+  if [ -z "$PKG_GIT_URL" -o -z "$PKG_SOURCE_NAME" ]; then
+    exit 1
+  fi
+fi
+
 [ ! -d "$SOURCES/$1" -o ! -d "$2" ] && exit 1
 
 for pattern in .tar.gz .tar.xz .tar.bz2 .tgz .txz .tbz .7z .zip; do

--- a/scripts/get
+++ b/scripts/get
@@ -22,7 +22,7 @@
 
 _get_file_already_downloaded() {
   if [ -f $PACKAGE ]; then
-    if [ "$(cat $STAMP_URL 2>/dev/null)" == "${PKG_URL}" ]; then
+    if [ "$(cat $STAMP_URL 2>/dev/null)" == "${PKG_URL}" -o "$(cat $STAMP_URL 2>/dev/null)" == "${PKG_GIT_URL}" ]; then
       [ -z "${PKG_SHA256}" -o "$(cat $STAMP_SHA 2>/dev/null)" == "${PKG_SHA256}" ] && return 0
     fi
   fi
@@ -36,7 +36,16 @@ if [ -z "$1" ]; then
   done
 fi
 
-[ -z "$PKG_URL" -o -z "$PKG_SOURCE_NAME" ] && exit 0
+if [ -z "$PKG_URL" -o -z "$PKG_SOURCE_NAME" ]; then
+  if [ -z "$PKG_GIT_URL" -o -z "$PKG_SOURCE_NAME" ]; then
+    exit 0
+  fi
+fi
+
+if [ -n "$PKG_GIT_URL" -a -n "$PKG_URL" ]; then
+  echo -e "${boldred}ERROR${endcolor} Package '$PKG_NAME' has PKG_URL and PKG_GIT_URL defined. Concurrent usage of both is not supported. Use only one of those!"
+  exit 1
+fi
 
 mkdir -p $SOURCES/$1
 
@@ -70,6 +79,71 @@ export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 unset LD_LIBRARY_PATH
 
 rm -f $STAMP_URL $STAMP_SHA
+
+if [ -n "$PKG_GIT_URL" -a -z "$PKG_URL" ]; then
+
+  if [ -n "$LAKKA_MIRROR" ]; then
+    PACKAGE_MIRROR="$LAKKA_MIRROR/$PKG_SOURCE_NAME"
+    NBWGET=5
+
+    # first look if we have tarball mirrored
+    while [ $NBWGET -gt 0 ]; do
+      rm -f $PACKAGE
+
+      if $WGET_CMD "$PACKAGE_MIRROR"; then
+        break
+      fi
+
+      NBWGET=$((NBWGET - 1))
+      rm -f $PACKAGE
+    done
+
+    if [ $NBWGET -eq 0 ]; then
+      # no tarball on mirror - clone and create tarball
+      CUR_PWD="$(pwd)"
+      GIT_REPO_FOLDER="$SOURCES/$1/repo"
+
+      # remove stale folders if they exist
+      rm -rf $SOURCES/$1/$PKG_NAME-*/
+
+      if [ ! -d "$GIT_REPO_FOLDER" ]; then
+        git clone $PKG_GIT_URL $GIT_REPO_FOLDER
+      fi
+
+      cd $GIT_REPO_FOLDER
+      git clean -fdx
+      git checkout -- .
+      git pull
+      [ -n "$PKG_GIT_BRANCH" ] && git checkout $PKG_GIT_BRANCH
+      git reset --hard $PKG_VERSION
+      git submodule update --init --recursive
+      cd "$ROOT/$SOURCES/$1"
+      mv repo $PKG_NAME-$PKG_VERSION
+      echo -n "Creating tarball..."
+      tar -pcJf $ROOT/$PACKAGE $PKG_NAME-$PKG_VERSION
+      echo "done!"
+      mv $PKG_NAME-$PKG_VERSION repo
+      cd "$CUR_PWD"
+    fi
+
+    CALC_SHA256="$(sha256sum $PACKAGE | cut -d" " -f1)"
+
+    if [ -z "${PKG_SHA256}" -o "${PKG_SHA256}" == "${CALC_SHA256}" ]; then
+      printf "${boldgreen}INFO${endcolor} Calculated checksum is: ${CALC_SHA256}\n\n"
+    else
+      printf "${boldred}WARNING${endcolor} Incorrect checksum calculated on downloaded file: got ${CALC_SHA256}, wanted ${PKG_SHA256}\n\n"
+    fi
+
+    echo "${PKG_GIT_URL}" > $STAMP_URL
+    echo "${CALC_SHA256}" > $STAMP_SHA
+
+  else
+    echo -e "${boldred}WARNING${endcolor} Package '$PKG_NAME' not downloaded! Use\n\n\tDISTRO=Lakka $0\n\nto download Lakka libretro git-based packages!\n\n"
+  fi
+
+  exit 0
+
+fi
 
 NBWGET=10
 while [ $NBWGET -gt 0 ]; do

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -60,7 +60,7 @@ fi
 
 [ -f "$STAMP" ] && exit 0
 
-if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
+if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" ]; then
   printf "%${BUILD_INDENT}c ${boldcyan}UNPACK${endcolor}   $1\n" ' '>&$SILENT_OUT
   export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
@@ -73,43 +73,32 @@ if [ -d "$SOURCES/$1" -o -d "$PKG_DIR/sources" -o -n "$PKG_GIT_URL" ]; then
 
   . $PKG_DIR/package.mk
 
-  if [ -z "$PKG_GIT_URL" ] ; then
-
-    if [ "$(type -t pre_unpack)" = "function" ]; then
-      pre_unpack
-    fi
-
-    if [ "$(type -t unpack)" = "function" ]; then
-      unpack
-    else
-      if [ -n "$PKG_URL" ]; then
-        $SCRIPTS/extract $1 $BUILD
-      fi
-    fi
-
-    if [ ! -d $BUILD/$PKG_NAME-$PKG_VERSION ]; then
-      if [ -n "$PKG_SOURCE_DIR" ]; then
-        mv $BUILD/$PKG_SOURCE_DIR $BUILD/$PKG_NAME-$PKG_VERSION
-      elif [ -d $BUILD/$PKG_NAME-$PKG_VERSION* ]; then
-        mv $BUILD/$PKG_NAME-$PKG_VERSION* $BUILD/$PKG_NAME-$PKG_VERSION
-      fi
-    fi
-  
-    if [ -d "$PKG_DIR/sources" ]; then
-      [ ! -d "$BUILD/${PKG_NAME}-${PKG_VERSION}" ] && mkdir -p $BUILD/${PKG_NAME}-${PKG_VERSION}
-      cp -PRf $PKG_DIR/sources/* $BUILD/${PKG_NAME}-${PKG_VERSION}
-    fi
-
+  if [ "$(type -t pre_unpack)" = "function" ]; then
+    pre_unpack
   fi
 
-  if [ -z "$PKG_URL" -a -n "$PKG_GIT_URL" ]; then
-    rm -rf $BUILD/$PKG_NAME-$PKG_VERSION
-    git clone $PKG_GIT_URL $BUILD/$PKG_NAME-$PKG_VERSION/
-    cd $BUILD/$PKG_NAME-$PKG_VERSION/
-    git checkout $PKG_VERSION
-    git submodule update --init --recursive
-    cd $ROOT
-  elif [ -z "$PKG_URL" ]; then
+  if [ "$(type -t unpack)" = "function" ]; then
+    unpack
+  else
+    if [ -n "$PKG_URL" -o -n "$PKG_GIT_URL" ]; then
+      $SCRIPTS/extract $1 $BUILD
+    fi
+  fi
+
+  if [ ! -d $BUILD/$PKG_NAME-$PKG_VERSION ]; then
+    if [ -n "$PKG_SOURCE_DIR" ]; then
+      mv $BUILD/$PKG_SOURCE_DIR $BUILD/$PKG_NAME-$PKG_VERSION
+    elif [ -d $BUILD/$PKG_NAME-$PKG_VERSION* ]; then
+      mv $BUILD/$PKG_NAME-$PKG_VERSION* $BUILD/$PKG_NAME-$PKG_VERSION
+    fi
+  fi
+  
+  if [ -d "$PKG_DIR/sources" ]; then
+    [ ! -d "$BUILD/${PKG_NAME}-${PKG_VERSION}" ] && mkdir -p $BUILD/${PKG_NAME}-${PKG_VERSION}
+    cp -PRf $PKG_DIR/sources/* $BUILD/${PKG_NAME}-${PKG_VERSION}
+  fi
+
+  if [ -z "$PKG_URL" -a -z "$PKG_GIT_URL" ]; then
     mkdir -p "${BUILD}/${PKG_NAME}-${PKG_VERSION}"
   fi
 


### PR DESCRIPTION
It happens quite often that some libretro repositories lose some history and subsequent builds fail, as cloned repositories are used instead of archive/tarball. As for many libretro packages it is better to have a cloned repository for the build (e.g. to have correct GIT_VERSION in the build), this PR creates tarballs from the cloned repositories. The devs should upload the tarball(s) to the LAKKA_MIRROR after they update the libretro packages, so users download a tarball from LAKKA_MIRROR instead of cloning the individual repositories.
