### PR TITLE
Add mk_arcade_joystick_rpi kernel module

### DIFF
--- a/packages/lakka/RPi/package.mk
+++ b/packages/lakka/RPi/package.mk
@@ -27,8 +27,8 @@ PKG_SITE="https://github.com/libretro/Lakka-LibreELEC"
 PKG_URL=""
 PKG_DEPENDS_TARGET="retroarch"
 
-if [ "$DEVICE" = "RPi" -o "$DEVICE" = "RPi2" ] ; then
-  PKG_DEPENDS_TARGET+=" wii-u-gc-adapter wiringPi"
+if [ "$DEVICE" = "RPi" -o "$DEVICE" = "RPi2" -o "$DEVICE" = "RPi4" ] ; then
+  PKG_DEPENDS_TARGET+=" wii-u-gc-adapter wiringPi mk_arcade_joystick_rpi"
 fi
 
 if [ "$DEVICE" = "Gamegirl" ]; then

--- a/packages/linux-drivers/mk_arcade_joystick_rpi/Readme.md
+++ b/packages/linux-drivers/mk_arcade_joystick_rpi/Readme.md
@@ -1,0 +1,3 @@
+Instructions here:
+
+https://github.com/Turro75/mk_arcade_joystick_rpi/wiki/Raspberry-pi-and-GPIO-controllers-with-Lakka-3

--- a/packages/linux-drivers/mk_arcade_joystick_rpi/package.mk
+++ b/packages/linux-drivers/mk_arcade_joystick_rpi/package.mk
@@ -1,0 +1,62 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="mk_arcade_joystick_rpi"
+PKG_VERSION="10526d2"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/Turro75/mk_arcade_joystick_rpi"
+PKG_URL="$PKG_SITE.git"
+PKG_SOURCE_DIR="${PKG_NAME}-${PKG_VERSION}"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Generic GPIO rpi joystick driver"
+PKG_TOOLCHAIN="manual"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET gcc-linaro-aarch64-elf:host"
+  export PATH=$TOOLCHAIN/lib/gcc-linaro-aarch64-elf/bin/:$PATH
+  TARGET_PREFIX=aarch64-elf-
+fi
+
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  cd $PKG_BUILD
+  make V=1 \
+       ARCH=$TARGET_KERNEL_ARCH \
+       KERNELDIR=$(kernel_path) \
+       CROSS_COMPILE=$TARGET_PREFIX \
+       CONFIG_POWER_SAVING=n \
+       ARCH="$ARCH" \
+       -f Makefile.cross
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/$(get_full_module_dir)/$PKG_NAME
+  cp $PKG_BUILD/*.ko $INSTALL/$(get_full_module_dir)/$PKG_NAME
+
+}
+


### PR DESCRIPTION
Add mk_arcade_joystick_rpi kernel module
Based on game-hat package available in lakka 2.3.2
