### PR TITLE
rpi4-aarch64: add parallel-n64

### DIFF
--- a/packages/libretro/parallel-n64/package.mk
+++ b/packages/libretro/parallel-n64/package.mk
@@ -58,7 +58,11 @@ make_target() {
     make platform=rpi
   elif [ "$DEVICE" = "RPi4" ]; then
     LDFLAGS="$LDFLAGS -lpthread"
-    make platform=armv-neon WITH_DYNAREC=$DYNAREC HAVE_PARALLEL=1
+    if [ "$ARCH" = "aarch64" ]; then
+      make WITH_DYNAREC=$DYNAREC FORCE_GLES=1 HAVE_PARALLEL=1
+    else
+      make platform=armv-neon WITH_DYNAREC=$DYNAREC HAVE_PARALLEL=1
+    fi
   elif [[ "$PROJECT" == "Generic_VK_nvidia" ]]; then
     LDFLAGS="$LDFLAGS -lpthread"
     make WITH_DYNAREC=$DYNAREC HAVE_PARALLEL=1 HAVE_OPENGL=0

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -48,7 +48,6 @@
 
         # Exclude non-building cores
         LIBRETRO_CORES="${LIBRETRO_CORES// mame2015 /}"
-        LIBRETRO_CORES="${LIBRETRO_CORES// parallel-n64 /}"
         LIBRETRO_CORES="${LIBRETRO_CORES// pcsx_rearmed /}"
         LIBRETRO_CORES="${LIBRETRO_CORES// yabause /}"
         ;;


### PR DESCRIPTION
I tried it and it works much better than mupen64.