### PR TITLE
rpi4-aarch64: fix flycast and enable ppsspp

### DIFF
--- a/packages/libretro/flycast/package.mk
+++ b/packages/libretro/flycast/package.mk
@@ -64,7 +64,11 @@ make_target() {
         make AS=${AS} CC_AS=${CC} platform=armv-gles-neon $FLYCAST_GL HAVE_OPENMP=0 LDFLAGS=-lrt
       fi
     else
-      make AS=${AS} CC_AS=${AS} ARCH=${ARCH} $FLYCAST_GL HAVE_OPENMP=0 LDFLAGS=-lrt
+      if [ "$DEVICE" = "RPi4" -a "$ARCH" = "aarch64" ]; then
+        make AS=${AS} CC_AS=${CC} platform=rpi4_64-gles-neon HAVE_OPENMP=0 LDFLAGS=-lrt
+      else
+        make AS=${AS} CC_AS=${AS} ARCH=${ARCH} $FLYCAST_GL HAVE_OPENMP=0 LDFLAGS=-lrt
+      fi
     fi
   fi
 }

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -47,7 +47,6 @@
         KERNEL_TARGET="Image"
 
         # Exclude non-building cores
-        LIBRETRO_CORES="${LIBRETRO_CORES// flycast /}"
         LIBRETRO_CORES="${LIBRETRO_CORES// mame2015 /}"
         LIBRETRO_CORES="${LIBRETRO_CORES// parallel-n64 /}"
         LIBRETRO_CORES="${LIBRETRO_CORES// pcsx_rearmed /}"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -50,7 +50,6 @@
         LIBRETRO_CORES="${LIBRETRO_CORES// mame2015 /}"
         LIBRETRO_CORES="${LIBRETRO_CORES// parallel-n64 /}"
         LIBRETRO_CORES="${LIBRETRO_CORES// pcsx_rearmed /}"
-        LIBRETRO_CORES="${LIBRETRO_CORES// ppsspp /}"
         LIBRETRO_CORES="${LIBRETRO_CORES// yabause /}"
         ;;
     esac


### PR DESCRIPTION
Flycast appears to already have a config for rpi4 aarch64, so this just configures `package.mk` to use it

ppsspp appears to build now and has an aarch64 config in its CMakeLists.txt.