### PR TITLE
mesen: Switch to libretro repository

### DIFF
--- a/packages/libretro/mesen-s/package.mk
+++ b/packages/libretro/mesen-s/package.mk
@@ -19,11 +19,11 @@
 ################################################################################
 
 PKG_NAME="mesen-s"
-PKG_VERSION="89199f2"
+PKG_VERSION="56989d1"
 PKG_REV="1"
 PKG_ARCH="i386 x86_64 arm"
 PKG_LICENSE="GPLv3"
-PKG_SITE="https://github.com/SourMesen/Mesen-S"
+PKG_SITE="https://github.com/libretro/Mesen-S"
 PKG_URL="$PKG_SITE.git"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"

--- a/packages/libretro/mesen/package.mk
+++ b/packages/libretro/mesen/package.mk
@@ -19,11 +19,11 @@
 ################################################################################
 
 PKG_NAME="mesen"
-PKG_VERSION="86326e8"
+PKG_VERSION="aa2f444"
 PKG_REV="1"
 PKG_ARCH="i386 x86_64 arm"
 PKG_LICENSE="GPLv3"
-PKG_SITE="https://github.com/SourMesen/Mesen"
+PKG_SITE="https://github.com/libretro/Mesen"
 PKG_URL="$PKG_SITE.git"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"


### PR DESCRIPTION
- As upstream [mesen](https://github.com/SourMesen/Mesen) and [mesen-s](https://github.com/SourMesen/Mesen-s) won't be updated anymore.