### PR TITLE
quicknes: fix package.mk so it actually builds

### DIFF
--- a/packages/libretro/quicknes/package.mk
+++ b/packages/libretro/quicknes/package.mk
@@ -35,10 +35,10 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 make_target() {
-  make -C libretro
+  make
 }
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro
-  cp libretro/quicknes_libretro.so $INSTALL/usr/lib/libretro/
+  cp quicknes_libretro.so $INSTALL/usr/lib/libretro/
 }


### PR DESCRIPTION
This resolves this issue: https://github.com/libretro/Lakka-LibreELEC/issues/835

The package.mk file for quicknes assumed that the makefiles were in the libretro folder, but they are at the root. With this change, it actually builds the .so files and copies it correctly for quicknes.