### PR TITLE
snes9x: bump version to 68bf0fe

### DIFF
--- a/packages/libretro/snes9x/package.mk
+++ b/packages/libretro/snes9x/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x"
-PKG_VERSION="2f6aee4"
+PKG_VERSION="68bf0fe"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"


### PR DESCRIPTION
The core has been rebased and commit id 2f6aee4 is no longer valid