### PR TITLE
Re-add vc-egl patch for RPi

### DIFF
--- a/packages/libretro/retroarch/patches/retroarch-04-vc-egl.patch
+++ b/packages/libretro/retroarch/patches/retroarch-04-vc-egl.patch
@@ -1,0 +1,61 @@
+diff --git a/gfx/drivers_context/vc_egl_ctx.c b/gfx/drivers_context/vc_egl_ctx.c
+index 3c52edb96a..ba82a9418d 100644
+--- a/gfx/drivers_context/vc_egl_ctx.c
++++ b/gfx/drivers_context/vc_egl_ctx.c
+@@ -147,6 +147,28 @@ static void dispmanx_vsync_callback(DISPMANX_UPDATE_HANDLE_T u, void *data)
+    slock_unlock(vc->vsync_condition_mutex);
+ }
+ 
++static bool gfx_ctx_vc_bind_api(void *data,
++      enum gfx_ctx_api api, unsigned major, unsigned minor)
++{
++   vc_api = api;
++
++   switch (api)
++   {
++#ifdef HAVE_EGL
++      case GFX_CTX_OPENGL_API:
++         return egl_bind_api(EGL_OPENGL_API);
++      case GFX_CTX_OPENGL_ES_API:
++         return egl_bind_api(EGL_OPENGL_ES_API);
++      case GFX_CTX_OPENVG_API:
++         return egl_bind_api(EGL_OPENVG_API);
++#endif
++      default:
++         break;
++   }
++
++   return false;
++}
++
+ static void gfx_ctx_vc_destroy(void *data)
+ {
+    vc_ctx_data_t *vc = (vc_ctx_data_t*)data;
+@@ -456,27 +478,6 @@ static enum gfx_ctx_api gfx_ctx_vc_get_api(void *data)
+    return vc_api;
+ }
+ 
+-static bool gfx_ctx_vc_bind_api(void *data,
+-      enum gfx_ctx_api api, unsigned major, unsigned minor)
+-{
+-   vc_api = api;
+-
+-   switch (api)
+-   {
+-#ifdef HAVE_EGL
+-      case GFX_CTX_OPENGL_API:
+-         return egl_bind_api(EGL_OPENGL_API);
+-      case GFX_CTX_OPENGL_ES_API:
+-         return egl_bind_api(EGL_OPENGL_ES_API);
+-      case GFX_CTX_OPENVG_API:
+-         return egl_bind_api(EGL_OPENVG_API);
+-#endif
+-      default:
+-         break;
+-   }
+-
+-   return false;
+-}
+ 
+ static void gfx_ctx_vc_input_driver(void *data,
+       const char *name,


### PR DESCRIPTION
Since we changed our retroarch version, we need to re-add the patch to fix RPi builds