### PR TITLE
Bump version to 2.3

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -1,7 +1,7 @@
 # Name of the Distro to build (full name, without special characters)
   DISTRONAME="Lakka"
   LIBREELEC_VERSION="devel"
-  OS_VERSION="2.2"
+  OS_VERSION="2.3"
 
 # short project description
   DESCRIPTION="The DIY retro emulation console"


### PR DESCRIPTION
I left `LIBREELEC_VERSION` to `devel`, I will change it to `official` when building locally (along with `OFFICIAL=yes`), tell me if it's not the way to do it (should I set it to `2.3` too instead?)