### PR TITLE
add/enable mame2016

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -225,6 +225,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 " mame2003-plus "\
 " mame2010 "\
 " mame2015 "\
+" mame2016 "\
 " melonds "\
 " meowpc98 "\
 " mesen "\
@@ -305,6 +306,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 "MAME 2003-Plus.lpl;"\
 "MAME 2010.lpl;"\
 "MAME 2015.lpl;"\
+"MAME 2016.lpl;"\
 "Mattel - Intellivision.lpl;"\
 "Microsoft - MSX2.lpl;"\
 "Microsoft - MSX.lpl;"\
@@ -380,6 +382,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 "/tmp/cores/mame2003_plus_libretro.so;"\
 "/tmp/cores/mame2010_libretro.so;"\
 "/tmp/cores/mame2015_libretro.so;"\
+"/tmp/cores/mame2016_libretro.so;"\
 "/tmp/cores/freeintv_libretro.so;"\
 "/tmp/cores/bluemsx_libretro.so;"\
 "/tmp/cores/bluemsx_libretro.so;"\
@@ -475,6 +478,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
       LIBRETRO_CORES="${LIBRETRO_CORES// mame2003 /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// mame2010 /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// mame2015 /}"
+      LIBRETRO_CORES="${LIBRETRO_CORES// mame2016 /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// melonds /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// meowpc98 /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// mesen-s /}"

--- a/packages/libretro/mame2016/package.mk
+++ b/packages/libretro/mame2016/package.mk
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="mame2016"
+PKG_VERSION="02987af"
+PKG_ARCH="x86_64 aarch64 arm"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/libretro/mame2016-libretro"
+PKG_URL="$PKG_SITE.git"
+PKG_DEPENDS_TARGET="toolchain linux glibc alsa-lib"
+PKG_LONGDESC="Late 2016 version of MAME (0.174) for libretro. Compatible with MAME 0.174 romsets."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+PKG_TOOLCHAIN="make"
+
+make_target() {
+  if [ "${ARCH}" = "arm" ]; then
+    PKG_NOASM="1"
+  else
+    PKG_NOASM="0"
+  fi
+
+  if [ "${ARCH}" = "x86_64" ]; then
+    PKG_PTR64="1"
+  else
+    PKG_PTR64="0"
+  fi
+
+  make REGENIE=1 VERBOSE=1 NOWERROR=1 PYTHON_EXECUTABLE=python2 CONFIG=libretro \
+       LIBRETRO_OS="unix" ARCH="" PROJECT="" LIBRETRO_CPU="${ARCH}" DISTRO="debian-stable" \
+       CROSS_BUILD="1" OVERRIDE_CC="${CC}" OVERRIDE_CXX="${CXX}" \
+       PTR64="${PKG_PTR64}" NOASM="${PKG_NOASM}" TARGET="mame" \
+       SUBTARGET="arcade" PLATFORM="${ARCH}" RETRO=1 OSD="retro" GIT_VERSION=${PKG_VERSION}
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/libretro
+  cp mamearcade2016_libretro.so $INSTALL/usr/lib/libretro/mame2016.so
+}

--- a/packages/libretro/mame2016/patches/libretro-mame2016-100.01-cross-compile.patch
+++ b/packages/libretro/mame2016/patches/libretro-mame2016-100.01-cross-compile.patch
@@ -1,0 +1,52 @@
+--- a/3rdparty/genie/build/gmake.linux/genie.make
++++ b/3rdparty/genie/build/gmake.linux/genie.make
+@@ -28,8 +28,8 @@
+   RM    = $(SILENT) del /F "$(subst /,\\,$(1))" 2> nul || exit 0
+ endif
+ 
+-CC  = gcc
+-CXX = g++
++CC  = $(HOST_CC)
++CXX = $(HOST_CXX)
+ AR  = ar
+ 
+ ifndef RESCOMP
+@@ -47,11 +47,11 @@
+   DEFINES   += -DNDEBUG -DLUA_COMPAT_MODULE -DLUA_USE_POSIX -DLUA_USE_DLOPEN
+   INCLUDES  += -I../../src/host/lua-5.3.0/src
+   ALL_CPPFLAGS  += $(CPPFLAGS) -MMD -MP -MP $(DEFINES) $(INCLUDES)
+-  ALL_CFLAGS    += $(CFLAGS) $(ALL_CPPFLAGS) $(ARCH) -Wall -Wextra -Os
+-  ALL_CXXFLAGS  += $(CXXFLAGS) $(CFLAGS) $(ALL_CPPFLAGS) $(ARCH) -Wall -Wextra -Os
+-  ALL_OBJCFLAGS += $(CXXFLAGS) $(CFLAGS) $(ALL_CPPFLAGS) $(ARCH) -Wall -Wextra -Os
++  ALL_CFLAGS    += $(ALL_CPPFLAGS) $(ARCH) -Wall -Wextra -Os
++  ALL_CXXFLAGS  += $(ALL_CPPFLAGS) $(ARCH) -Wall -Wextra -Os
++  ALL_OBJCFLAGS += $(ALL_CPPFLAGS) $(ARCH) -Wall -Wextra -Os
+   ALL_RESFLAGS  += $(RESFLAGS) $(DEFINES) $(INCLUDES)
+-  ALL_LDFLAGS   += $(LDFLAGS) -L. -s -rdynamic
++  ALL_LDFLAGS   += -L. -s -rdynamic
+   LDDEPS    +=
+   LIBS      += $(LDDEPS) -ldl -lm
+   EXTERNAL_LIBS +=
+--- a/scripts/toolchain.lua
++++ b/scripts/toolchain.lua
+@@ -675,9 +675,6 @@
+ 
+ 	configuration { "linux-gcc", "x32" }
+ 		objdir (_buildDir .. "linux_gcc" .. "/obj")
+-		buildoptions {
+-			"-m32",
+-		}
+ 
+ 	configuration { "linux-gcc", "x32", "Release" }
+ 		targetdir (_buildDir .. "linux_gcc" .. "/bin/x32/Release")
+--- a/3rdparty/genie/src/host/scripts.c
++++ b/3rdparty/genie/src/host/scripts.c
+@@ -131,7 +131,7 @@
+ 	"gs(cfg)\nlocal result = table.translate(cfg.flags, flags)\nreturn result\nend\nfunction premake.dotnet.getkind(cfg)\nif (cfg.kind == \"ConsoleApp\") then\nreturn \"Exe\"\nelseif (cfg.kind == \"WindowedApp\") then\nreturn \"WinExe\"\nelseif (cfg.kind == \"SharedLib\") then\nreturn \"Library\"\nend\nend",
+ 
+ 	/* tools/gcc.lua */
+-	"premake.gcc = { }\npremake.gcc.cc     = \"gcc\"\npremake.gcc.cxx    = \"g++\"\npremake.gcc.ar     = \"ar\"\npremake.gcc.llvm   = false\nlocal cflags =\n{\nEnableSSE      = \"-msse\",\nEnableSSE2     = \"-msse2\",\nEnableAVX      = \"-mavx\",\nEnableAVX2     = \"-mavx2\",\nExtraWarnings  = \"-Wall -Wextra\",\nFatalWarnings  = \"-Werror\",\nFloatFast      = \"-ffast-math\",\nFloatStrict    = \"-ffloat-store\",\nNoFramePointer = \"-fomit-frame-pointer\",\nOptimize       = \"-O2\",\nOptimizeSize   = \"-Os\",\nOptimizeSpeed  = \"-O3\",\nSymbols        = \"-g\",\n}\nlocal cxxflags =\n{\nNoExceptions   = \"-fno-exceptions\",\nNoRTTI         = \"-fno-rtti\",\nUnsignedChar   = \"-funsigned-char\",\n}\npremake.gcc.platforms =\n{\nNative = {\ncppflags = \"-MMD -MP\",\n},\nx32 = {\ncppflags = \"-MMD -MP\",\nflags    = \"-m32\",\n},\nx64 = {\ncppflags = \"-MMD -MP\",\nflags    = \"-m64\",\n},\nUniversal = {\nar       = \"libtool\",\ncppflags = \"-MMD -MP\",\nflags    = \"-arch i386 -arch x86_64 -arch ppc -arch ppc64\",\n},"
++	"premake.gcc = { }\npremake.gcc.cc     = \"gcc\"\npremake.gcc.cxx    = \"g++\"\npremake.gcc.ar     = \"ar\"\npremake.gcc.llvm   = false\nlocal cflags =\n{\nEnableSSE      = \"-msse\",\nEnableSSE2     = \"-msse2\",\nEnableAVX      = \"-mavx\",\nEnableAVX2     = \"-mavx2\",\nExtraWarnings  = \"-Wall -Wextra\",\nFatalWarnings  = \"-Werror\",\nFloatFast      = \"-ffast-math\",\nFloatStrict    = \"-ffloat-store\",\nNoFramePointer = \"-fomit-frame-pointer\",\nOptimize       = \"-O2\",\nOptimizeSize   = \"-Os\",\nOptimizeSpeed  = \"-O3\",\nSymbols        = \"-g\",\n}\nlocal cxxflags =\n{\nNoExceptions   = \"-fno-exceptions\",\nNoRTTI         = \"-fno-rtti\",\nUnsignedChar   = \"-funsigned-char\",\n}\npremake.gcc.platforms =\n{\nNative = {\ncppflags = \"-MMD -MP\",\n},\nx32 = {\ncppflags = \"-MMD -MP\",\n},\nx64 = {\ncppflags = \"-MMD -MP\",\nflags    = \"-m64\",\n},\nUniversal = {\nar       = \"libtool\",\ncppflags = \"-MMD -MP\",\nflags    = \"-arch i386 -arch x86_64 -arch ppc -arch ppc64\",\n},"
+ 	"\nUniversal32 = {\nar       = \"libtool\",\ncppflags = \"-MMD -MP\",\nflags    = \"-arch i386 -arch ppc\",\n},\nUniversal64 = {\nar       = \"libtool\",\ncppflags = \"-MMD -MP\",\nflags    = \"-arch x86_64 -arch ppc64\",\n},\nPS3 = {\ncc         = \"ppu-lv2-g++\",\ncxx        = \"ppu-lv2-g++\",\nar         = \"ppu-lv2-ar\",\ncppflags   = \"-MMD -MP\",\n},\nWiiDev = {\ncppflags    = \"-MMD -MP -I$(LIBOGC_INC) $(MACHDEP)\",\nldflags= \"-L$(LIBOGC_LIB) $(MACHDEP)\",\ncfgsettings = [[\n  ifeq ($(strip $(DEVKITPPC)),)\n    $(error \"DEVKITPPC environment variable is not set\")'\n  endif\n  include $(DEVKITPPC)/wii_rules']],\n},\nOrbis = {\ncc         = \"orbis-clang\",\ncxx        = \"orbis-clang++\",\nar         = \"orbis-ar\",\ncppflags   = \"-MMD -MP\",\n}\n}\nlocal platforms = premake.gcc.platforms\nfunction premake.gcc.getcppflags(cfg)\nlocal flags = { }\ntable.insert(flags, platforms[cfg.platform].cppflags)\nif flags[1]:startswith(\"-MMD\") then\ntable.insert(flags, \"-MP\")\nend\nreturn flags\nend\nfunction "
+ 	"premake.gcc.getcflags(cfg)\nlocal result = table.translate(cfg.flags, cflags)\ntable.insert(result, platforms[cfg.platform].flags)\nif cfg.system ~= \"windows\" and cfg.kind == \"SharedLib\" then\ntable.insert(result, \"-fPIC\")\nend\nreturn result\nend\nfunction premake.gcc.getcxxflags(cfg)\nlocal result = table.translate(cfg.flags, cxxflags)\nreturn result\nend\nfunction premake.gcc.getldflags(cfg)\nlocal result = { }\nif not cfg.flags.Symbols then\nif cfg.system == \"macosx\" then\nelse\ntable.insert(result, \"-s\")\nend\nend\nif cfg.kind == \"SharedLib\" then\nif cfg.system == \"macosx\" then\ntable.insert(result, \"-dynamiclib\")\nelse\ntable.insert(result, \"-shared\")\nend\nif cfg.system == \"windows\" and not cfg.flags.NoImportLib then\ntable.insert(result, '-Wl,--out-implib=\"' .. cfg.linktarget.fullpath .. '\"')\nend\nend\nif cfg.kind == \"WindowedApp\" and cfg.system == \"windows\" then\ntable.insert(result, \"-mwindows\")\nend\nlocal platform = platforms[cfg.platform]\ntable.insert(result, platform"
+ 	".flags)\ntable.insert(result, platform.ldflags)\nreturn result\nend\nfunction premake.gcc.getlibdirflags(cfg)\nlocal result = { }\nfor _, value in ipairs(premake.getlinks(cfg, \"all\", \"directory\")) do\ntable.insert(result, '-L' .. _MAKE.esc(value))\nend\nreturn result\nend\nfunction premake.gcc.islibfile(p)\nif path.getextension(p) == \".a\" then\nreturn true\nend\nreturn false\nend\nfunction premake.gcc.getlibfiles(cfg)\nlocal result = {}\nfor _, value in ipairs(premake.getlinks(cfg, \"system\", \"fullpath\")) do\nif premake.gcc.islibfile(value) then\ntable.insert(result, _MAKE.esc(value))\nend\nend\nreturn result\nend\nfunction premake.gcc.getlinkflags(cfg)\nlocal result = {}\nfor _, value in ipairs(premake.getlinks(cfg, \"system\", \"fullpath\")) do\nif premake.gcc.islibfile(value) then\ntable.insert(result, _MAKE.esc(value))\nelseif path.getextension(value) == \".framework\" then\ntable.insert(result, '-framework ' .. _MAKE.esc(path.getbasename(value)))\nelse\ntable.insert(result, '-l' .. _MAKE.esc(path"


### PR DESCRIPTION
`LibreElec` had a package already named `libretro-mame2016` so used it as a base and configured it for our use.