### PR TITLE
chailove: Update to 0.32.0

### DIFF
--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="67e775e"
+PKG_VERSION="d57052e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
- ChaiLove now requires content to run
- Updated ChaiScript_Extras for more string methods
- Updated PhysFS
- Updated libretro-common
- Updated random to fix a gcc 7.3+ error
- Updated stb