### PR TITLE
Add NO_MIRROR to force cloning of git repos (disables targz download)

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -84,7 +84,11 @@ if [ -n "$PKG_GIT_URL" -a -z "$PKG_URL" ]; then
 
   if [ -n "$LAKKA_MIRROR" ]; then
     PACKAGE_MIRROR="$LAKKA_MIRROR/$PKG_SOURCE_NAME"
-    NBWGET=5
+    if [ "$NO_MIRROR" == "yes" ]; then
+      NBWGET=0
+    else
+      NBWGET=5
+    fi
 
     # first look if we have tarball mirrored
     while [ $NBWGET -gt 0 ]; do


### PR DESCRIPTION
Builds started with `NO_MIRROR=yes` will not try to download the targzs from the Lakka.tv mirrors, and always clone from git (if available).