### PR TITLE
Lakka: change online updater URL for nightlies

### DIFF
--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -92,6 +92,17 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-vg \
                            --enable-zlib \
                            --enable-freetype"
 
+post_patch() {
+  # patch URL to nightly builds instead of stable builds if building nightly
+  if [ "$LAKKA_NIGHTLY" = yes ]; then
+    i="${PKG_DIR}/patches/nightly/retroarch-lakka_nightly_url.patch"
+    if [ -f "$i" ]; then
+      printf "%${BUILD_INDENT}c ${boldgreen}APPLY PATCH${endcolor} ${boldwhite}(nightly)${endcolor}   ${i#$ROOT/}\n" ' '>&$SILENT_OUT
+      cat $i | patch -d `echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 >&$VERBOSE_OUT
+    fi
+  fi
+}
+
 pre_configure_target() {
   cd $PKG_BUILD
 }

--- a/packages/libretro/retroarch/patches/nightly/retroarch-lakka_nightly_url.patch
+++ b/packages/libretro/retroarch/patches/nightly/retroarch-lakka_nightly_url.patch
@@ -1,0 +1,13 @@
+diff --git a/file_path_str.c b/file_path_str.c
+index d1b0c781c1..3442b173cc 100644
+--- a/file_path_str.c
++++ b/file_path_str.c
+@@ -171,7 +171,7 @@ const char *file_path_str(enum file_path_enum enum_idx)
+          str = "http://thumbnailpacks.libretro.com";
+          break;
+       case FILE_PATH_LAKKA_URL:
+-         str = "http://le.builds.lakka.tv";
++         str = "http://nightly.builds.lakka.tv/.updater";
+          break;
+       case FILE_PATH_SHADERS_GLSL_ZIP:
+          str = "shaders_glsl.zip";


### PR DESCRIPTION
if users try to upgrade nightly build, they are offered to upgrade to
latest stable release, which is a downgrade. a patch corrects the URL to
the nightlies server. this patch is applied only when the build is
started with LAKKA_NIGHTLY=yes, so it has no impact in other scenarios.

The nightlies build script will take care of populating the `.updater` folder with next nightly build.