### PR TITLE
brcmfmac_sdio-firmware: update to 4b4acd5

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="brcmfmac_sdio-firmware"
-PKG_VERSION="b51b1c3abf454d377aa01731c2da11b4adb3f9b3"
-PKG_SHA256="44fe38799a98335af8a6d55423ab5261997e5c7f1a3ec2705aef814b1904b45a"
+PKG_VERSION="4b4acd5f91fcf3c8190a08b74e1afd2274080860"
+PKG_SHA256="df786a745c6af7754793367824830e4455e46cdcc8c0f06ab053ac8f25f6442c"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/brcmfmac_sdio-firmware"
 PKG_URL="https://github.com/LibreELEC/brcmfmac_sdio-firmware/archive/$PKG_VERSION.tar.gz"


### PR DESCRIPTION
Adds firmware and nvrams for BCM4329 used in Wandboard rev B1