### PR TITLE
rpi4-aarch64: set arm_64bit and kernel in distroconfig.txt

### DIFF
--- a/packages/tools/bcm2835-bootloader/release
+++ b/packages/tools/bcm2835-bootloader/release
@@ -18,12 +18,12 @@ mkdir -p $RELEASE_DIR/3rdparty/bootloader
 
   if [ -f $INSTALL/usr/share/bootloader/config.txt ]; then
     cp -PR $INSTALL/usr/share/bootloader/config.txt $RELEASE_DIR/3rdparty/bootloader/
-    # Enable 64-bit mode if ARCH is aarch64 and set kernel name
-    if [ "$ARCH" = "aarch64" ]; then
-      echo "arm_64bit=1" >> $RELEASE_DIR/3rdparty/bootloader/config.txt
-      echo "kernel=kernel.img" >> $RELEASE_DIR/3rdparty/bootloader/config.txt
-    fi
   fi
   if [ -f $INSTALL/usr/share/bootloader/distroconfig.txt ]; then
     cp -PR $INSTALL/usr/share/bootloader/distroconfig.txt $RELEASE_DIR/3rdparty/bootloader/
+    # Enable 64-bit mode if ARCH is aarch64 and set kernel name
+    if [ "$ARCH" = "aarch64" ]; then
+      echo "arm_64bit=1" >> $RELEASE_DIR/3rdparty/bootloader/distroconfig.txt
+      echo "kernel=kernel.img" >> $RELEASE_DIR/3rdparty/bootloader/distroconfig.txt
+    fi
   fi


### PR DESCRIPTION
This ensures that it gets added and taken away as expected if a user upgrades from one to the other