### PR TITLE
Adjust mkpkg script for RTL8812AU to point to a branch that exists

### DIFF
--- a/tools/mkpkg/mkpkg_RTL8812AU
+++ b/tools/mkpkg/mkpkg_RTL8812AU
@@ -21,7 +21,7 @@
 
 echo "getting sources..."
   if [ ! -d RTL8812AU.git ]; then
-    git clone https://github.com/Grawp/rtl8812au_rtl8821au.git -b 4.3.22_beta RTL8812AU.git
+    git clone https://github.com/Grawp/rtl8812au_rtl8821au.git -b 4.3.20 RTL8812AU.git
   fi
 
   cd RTL8812AU.git


### PR DESCRIPTION
This does technically downgrade the package, however it seems that there is no branch on the repo from Grawp which has a later one.  We could switch to an alternative source of this driver, though.  There are 3 or 4 on github... I'm just not sure which ones are trustworthy and which ones aren't.

This also leaves open the issue, where there is another place that this  driver is built/patched under `Lakka-LibreELEC/packages/linux-drivers/RTL8812AU`.  I'm not familiar enough with this code base to understand why its in two places, or what should be done over there. If somebody can point me in the right direction I'd be happy to do it though.