### PR TITLE
retroarch: add a .placeholder file

### DIFF
--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -238,6 +238,7 @@ makeinstall_target() {
   
   # System overlay
   mkdir -p $INSTALL/usr/share/retroarch-system
+    touch $INSTALL/usr/share/retroarch-system/.placeholder
 }
 
 post_install() {  


### PR DESCRIPTION
this protects the empty folder retroarch-system from being deleted by
the build script
[DNB] - do not build by buildbot