### PR TITLE
fix and enable emux-sms build

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -201,6 +201,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 " dosbox "\
 " dosbox-svn "\
 " duckstation "\
+" emux-sms"\
 " easyrpg "\
 " fbneo "\
 " fceumm "\

--- a/packages/libretro/emux-sms/package.mk
+++ b/packages/libretro/emux-sms/package.mk
@@ -33,6 +33,7 @@ PKG_LONGDESC="Emux is a cross-platform emulator project supporting various machi
 
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
+PKG_TOOLCHAIN="manual"
 
 make_target() {
   make -C libretro -f Makefile.lakka MACHINE=sms


### PR DESCRIPTION
Needed to specify `PKG_TOOLCHAIN` but got it to build just fine.