### PR TITLE
Added retrodream core to replace redream

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -244,6 +244,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 " prosystem "\
 " puae "\
 " px68k "\
+" retrodream "\
 " reminiscence "\
 " sameboy "\
 " scummvm "\
@@ -472,6 +473,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
       LIBRETRO_CORES="${LIBRETRO_CORES// parallel-n64 /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// ppsspp /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// puae /}"
+      LIBRETRO_CORES="${LIBRETRO_CORES// retrodream /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// snes9x2005_plus /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// snes9x2005 /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// snes9x2010 /}"

--- a/packages/libretro/retrodream/package.mk
+++ b/packages/libretro/retrodream/package.mk
@@ -18,12 +18,12 @@
 #  http://www.gnu.org/copyleft/gpl.html
 ################################################################################
 
-PKG_NAME="redream"
-PKG_VERSION="ffb7302"
+PKG_NAME="retrodream"
+PKG_VERSION="bf4d812"
 PKG_REV="1"
 PKG_ARCH="arm i386 x86_64"
 PKG_LICENSE="MIT"
-PKG_SITE="https://github.com/inolen/redream"
+PKG_SITE="https://github.com/libretro/retrodream"
 PKG_URL="$PKG_SITE.git"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
@@ -46,5 +46,5 @@ make_target() {
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro
-  cp redream_libretro.so $INSTALL/usr/lib/libretro/
+  cp retrodream_libretro.so $INSTALL/usr/lib/libretro/
 }


### PR DESCRIPTION
The open source branch of redream core is now called retrodream: https://github.com/libretro/retrodream

Libretro-super is already up to date:
https://github.com/libretro/libretro-super/blob/master/dist/info/retrodream_libretro.info