### PR TITLE
add hexdump via bsdmainutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
 		build-essential \
 		bash \
 		bc \
+		bsdmainutils \
 		build-essential \
 		bzip2 \
 		diffutils \


### PR DESCRIPTION
Resolves `hexdump: not found`  issue encountered when building sameboy with [Dockerfile](https://github.com/libretro/Lakka-LibreELEC/blob/master/Dockerfile):

```
make[1]: Entering directory '/root/Lakka-LibreELEC/build.Lakka-Generic.x86_64-2.2-devel/sameboy-8f66f11/libretro'
echo "/* AUTO-GENERATED */" > ..//libretro/agb_boot.c
echo "/* AUTO-GENERATED */" > ..//libretro/cgb_boot.c
echo "const unsigned char agb_boot[] = {" >> ..//libretro/agb_boot.c
hexdump -v -e '/1 "0x%02x, "' ..//BootROMs/prebuilt/agb_boot.bin >> ..//libretro/agb_boot.c
echo "const unsigned char cgb_boot[] = {" >> ..//libretro/cgb_boot.c
/bin/sh: 1: hexdump: not found
hexdump -v -e '/1 "0x%02x, "' ..//BootROMs/prebuilt/cgb_boot.bin >> ..//libretro/cgb_boot.c
make[1]: *** [Makefile:322: ..//libretro/agb_boot.c] Error 127
make[1]: *** Waiting for unfinished jobs....
/bin/sh: 1: hexdump: not found
make[1]: *** [Makefile:322: ..//libretro/cgb_boot.c] Error 127
rm ..//libretro/cgb_boot.c ..//libretro/agb_boot.c
make[1]: Leaving directory '/root/Lakka-LibreELEC/build.Lakka-Generic.x86_64-2.2-devel/sameboy-8f66f11/libretro'
Makefile:29: recipe for target 'image' failed
make: *** [image] Error 2
```