### PR TITLE
build_all.sh: start in dashboard mode

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -48,7 +48,21 @@ tc="THREADCOUNT=${bt}"
 [ "${DASHBOARD_MODE}" = "yes" ] && v="" || v="-v"
 
 # remove any existing images / release files
-rm -rf target/
+check=$(ls target/ | wc -l)
+if [ ${check} -gt 0 ]
+then
+	echo -en "\nWARNING!!!\nThere are ${check} item(s) in target/, really remove them?\n(press y to confirm, anything else to abort) "
+	read -rn1 keypress
+	if [ "${keypress}" = "y" -o "${keypress}" = "Y" ]
+	then
+		echo -en "\nCleaning up target/ ... "
+		rm -rf target/
+		echo "done."
+	else
+		echo -e "\nAborted!"
+		exit
+	fi
+fi
 
 # list of targets/platforms in structure PROJECT|DEVICE|ARCH|make_rule
 

--- a/build_all.sh
+++ b/build_all.sh
@@ -24,6 +24,9 @@
 # by default do not bail out after failed build
 [ -z "${BAILOUT_FAILED}" ] && BAILOUT_FAILED="no"
 
+# by default do not use version in build folder
+[ -z "${IGNORE_VERSION}" ] && iv=1 || iv=0
+
 rm -rf target/
 
 # list of targets/platforms in structure PROJECT|DEVICE|ARCH|OUTPUT
@@ -81,7 +84,7 @@ do
 	then
 		# show logs during build (non-dashboard build)
 		echo "Starting build of ${target_name}"
-		make ${out} PROJECT=${project} DEVICE=${device} ARCH=${arch} ${tc}
+		make ${out} PROJECT=${project} DEVICE=${device} ARCH=${arch} IGNORE_VERSION=${iv} ${tc}
 		non_db_ret=${?}
 		if [ ${non_db_ret} -gt 0 -a "${BAILOUT_FAILED}" != "no" ]
 		then
@@ -93,7 +96,7 @@ do
 		# remove the old dashboard, so we don't show old/stale dashboard
 		rm -f ${statusfile}
 		# start the build process in background
-		make ${out} PROJECT=${project} DEVICE=${device} ARCH=${arch} ${tc} &>/dev/null &
+		make ${out} PROJECT=${project} DEVICE=${device} ARCH=${arch} IGNORE_VERSION=${iv} ${tc} &>/dev/null &
 		# store the pid
 		pid=${!}
 		finished=0

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,7 +1,32 @@
 #!/bin/bash
+#
+# Lakka build script
+#
+# This script builds images for all supported platforms/target devices listed in
+# the 'targets' variable.
+#
+# By default (./build_all.sh) it starts in dashboard mode, showing a dashboard
+# with the current status of the build job and not bailing out after unsuccessful
+# build job (tries to build all targets in one run and then show failed targets
+# at the end).
+#
+# To run in log mode:
+# $ DASHBOARD_MODE=off ./build_all.sh
+# Or instead of 'off' you can use any other value, e. g. 'foo', except 'yes'
+#
+# To bail out after first failure:
+# $ BAILOUT_FAILED=yes ./build_all.sh
+# or instead of 'yes' you can use any other value, e. g. 'bar', except 'no'
+
+# by default start in dashboard mode
+[ -z "${DASHBOARD_MODE}" ] && DASHBOARD_MODE="yes"
+
+# by default do not bail out after failed build
+[ -z "${BAILOUT_FAILED}" ] && BAILOUT_FAILED="no"
 
 rm -rf target/
 
+# list of targets/platforms in structure PROJECT|DEVICE|ARCH|OUTPUT
 targets="\
 	Allwinner|A64|arm|image \
 	Allwinner|H3|arm|image \
@@ -21,6 +46,7 @@ targets="\
 	Qualcomm|Dragonboard|arm|image \
 	"
 
+# initialize variables for list and count of failed builds
 failed_targets=""
 declare -i failed_jobs=0
 
@@ -31,34 +57,108 @@ then
 	tc="THREADCOUNT=$(($(nproc)*2))"
 fi
 
-for target in $targets
+for target in ${targets}
 do
-	IFS='|' read -r -a build  <<< "$target"
+	distro="Lakka"
+	IFS='|' read -r -a build  <<< "${target}"
 	project=${build[0]}
 	device=${build[1]}
 	arch=${build[2]}
 	out=${build[3]}
 	target_name=${device:-$project}.${arch}
 
-	echo "Starting build of ${target_name}"
+	# initialize return value of the non-dashboard job
+	non_db_ret=0
+	# initialize result variable for dashboard job
+	failed_dashboard=0
 
-	make $out PROJECT=$project DEVICE=$device ARCH=$arch $tc
-
-	if [ $? -gt 0 ]
+	if [ "${DASHBOARD_MODE}" != "yes" ]
 	then
+		# show logs during build (non-dashboard build)
+		echo "Starting build of ${target_name}"
+		make ${out} PROJECT=${project} DEVICE=${device} ARCH=${arch} ${tc}
+		non_db_ret=${?}
+		if [ ${non_db_ret} -gt 0 -a "${BAILOUT_FAILED}" != "no" ]
+		then
+			exit ${non_db_ret}
+		fi
+	else
+		# show dashboard during build
+		statusfile="build.${distro}-${target_name}*/.threads/status"
+		# remove the old dashboard, so we don't show old/stale dashboard
+		rm -f ${statusfile}
+		# start the build process in background
+		make ${out} PROJECT=${project} DEVICE=${device} ARCH=${arch} ${tc} &>/dev/null &
+		# store the pid
+		pid=${!}
+		finished=0
+		while [ ${finished} -eq 0 ]
+		do
+			# check if the build process is still running
+			ps -q ${pid} &>/dev/null
+			ret=${?}
+			if [ ${ret} -eq 0 ]
+			then
+				# build process is still running, show the dashboard
+				if [ -f ${statusfile} ]
+				then
+					cat ${statusfile}
+					sleep 0.1s
+				fi
+			else
+				# build process is not running anymore
+				finished=1
+				if [ -f ${statusfile} ]
+				then
+					# show the dashboard
+					cat ${statusfile}
+					# check if there are any failed jobs in the dashboard
+					failed_count=$(cat ${statusfile} | grep "^\[" | cut -d' ' -f 2 | grep FAILED | wc -l)
+					if [ ${failed_count} -gt 0 ]
+					then
+						failed_dashboard=1
+						if [ "${BAILOUT_FAILED}" != "no" ]
+						then
+							echo "Build of some package(s) failed."
+							echo "Check the logs in build.${distro}.${target_name}*/.threads/logs/<job_id>/"
+							exit ${failed_count}
+						fi
+					fi
+				else
+					# no dashboard and build process finished - we did not build anything
+					failed_dashboard=1
+					if [ "${BAILOUT_FAILED}" != "no" ]
+					then
+						echo "Build job for ${target_name} was probably not started (no dashboard file found)."
+						echo "Try running the build manually:"
+						echo "PROJECT=${project} DEVICE=${device} ARCH=${arch} make ${out}"
+						exit 127
+					fi
+				fi
+			fi
+		done
+	fi
+
+	if [ ${non_db_ret} -gt 0 -o ${failed_dashboard} -eq 1 ]
+	then
+		# record the failed build
 		failed_jobs+=1
 		failed_targets+="${target_name}\n"
 	else
+		# store the release files in platform/target folder
 		cd target
 		mkdir -p ${target_name}
+		# add md5 checksums to system and kernel files
 		for file in Lakka-${target_name}-*.{kernel,system}
 		do
 			md5sum ${file} > ${file}.md5
 		done
+		# move release files to the folder
 		for file in Lakka-${target_name}-*{.img.gz,-noobs.tar,.kernel,.system}*
 		do
 			mv -v ${file} ${target_name}/
 		done
+		# remove files we do not use
 		rm -vf Lakka-${target_name}-*.{tar,ova}*
 		cd ..
 	fi

--- a/build_all.sh
+++ b/build_all.sh
@@ -48,7 +48,7 @@ tc="THREADCOUNT=${bt}"
 [ "${DASHBOARD_MODE}" = "yes" ] && v="" || v="-v"
 
 # remove any existing images / release files
-check=$(ls target/ | wc -l)
+check=$(ls target/ 2>/dev/null | wc -l)
 if [ ${check} -gt 0 ]
 then
 	echo -en "\nWARNING!!!\nThere are ${check} item(s) in target/, really remove them?\n(press y to confirm, anything else to abort) "

--- a/build_all.sh
+++ b/build_all.sh
@@ -151,7 +151,7 @@ do
 					then
 						echo "Build job for ${target_name} was probably not started (no dashboard file found)."
 						echo "Try running the build manually:"
-						echo "PROJECT=${project} DEVICE=${device} ARCH=${arch} make ${out}"
+						echo "PROJECT=${project} DEVICE=${device} ARCH=${arch} IGNORE_VERSION=${iv} make ${out}"
 						exit 127
 					fi
 				fi


### PR DESCRIPTION
modification of the build script to start in dashboard mode. instead of
showing the output of the individual package compilation a dashboard is
shown showing the overall progress of the current build.

[DNB] do not build by buildbot (no changes to the packages/projects/etc.)