### PR TITLE
Fix Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
 		build-essential \
 		bash \
 		bc \
+		bsdmainutils \
 		build-essential \
 		bzip2 \
 		diffutils \
@@ -36,6 +37,7 @@ RUN apt-get update \
 		sed \
 		tar \
 		texinfo \
+		u-boot-tools \
 		unzip \
 		wget \
 		xfonts-utils \


### PR DESCRIPTION
Sameboy compilation and image creation is broken in the image generated by the Dockerfile.  Easy fix.

- Add `bsdmainutils` (fix Sameboy compilation).
- Add `u-boot-tools` (fix image creation).