### PR TITLE
mkimage: add BOOT_IMAGE to cmdline.txt for RPi

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -172,7 +172,7 @@ elif [ "$BOOTLOADER" = "bcm2835-bootloader" ]; then
   # create bootloader configuration
     echo "image: creating bootloader configuration..."
     cat << EOF > "$LE_TMP"/cmdline.txt
-boot=LABEL=LAKKA disk=LABEL=LAKKA_DISK quiet $EXTRA_CMDLINE vt.global_cursor_default=0 loglevel=2
+boot=LABEL=LAKKA disk=LABEL=LAKKA_DISK BOOT_IMAGE=/$KERNEL_NAME quiet $EXTRA_CMDLINE vt.global_cursor_default=0 loglevel=2
 EOF
 
     mcopy "$LE_TMP/cmdline.txt" ::


### PR DESCRIPTION
on RPi4 it it seems the BOOT_IMAGE from kernel config file
(CONFIG_CMDLINE) is being ignored and updates are failing on missing
KERNEL or SYSTEM, as the update script defaults to "KERNEL" instead of
"kernel.img"