### PR TITLE
OdroidGoAdvance: Add support for OGA v1.1

### DIFF
--- a/packages/libretro/retroarch-joypad-autoconfig/package.mk
+++ b/packages/libretro/retroarch-joypad-autoconfig/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch-joypad-autoconfig"
-PKG_VERSION="66cb07f"
+PKG_VERSION="7d6c1d4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -23,8 +23,8 @@ case "$LINUX" in
     PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     ;;
   odroidgoA-4.4)
-    PKG_VERSION="857cdf6a2ff525fbbe7cf03cf88ef3688a83af1f"
-    PKG_SHA256="0332fe90d0c10a16ad9ea6de93dccc4ca0f15d2da088623f08096a74da9a8977"
+    PKG_VERSION="26e571de7635e63e16eb25feedc25726bfc9cbf0"
+    PKG_SHA256="8e6a773ca43f362c0a6df53f8a4973a29a909e356b4def1e10e75b6055cc9ada"
     PKG_URL="https://github.com/hardkernel/linux/archive/$PKG_VERSION.tar.gz"
     PKG_SOURCE_NAME="linux-$LINUX-$PKG_VERSION.tar.gz"
     ;;

--- a/packages/linux/patches/odroidgoA-4.4/linux-999-odroidgo2_joypad_v11.patch
+++ b/packages/linux/patches/odroidgoA-4.4/linux-999-odroidgo2_joypad_v11.patch
@@ -1,0 +1,64 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux-v11.dts b/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux-v11.dts
+index 405043c17b88..1d2bbd6445bb 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux-v11.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux-v11.dts
+@@ -22,6 +22,11 @@
+ 
+ 	joypad: odroidgo2-joypad {
+                 compatible = "odroidgo2-joypad";
++                
++                joypad-name = "odroidgo2_joypad_v11";
++                joypad-product = <0x0002>;
++                joypad-revision = <0x0011>;
++				
+                 /*
+                   - odroidgo2-joypad sysfs list -
+ 		   * for poll device interval(ms)
+diff --git a/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux.dts b/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux.dts
+index 687bdf388d27..1b2dd792af0c 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux.dts
+@@ -22,6 +22,11 @@
+ 
+ 	joypad: odroidgo2-joypad {
+                 compatible = "odroidgo2-joypad";
++                
++                joypad-name = "odroidgo2_joypad";
++                joypad-product = <0x0001>;
++                joypad-revision = <0x0101>;
++				
+                 /*
+                   - odroidgo2-joypad sysfs list -
+ 		   * for poll device interval(ms)
+diff --git a/drivers/input/joystick/odroidgo2-joypad.c b/drivers/input/joystick/odroidgo2-joypad.c
+index 208bfb473179..3c56809a8bb2 100644
+--- a/drivers/input/joystick/odroidgo2-joypad.c
++++ b/drivers/input/joystick/odroidgo2-joypad.c
+@@ -646,6 +646,8 @@
+ 	struct input_polled_dev *poll_dev;
+ 	struct input_dev *input;
+ 	int nbtn, error;
++	u32 joypad_revision = 0;
++	u32 joypad_product = 0;
+ 
+ 	poll_dev = devm_input_allocate_polled_device(dev);
+ 	if (!poll_dev) {
+@@ -661,13 +663,15 @@
+ 
+ 	input = poll_dev->input;
+ 
+-	input->name = DRV_NAME;
++	device_property_read_string(dev, "joypad-name", &input->name);
+ 	input->phys = DRV_NAME"/input0";
+ 
++	device_property_read_u32(dev, "joypad-revision", &joypad_revision);
++	device_property_read_u32(dev, "joypad-product", &joypad_product);
+ 	input->id.bustype = BUS_HOST;
+ 	input->id.vendor  = 0x0001;
+-	input->id.product = 0x0001;
+-	input->id.version = 0x0101;
++	input->id.product = (u16)joypad_product;
++	input->id.version = (u16)joypad_revision;
+ 
+ 	/* IIO ADC key setup (0 mv ~ 1800 mv) * adc->scale */
+ 	__set_bit(EV_ABS, input->evbit);

--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -24,7 +24,8 @@ case "$PROJECT" in
   Rockchip)
     case "$DEVICE" in
       OdroidGoAdvance)
-        PKG_VERSION="1d26e6c536200fb6fdcda026f54b9b5721e49ef5"
+        PKG_VERSION="e7b255b54c42c8a805dee7a9409a8838cfa13586"
+        PKG_SHA256="a3c9d17c363cdedb43ec34f3965594d82bf499cc1d70334610afe477adcdf9b6"
         PKG_URL="https://github.com/hardkernel/u-boot/archive/$PKG_VERSION.tar.gz"
         ;;
       *)

--- a/projects/Rockchip/bootloader/mkimage
+++ b/projects/Rockchip/bootloader/mkimage
@@ -18,3 +18,20 @@ if [ -f "$RELEASE_DIR/3rdparty/bootloader/boot.ini" ]; then
   echo "image: copy boot.ini to root..."
   mcopy "$RELEASE_DIR/3rdparty/bootloader/boot.ini" ::
 fi
+
+mkdir -p "${LE_TMP}/extlinux"
+
+# copy device trees to part1
+for dtb in $RELEASE_DIR/3rdparty/bootloader/*.dtb; do
+
+cat << EOF > "${LE_TMP}/extlinux/$(basename ${dtb}).conf"
+LABEL ${DISTRO}
+  LINUX /${KERNEL_NAME}
+  FDT /$(basename ${dtb})
+  APPEND boot=UUID=${UUID_SYSTEM} disk=UUID=${UUID_STORAGE} quiet ${EXTRA_CMDLINE}
+EOF
+
+  [ -e "$dtb" ] && mcopy -o "$dtb" ::
+done
+
+ mcopy -so "${LE_TMP}/extlinux" ::

--- a/projects/Rockchip/bootloader/odroidgo2.ini
+++ b/projects/Rockchip/bootloader/odroidgo2.ini
@@ -6,4 +6,8 @@ setenv loadaddr "0x100000"
 setenv scriptaddr "0x00500000"
 setenv kernel_addr_r "0x02008000"
 
-sysboot mmc 1:1 any ${scriptaddr} /extlinux/extlinux.conf
+if test ${hwrev} = 'v11'; then
+sysboot mmc 1:1 any ${scriptaddr} /extlinux/rk3326-odroidgo2-linux-v11.dtb.conf
+else
+sysboot mmc 1:1 any ${scriptaddr} /extlinux/rk3326-odroidgo2-linux.dtb.conf
+fi

--- a/projects/Rockchip/devices/OdroidGoAdvance/options
+++ b/projects/Rockchip/devices/OdroidGoAdvance/options
@@ -27,6 +27,7 @@
   # Additional kernel make parameters (for example to specify the u-boot loadaddress)
     KERNEL_MAKE_EXTRACMD=""
     KERNEL_MAKE_EXTRACMD+=" rockchip/rk3326-odroidgo2-linux.dtb"
+    KERNEL_MAKE_EXTRACMD+=" rockchip/rk3326-odroidgo2-linux-v11.dtb"
 
   # Mali GPU family
     MALI_FAMILY="g31"


### PR DESCRIPTION
This adds support for the OGA v1.1 (Black Edition)

* Bumps retroarch-joypad-autoconfig  to 7d6c1d4 (includes Oga v1.1 game-pad mapping)
* Bumps OGA Linux to 26e571d
* Bumps OGA u-boot to e7b255b
* Modified boot.ini to include dtbs for each revision
* Slight modification to the v1.0 game-pad mapping as I feel this gives more options (fast foward, load/save state, etc) please test to make sure its up to your liking. 

I did not include a rev 1.1 game-pad config as one already exists on the retroarch-joypad-autoconfig package and I am not sure how that is handled, but I think one should be created with all the hotkeys. 