### PR TITLE
add reicast dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN apt-get update \
 		git-core \
 		gperf \
 		gzip \
+		libasound2-dev \
+		libgl1-mesa-dev \
+		libgles2-mesa-dev \
 		libjson-perl \
 		libncurses5-dev \
 		lzop \


### PR DESCRIPTION
Adds missing [Dependencies required to build Reicast](https://github.com/libretro/reicast-emulator#building-for-linux)