### PR TITLE
add missing mkimg via u-boot-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
 		sed \
 		tar \
 		texinfo \
+		u-boot-tools \		
 		unzip \
 		wget \
 		xfonts-utils \


### PR DESCRIPTION
*adds missing `mkimg` tool needed by https://github.com/libretro/Lakka-LibreELEC/blob/master/scripts/image#L298