### PR TITLE
retroarch: add system overlay

### DIFF
--- a/packages/libretro/ppsspp/package.mk
+++ b/packages/libretro/ppsspp/package.mk
@@ -65,4 +65,7 @@ make_target() {
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro
   cp ../libretro/ppsspp_libretro.so $INSTALL/usr/lib/libretro/
+
+  mkdir -p $INSTALL/usr/share/retroarch-system/PPSSPP
+  cp -R $PKG_BUILD/assets/* $INSTALL/usr/share/retroarch-system/PPSSPP/
 }

--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -122,7 +122,7 @@ makeinstall_target() {
   sed -i -e "s/# playlist_directory =/playlist_directory =\/storage\/playlists/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# savefile_directory =/savefile_directory =\/storage\/savefiles/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# savestate_directory =/savestate_directory =\/storage\/savestates/" $INSTALL/etc/retroarch.cfg
-  sed -i -e "s/# system_directory =/system_directory =\/storage\/system/" $INSTALL/etc/retroarch.cfg
+  sed -i -e "s/# system_directory =/system_directory =\/tmp\/system/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# screenshot_directory =/screenshot_directory =\/storage\/screenshots/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# video_shader_dir =/video_shader_dir =\/tmp\/shaders/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# rgui_show_start_screen = true/rgui_show_start_screen = false/" $INSTALL/etc/retroarch.cfg
@@ -229,6 +229,7 @@ post_install() {
   enable_service tmp-assets.mount
   enable_service tmp-shaders.mount
   enable_service tmp-overlays.mount
+  enable_service tmp-system.mount
 }
 
 post_makeinstall_target() {

--- a/packages/libretro/retroarch/system.d/tmp-system.mount
+++ b/packages/libretro/retroarch/system.d/tmp-system.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=System directory
+Before=retroarch.target
+After=storage.mount
+After=systemd-tmpfiles-setup.service
+
+[Mount]
+What=none
+Where=/tmp/system
+Type=overlay
+Options=lowerdir=/usr/share/retroarch-system,upperdir=/storage/system,workdir=/storage/.tmp/system-workdir
+
+[Install]
+WantedBy=retroarch.target

--- a/packages/libretro/retroarch/tmpfiles.d/retroarch-userdirs.conf
+++ b/packages/libretro/retroarch/tmpfiles.d/retroarch-userdirs.conf
@@ -38,3 +38,4 @@ d    /storage/.tmp/database-workdir 0777 root root - -
 d    /storage/.tmp/assets-workdir   0777 root root - -
 d    /storage/.tmp/overlays-workdir 0777 root root - -
 d    /storage/.tmp/shaders-workdir  0777 root root - -
+d    /storage/.tmp/system-workdir   0777 root root - -


### PR DESCRIPTION
This adds a `system` directory overlay, with for now only the PPSSPP assets.