### PR TITLE
Uncomment DISTRO_SRC and DISTRO_MIRROR so that sources can be downloaded

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -127,8 +127,8 @@
   CRON_SUPPORT="yes"
 
 # Distribution Specific source location
-#  DISTRO_MIRROR="http://sources.libreelec.tv/mirror"
-#  DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
+  DISTRO_MIRROR="http://sources.libreelec.tv/mirror"
+  DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 
 # Addon Server Url
 # ADDON_SERVER_URL="https://addons.libreelec.tv"


### PR DESCRIPTION
Not sure whether DISTRO_MIRROR is necessary but RPi targets can't be built without DISTRO_SRC at the moment.

Perhaps this change was intentional and the package files need fixing instead? I couldn't find any information about it.