### PR TITLE
Disable ChaiLove builds

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -190,7 +190,6 @@
 " bsnes-mercury "\
 " cannonball "\
 " cap32 "\
-" chailove "\
 " citra "\
 " crocods "\
 " daphne "\
@@ -278,7 +277,6 @@
 "Bandai - WonderSwan Color.lpl;"\
 "Bandai - WonderSwan.lpl;"\
 "Cave Story.lpl;"\
-"ChaiLove.lpl;"\
 "Coleco - ColecoVision.lpl;"\
 "Commodore - 64 (PP).lpl;"\
 "Commodore - 64 (Tapes).lpl;"\
@@ -350,7 +348,6 @@
 "/tmp/cores/mednafen_wswan_libretro.so;"\
 "/tmp/cores/mednafen_wswan_libretro.so;"\
 "/tmp/cores/nxengine_libretro.so;"\
-"/tmp/cores/chailove_libretro.so;"\
 "/tmp/cores/bluemsx_libretro.so;"\
 "/tmp/cores/vice_x64_libretro.so;"\
 "/tmp/cores/vice_x64_libretro.so;"\


### PR DESCRIPTION
This change aims to disable the ChaiLove package, at least for now. There is a dependency chain issue with SDL, so once that is fixed, we can restore it.