### PR TITLE
retroarch: allow to have persistent environment file

### DIFF
--- a/packages/libretro/retroarch/system.d/retroarch.service
+++ b/packages/libretro/retroarch/system.d/retroarch.service
@@ -7,6 +7,7 @@ Requires=graphical.target
 [Service]
 Environment=HOME=/storage
 EnvironmentFile=-/run/libreelec/retroarch.conf
+EnvironmentFile=-/storage/.cache/services/retroarch.conf
 ExecStartPre=-/usr/lib/retroarch/retroarch-config
 ExecStart=/usr/bin/retroarch
 # keep KillMode=process unless there is no good reason to switch to cgroup


### PR DESCRIPTION
This change allows to workaround retroarch issues like the following:

```
Unable to find target for this triple (no targets are registered)
Segmentation fault (core dumped)
```

which some users are facing, so these issues can be closed (maybe some other too):
https://github.com/libretro/Lakka-LibreELEC/issues/618
https://github.com/libretro/Lakka-LibreELEC/issues/486
https://github.com/libretro/Lakka-LibreELEC/issues/322

I will document the workaround in `Hardware tips/PC` section of Lakka website later.