### PR TITLE
Use Estuary as default Theme for Kodi.

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -25,13 +25,13 @@
 # Mediacenter to use (kodi / no)
   MEDIACENTER="no"
 
-# Skins to install (Confluence)
+# Skins to install (Estuary)
 # Space separated list is supported,
-# e.g. SKINS="Confluence"
-  SKINS="Confluence"
+# e.g. SKINS="Estuary"
+  SKINS="Estuary"
 
-# Default Skin (Confluence)
-  SKIN_DEFAULT="Confluence"
+# Default Skin (Estuary)
+  SKIN_DEFAULT="Estuary"
 
 # install extra subtitle Fonts for KODI (yes / no)
   KODI_EXTRA_FONTS="yes"


### PR DESCRIPTION
When building Lakka with Kodi, 
e.g. MEDIACENTER="kodi" in distributions/Lakka/options, 
Use the default Theme Estuary instead of old default Theme name Confluence
Otherwise the build will interrupt.