### PR TITLE
Adds a fix for p7zip on GCC10

### DIFF
--- a/packages/compress/p7zip/patches/fix-int-cast-gcc10.patch
+++ b/packages/compress/p7zip/patches/fix-int-cast-gcc10.patch
@@ -1,0 +1,12 @@
+--- a/CPP/Windows/ErrorMsg.cpp
++++ b/CPP/Windows/ErrorMsg.cpp
+@@ -13,7 +13,7 @@
+   const char * txt = 0;
+   AString msg;
+ 
+-  switch(errorCode) {
++  switch(HRESULT(errorCode)) {
+     case ERROR_NO_MORE_FILES   : txt = "No more files"; break ;
+     case E_NOTIMPL             : txt = "E_NOTIMPL"; break ;
+     case E_NOINTERFACE         : txt = "E_NOINTERFACE"; break ;
+


### PR DESCRIPTION
New GCC throws errors instead of warnings:
  CPP/Common/MyWindows.h:89:43: error: narrowing conversion of
  '-2147024809' from 'LONG' {aka 'int'} to 'unsigned int' [-Wnarrowing]