### PR TITLE
systemd/retroarch overlays: fix systemd ordering

### DIFF
--- a/packages/libretro/retroarch/system.d/tmp-assets.mount
+++ b/packages/libretro/retroarch/system.d/tmp-assets.mount
@@ -1,7 +1,6 @@
 [Unit]
 Description=Assets directory
 Before=retroarch.service
-After=storage.mount
 After=systemd-tmpfiles-setup.service
 
 [Mount]

--- a/packages/libretro/retroarch/system.d/tmp-cores.mount
+++ b/packages/libretro/retroarch/system.d/tmp-cores.mount
@@ -1,7 +1,6 @@
 [Unit]
 Description=Cores directory
 Before=retroarch.service
-After=storage.mount
 After=systemd-tmpfiles-setup.service
 
 [Mount]

--- a/packages/libretro/retroarch/system.d/tmp-database.mount
+++ b/packages/libretro/retroarch/system.d/tmp-database.mount
@@ -1,7 +1,6 @@
 [Unit]
 Description=Database directory
 Before=retroarch.service
-After=storage.mount
 After=systemd-tmpfiles-setup.service
 
 [Mount]

--- a/packages/libretro/retroarch/system.d/tmp-joypads.mount
+++ b/packages/libretro/retroarch/system.d/tmp-joypads.mount
@@ -1,7 +1,6 @@
 [Unit]
 Description=Joypad configs directory
 Before=retroarch.service
-After=storage.mount
 After=systemd-tmpfiles-setup.service
 
 [Mount]

--- a/packages/libretro/retroarch/system.d/tmp-overlays.mount
+++ b/packages/libretro/retroarch/system.d/tmp-overlays.mount
@@ -1,7 +1,6 @@
 [Unit]
 Description=Overlays directory
 Before=retroarch.service
-After=storage.mount
 After=systemd-tmpfiles-setup.service
 
 [Mount]

--- a/packages/libretro/retroarch/system.d/tmp-shaders.mount
+++ b/packages/libretro/retroarch/system.d/tmp-shaders.mount
@@ -1,7 +1,6 @@
 [Unit]
 Description=Shaders directory RetroArch
 Before=retroarch.service
-After=storage.mount
 After=systemd-tmpfiles-setup.service
 
 [Mount]

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -187,7 +187,12 @@ post_makeinstall_target() {
   sed -e "s,^.*HandleLidSwitch=.*$,HandleLidSwitch=ignore,g" -i $INSTALL/etc/systemd/logind.conf
   sed -e "s,^.*HandlePowerKey=.*$,HandlePowerKey=ignore,g" -i $INSTALL/etc/systemd/logind.conf
 
-  # replace systemd-machine-id-setup with ours
+  # fix ordering cycle for overlay mounts
+  if [ "$DISTRO" = "Lakka" ]; then
+    sed -e "s/local-fs\.target/tmp.mount var.mount/" -i $INSTALL/usr/lib/systemd/system/systemd-tmpfiles-setup.service
+  fi
+
+# replace systemd-machine-id-setup with ours
   safe_remove $INSTALL/usr/lib/systemd/systemd-machine-id-commit
   safe_remove $INSTALL/usr/lib/systemd/system/systemd-machine-id-commit.service
   safe_remove $INSTALL/usr/lib/systemd/system/*.target.wants/systemd-machine-id-commit.service


### PR DESCRIPTION
`systemd-tmpfiles-setup.service` was queued after `local-fs.target`, which
also mounted `/tmp` and in order to mount overlays, we need the workdir to
be created (by `systemd-tmpfiles-setup.service`), but `tmp.mount` (on which
the overlay `tmp-*.mount` units depend) is queued before `local-fs.target`.
this resulted into endless cycle and systemd broke the cycle by removing
one of the units, which resulted e.g. the worker dirs not to be ready or
skipping the `tmp-*.mount` units for overlays.

now `systemd-tmpfiles-setup.service` is queued after `tmp.mount` and
`var.mount` (instead of `local-fs.target`) and the queue is correct, the
overlays mount correctly.