### PR TITLE
Only build play! on i386/x86_64

### DIFF
--- a/packages/libretro/play/package.mk
+++ b/packages/libretro/play/package.mk
@@ -20,7 +20,7 @@
 
 PKG_NAME="play"
 PKG_VERSION="80bfc0a"
-PKG_ARCH="any"
+PKG_ARCH="i386 x86_64"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/jpd002/Play-"
 PKG_URL="$PKG_SITE.git"


### PR DESCRIPTION
play! has issues on aarch64/arm so let's only build it on i386/x86_64 for now