### PR TITLE
reicast: properly fix segfaults with Generic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,6 @@ RUN apt-get update \
 		git-core \
 		gperf \
 		gzip \
-		libasound2-dev \
-		libgl1-mesa-dev \
-		libgles2-mesa-dev \
 		libjson-perl \
 		libncurses5-dev \
 		lzop \

--- a/packages/libretro/reicast/package.mk
+++ b/packages/libretro/reicast/package.mk
@@ -35,14 +35,12 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 pre_configure_target() {
-  if [ "$ARCH" != "arm" ]; then
-    CFLAGS="${CFLAGS//-flto/}"
-    CFLAGS="${CFLAGS//-ffat-lto-objects/}"
-    CXXFLAGS="${CXXFLAGS//-flto/}"
-    CXXFLAGS="${CXXFLAGS//-ffat-lto-objects/}"
-    LDFLAGS="${LDFLAGS//-flto/}"
-    LDFLAGS="${LDFLAGS//-ffat-lto-objects/}"
-  fi
+  CFLAGS="${CFLAGS//-flto/}"
+  CFLAGS="${CFLAGS//-ffat-lto-objects/}"
+  CXXFLAGS="${CXXFLAGS//-flto/}"
+  CXXFLAGS="${CXXFLAGS//-ffat-lto-objects/}"
+  LDFLAGS="${LDFLAGS//-flto/}"
+  LDFLAGS="${LDFLAGS//-ffat-lto-objects/}"
 }
 
 make_target() {

--- a/packages/libretro/reicast/package.mk
+++ b/packages/libretro/reicast/package.mk
@@ -34,6 +34,17 @@ PKG_LONGDESC="Reicast is a multiplatform Sega Dreamcast emulator"
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
+pre_configure_target() {
+  if [ "$ARCH" != "arm" ]; then
+    CFLAGS="${CFLAGS//-flto/}"
+    CFLAGS="${CFLAGS//-ffat-lto-objects/}"
+    CXXFLAGS="${CXXFLAGS//-flto/}"
+    CXXFLAGS="${CXXFLAGS//-ffat-lto-objects/}"
+    LDFLAGS="${LDFLAGS//-flto/}"
+    LDFLAGS="${LDFLAGS//-ffat-lto-objects/}"
+  fi
+}
+
 make_target() {
   if [ "$ARCH" == "arm" ]; then
     make platform=rpi FORCE_GLES=1 HAVE_OPENMP=0

--- a/packages/libretro/reicast/package.mk
+++ b/packages/libretro/reicast/package.mk
@@ -35,12 +35,7 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 pre_configure_target() {
-  CFLAGS="${CFLAGS//-flto/}"
-  CFLAGS="${CFLAGS//-ffat-lto-objects/}"
-  CXXFLAGS="${CXXFLAGS//-flto/}"
-  CXXFLAGS="${CXXFLAGS//-ffat-lto-objects/}"
-  LDFLAGS="${LDFLAGS//-flto/}"
-  LDFLAGS="${LDFLAGS//-ffat-lto-objects/}"
+  strip_lto
 }
 
 make_target() {

--- a/packages/libretro/reicast/patches/reicast-01-buildfix.patch
+++ b/packages/libretro/reicast/patches/reicast-01-buildfix.patch
@@ -1,23 +1,13 @@
-diff --git a/Makefile b/Makefile
-index 44aa40d..472773f 100644
---- a/Makefile
-+++ b/Makefile
-@@ -20,18 +20,21 @@ HAVE_CHD      := 1
- 
+diff -Naur reicast-a2a14be/Makefile reicast.patch/Makefile
+--- reicast-a2a14be/Makefile	2018-08-12 16:28:43.398877322 +0200
++++ reicast.patch/Makefile	2018-08-12 16:04:39.396217020 +0200
+@@ -21,18 +21,12 @@
  TARGET_NAME   := reicast
+ endif
  
 -CXX      = ${CC_PREFIX}g++
 -CC       = ${CC_PREFIX}gcc
 -CC_AS    = ${CC_PREFIX}as
-+ifeq (,$(findstring arm, $(ARCH)))
-+	CXX      = ${CC_PREFIX}g++
-+	CC       = ${CC_PREFIX}gcc
-+	CC_AS    = ${CC_PREFIX}as
-+
-+	LDFLAGS  :=
-+	CFLAGS   :=
-+	CXXFLAGS :=
-+endif
  
  MFLAGS   := 
  ASFLAGS  := 
@@ -30,7 +20,7 @@ index 44aa40d..472773f 100644
  
  GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
  ifneq ($(GIT_VERSION)," unknown")
-@@ -835,7 +838,7 @@ LIBS     += -lm
+@@ -604,7 +598,7 @@
  PREFIX        ?= /usr/local
  
  ifneq (,$(findstring arm, $(ARCH)))


### PR DESCRIPTION
Removing Dockerfile updates which should be no longer needed and restore previous version of reicast patch, hopefully fixes #662 