### PR TITLE
add default ARCH value

### DIFF
--- a/config/options
+++ b/config/options
@@ -20,6 +20,7 @@ fi
 # determines TARGET_ARCH, if not forced by user (i386 / x86_64 / arm)
 # default is x86_64
 if [ -z "$ARCH" ]; then
+  ARCH="x86_64"
   TARGET_ARCH="x86_64"
 else
   TARGET_ARCH="$ARCH"


### PR DESCRIPTION
Default behavior (i.e. `make image`) is to build for Generic.x86_64, `config/options` sets the TARGET_ARCH variable, but leaves ARCH empty. As some packages rely also on the ARCH variable, this sets the default (x86_64) value.