### PR TITLE
Patches for glibc 2.28+ on Fedora

### DIFF
--- a/packages/devel/bison/package.mk
+++ b/packages/devel/bison/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bison"
-PKG_VERSION="3.0.4"
+PKG_VERSION="3.4.1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/bison/"

--- a/packages/devel/glib/package.mk
+++ b/packages/devel/glib/package.mk
@@ -18,11 +18,11 @@
 ################################################################################
 
 PKG_NAME="glib"
-PKG_VERSION="2.46.2"
+PKG_VERSION="2.56.4"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL"
 PKG_SITE="http://www.gtk.org/"
-PKG_URL="http://ftp.gnome.org/pub/gnome/sources/glib/2.46/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="http://ftp.gnome.org/pub/gnome/sources/glib/2.56/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain zlib libffi Python:host"
 PKG_DEPENDS_HOST="libffi:host"
 PKG_SECTION="devel"
@@ -32,7 +32,7 @@ PKG_LONGDESC="GLib is a library which includes support routines for C such as li
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared"
+PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared --disable-libmount --with-pcre=internal"
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_mmap_fixed_mapped=yes \
                            ac_cv_func_posix_getpwuid_r=yes \
                            ac_cv_func_posix_getgrgid_r=yes \
@@ -60,7 +60,7 @@ pre_configure_target() {
 }
 
 pre_configure_host() {
-  export CFLAGS="$CFLAGS -Wno-error=format-nonliteral"
+  export CFLAGS="$CFLAGS -Wno-error=format-nonliteral -Wno-error=format-overflow"
 }
 
 post_makeinstall_target() {

--- a/packages/devel/m4/package.mk
+++ b/packages/devel/m4/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="m4"
-PKG_VERSION="1.4.17"
+PKG_VERSION="1.4.18"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.gnu.org/software/m4/"

--- a/packages/devel/m4/patches/m4-1.4.18-glibc-change-work-around.patch
+++ b/packages/devel/m4/patches/m4-1.4.18-glibc-change-work-around.patch
@@ -1,0 +1,130 @@
+update for glibc libio.h removal in 2.28+
+
+see
+https://src.fedoraproject.org/rpms/m4/c/814d592134fad36df757f9a61422d164ea2c6c9b?branch=master
+
+Upstream-Status: Backport [https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=4af4a4a718]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Index: m4-1.4.18/lib/fflush.c
+===================================================================
+--- m4-1.4.18.orig/lib/fflush.c
++++ m4-1.4.18/lib/fflush.c
+@@ -33,7 +33,7 @@
+ #undef fflush
+ 
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+ /* Clear the stream's ungetc buffer, preserving the value of ftello (fp).  */
+ static void
+@@ -72,7 +72,7 @@ clear_ungetc_buffer (FILE *fp)
+ 
+ #endif
+ 
+-#if ! (defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
++#if ! (defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
+ 
+ # if (defined __sferror || defined __DragonFly__ || defined __ANDROID__) && defined __SNPT
+ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+@@ -148,7 +148,7 @@ rpl_fflush (FILE *stream)
+   if (stream == NULL || ! freading (stream))
+     return fflush (stream);
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+   clear_ungetc_buffer_preserving_position (stream);
+ 
+Index: m4-1.4.18/lib/fpending.c
+===================================================================
+--- m4-1.4.18.orig/lib/fpending.c
++++ m4-1.4.18/lib/fpending.c
+@@ -32,7 +32,7 @@ __fpending (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return fp->_IO_write_ptr - fp->_IO_write_base;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+Index: m4-1.4.18/lib/fpurge.c
+===================================================================
+--- m4-1.4.18.orig/lib/fpurge.c
++++ m4-1.4.18/lib/fpurge.c
+@@ -62,7 +62,7 @@ fpurge (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_IO_read_end = fp->_IO_read_ptr;
+   fp->_IO_write_ptr = fp->_IO_write_base;
+   /* Avoid memory leak when there is an active ungetc buffer.  */
+Index: m4-1.4.18/lib/freadahead.c
+===================================================================
+--- m4-1.4.18.orig/lib/freadahead.c
++++ m4-1.4.18/lib/freadahead.c
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+Index: m4-1.4.18/lib/freading.c
+===================================================================
+--- m4-1.4.18.orig/lib/freading.c
++++ m4-1.4.18/lib/freading.c
+@@ -31,7 +31,7 @@ freading (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return ((fp->_flags & _IO_NO_WRITES) != 0
+           || ((fp->_flags & (_IO_NO_READS | _IO_CURRENTLY_PUTTING)) == 0
+               && fp->_IO_read_base != NULL));
+Index: m4-1.4.18/lib/fseeko.c
+===================================================================
+--- m4-1.4.18.orig/lib/fseeko.c
++++ m4-1.4.18/lib/fseeko.c
+@@ -47,7 +47,7 @@ fseeko (FILE *fp, off_t offset, int when
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -123,7 +123,7 @@ fseeko (FILE *fp, off_t offset, int when
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+Index: m4-1.4.18/lib/stdio-impl.h
+===================================================================
+--- m4-1.4.18.orig/lib/stdio-impl.h
++++ m4-1.4.18/lib/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 

--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -89,9 +89,12 @@ fi
 
 TARGET_CONFIGURE_OPTS=""
 PKG_CONFIGURE_OPTS_TARGET="--disable-vg \
+                           --disable-al \
+                           --disable-cg \
                            --disable-sdl \
                            --disable-sdl2 \
                            --disable-ssl \
+                           --disable-x11 \
                            $RETROARCH_GL \
                            $RETROARCH_NEON \
                            --enable-zlib \

--- a/packages/sysutils/e2fsprogs/package.mk
+++ b/packages/sysutils/e2fsprogs/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="e2fsprogs"
-PKG_VERSION="1.43.4"
+PKG_VERSION="1.43.5"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://e2fsprogs.sourceforge.net/"

--- a/packages/sysutils/parted/patches/parted-sysmacros.patch
+++ b/packages/sysutils/parted/patches/parted-sysmacros.patch
@@ -1,0 +1,25 @@
+From ba5e0451b51c983e40afd123b6e0d3eddb55e610 Mon Sep 17 00:00:00 2001
+From: "Richard W.M. Jones" <rjones@redhat.com>
+Date: Sat, 24 Mar 2018 17:37:02 +0000
+Subject: linux: Include <sys/sysmacros.h> for major() macro.
+
+Since glibc 2.27 this header is required.
+---
+ libparted/arch/linux.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libparted/arch/linux.c b/libparted/arch/linux.c
+index 31b98ab..7e86b51 100644
+--- a/libparted/arch/linux.c
++++ b/libparted/arch/linux.c
+@@ -41,6 +41,7 @@
+ #include <sys/utsname.h>        /* for uname() */
+ #include <scsi/scsi.h>
+ #include <assert.h>
++#include <sys/sysmacros.h>
+ #ifdef ENABLE_DEVICE_MAPPER
+ #include <libdevmapper.h>
+ #endif
+-- 
+cgit v1.0-41-gc330
+

--- a/packages/sysutils/squashfs/patches/squashfs-tools-4.3-sysmacros.patch
+++ b/packages/sysutils/squashfs/patches/squashfs-tools-4.3-sysmacros.patch
@@ -1,0 +1,25 @@
+sys/types.h might not always include sys/sysmacros.h for major/minor/makedev
+
+--- a/squashfs-tools/mksquashfs.c
++++ b/squashfs-tools/mksquashfs.c
+@@ -59,6 +59,7 @@
+ #else
+ #include <endian.h>
+ #include <sys/sysinfo.h>
++#include <sys/sysmacros.h>
+ #endif
+ 
+ #include "squashfs_fs.h"
+--- a/squashfs-tools/unsquashfs.c
++++ b/squashfs-tools/unsquashfs.c
+@@ -38,6 +38,10 @@
+ #include <limits.h>
+ #include <ctype.h>
+ 
++#ifdef linux
++#include <sys/sysmacros.h>
++#endif
++
+ struct cache *fragment_cache, *data_cache;
+ struct queue *to_reader, *to_inflate, *to_writer, *from_writer;
+ pthread_t *thread, *inflator_thread;

--- a/packages/tools/populatefs/package.mk
+++ b/packages/tools/populatefs/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="populatefs"
-PKG_VERSION="95cc98b"
+PKG_VERSION="1.0"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/lipnitsk/populatefs"

--- a/packages/tools/populatefs/patches/populatefs-1.0-sysmacros.patch
+++ b/packages/tools/populatefs/patches/populatefs-1.0-sysmacros.patch
@@ -1,0 +1,11 @@
+diff -ur populatefs-1.0.orig/src/mod_path.c populatefs-1.0/src/mod_path.c
+--- populatefs-1.0.orig/src/mod_path.c	2019-08-14 00:14:18.411252751 +0200
++++ populatefs-1.0/src/mod_path.c	2019-08-14 00:14:03.978642084 +0200
+@@ -3,6 +3,7 @@
+ #include <string.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <unistd.h>
+ #include <dirent.h>
+ #include <ext2fs/ext2fs.h>

--- a/packages/tools/qemu/package.mk
+++ b/packages/tools/qemu/package.mk
@@ -17,11 +17,11 @@
 ################################################################################
 
 PKG_NAME="qemu"
-PKG_VERSION="2.7.0"
+PKG_VERSION="2.10.2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="http://wiki.qemu.org"
-PKG_URL="http://wiki.qemu-project.org/download/qemu-$PKG_VERSION.tar.bz2"
+PKG_SITE="https://www.qemu.org"
+PKG_URL="https://download.qemu.org/qemu-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_HOST="toolchain Python:host zlib:host glib:host"
 PKG_SECTION="tools"
 PKG_SHORTDESC="QEMU is a generic and open source machine emulator and virtualizer."

--- a/packages/tools/syslinux/patches/syslinux-6.03-sysmacros.patch
+++ b/packages/tools/syslinux/patches/syslinux-6.03-sysmacros.patch
@@ -1,0 +1,35 @@
+https://bugs.gentoo.org/579928
+
+From d84db34dbe39d55b4d7e868764c056689aa0793b Mon Sep 17 00:00:00 2001
+From: Mike Frysinger <vapier@gentoo.org>
+Date: Tue, 19 Apr 2016 01:56:41 -0400
+Subject: [PATCH] extlinux: pull in sys/sysmacros.h for major/minor/makedev
+
+These functions are defined in sys/sysmacros.h, so add the include to
+main.c.  This is already handled correctly in mountinfo.c.  Otherwise
+we get build failures like:
+
+main.o: In function 'find_device_sysfs':
+extlinux/main.c:1131: undefined reference to 'minor'
+
+Upstream-Status: Pending
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+
+The first part wasn't enough in OE build, I had to add the same for syslinuxext.c.
+---
+ extlinux/main.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/extlinux/main.c b/extlinux/main.c
+index a7ebd49..ebff7ea 100644
+--- a/extlinux/main.c
++++ b/extlinux/main.c
+@@ -38,6 +38,7 @@
+ #include <sysexits.h>
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <sys/types.h>
+ #include <sys/mount.h>
+ #include <sys/vfs.h>

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -102,3 +102,7 @@
   # override some playlist core assignation
     RA_PLAYLIST_CORES="${RA_PLAYLIST_CORES//pcsx_rearmed/mednafen_psx_hw}"
     RA_PLAYLIST_CORES="${RA_PLAYLIST_CORES//snes9x2010/snes9x}"
+
+  # extra build dependeices
+    EXTRA_DEPS="mkimage"
+    EXTRA_DEPS_PKG="uboot-tools"


### PR DESCRIPTION
These patches allow building Lakka on systems with glibc 2.28+
(ie. Fedora Linux)

Recent refactoring in glibc breaks assumptions built in gnulib and not updated yet software needs working around those assumptions.