### PR TITLE
Add /tmp/cores overlay to LD_LIBRARY_PATH

### DIFF
--- a/packages/libretro/retroarch/scripts/retroarch-config
+++ b/packages/libretro/retroarch/scripts/retroarch-config
@@ -3,3 +3,4 @@
 for i in 5 4 3 2 1 0; do [ -e /dev/snd/pcmC${i}D0p ] && export ALSA_CARD=$i; done
 
 echo "ALSA_CARD=\"$ALSA_CARD\"" > /run/libreelec/retroarch.conf
+echo "LD_LIBRARY_PATH=\"/usr/lib:/tmp/cores\"" >> /run/libreelec/retroarch.conf

--- a/packages/sysutils/busybox/profile.d/98-busybox.conf
+++ b/packages/sysutils/busybox/profile.d/98-busybox.conf
@@ -18,7 +18,7 @@
 
 export HOME="/storage"
 export PATH="/usr/bin:/usr/sbin"
-export LD_LIBRARY_PATH="/usr/lib"
+export LD_LIBRARY_PATH="/usr/lib:/tmp/cores"
 export HOSTNAME=`cat /etc/hostname`
 export PS1="\[\e[1;32m\]\h\[\e[1;32m\]:\[\e[1;34m\]\w \[\e[0m\]\\$ "
 # k0p


### PR DESCRIPTION
When libretro cores depend on shared libraries it is quite difficult to add anything to Lakka OS since root partition is a **squashfs** read-only partition. My particular issue was the **hatari_libretro.so** which was compiled without IPF support. When I recompiled it and enabled IPF, I also realized that I cannot copy the **ibcapsimage.so.4** dependency to root partition and the only was to run it would be to manually export **LD_LIBRARY_PATH** in **.profile** and run retroarch from shell, which is not acceptable. This pull request adds **/tmp/cores** overlay to **LD_LIBRARY_PATH** to facilitate installation of custom core dependencies.
