### PR TITLE
Enable beetle-gba build

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -175,6 +175,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 " 81 "\
 " atari800 "\
 " beetle-bsnes "\
+" beetle-gba"\
 " beetle-lynx "\
 " beetle-ngp "\
 " beetle-pce "\


### PR DESCRIPTION
Built fine with RPi.ARM image.

Haven't done any performance testing with the core so leaving it enabled for everything.