### PR TITLE
tic80: update for disabled demo carts

### DIFF
--- a/packages/libretro/tic80/package.mk
+++ b/packages/libretro/tic80/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="tic80"
-PKG_VERSION="c9e0630"
+PKG_VERSION="cfa72df"
 PKG_REV="1"
 PKG_ARCH="i386 x86_64 arm"
 PKG_LICENSE="GPLv3"


### PR DESCRIPTION
The change was merged forwards, so we can now update with that change in place. We'll continue to use our own remote though, in case there are any further modifications we want to rapidly push upstream:
https://github.com/libretro/TIC-80