### PR TITLE
Enable asm optimization for snes9x2002 on rpi0/1 targets

### DIFF
--- a/packages/libretro/snes9x2002/package.mk
+++ b/packages/libretro/snes9x2002/package.mk
@@ -34,6 +34,14 @@ PKG_LONGDESC="Snes9x 2002. Port of SNES9x 1.39 for libretro (was previously call
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
+make_target() {
+  if [ "$DEVICE" = "RPi" -o "$DEVICE" = "Gamegirl" -o "$DEVICE" = "GPICase" ]; then
+    make ARM_ASM=1 platform=unix
+  else
+    make platform=unix
+  fi
+}
+
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro
   cp snes9x2002_libretro.so $INSTALL/usr/lib/libretro/


### PR DESCRIPTION
The gain is not very big, hence it could explain why not activated...
I've seen some others distribution activating them.
Contra 3 has a slightly less choppy sound in gameplay on Pi 0, hence I only activated for this platform.