### PR TITLE
linux: Copy from dts/broadcom/*.dtb when PROJECT=RPi and ARCH=aarch64

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -279,10 +279,10 @@ makeinstall_target() {
 
     # install platform dtbs, but remove upstream kernel dtbs (i.e. without downstream
     # drivers and decent USB support) as these are not required by LibreELEC
-    if [ "$PLATFORM" != "RPi4" ] && [ "$ARCH" != "aarch64" ]; then
-      cp -p arch/$TARGET_KERNEL_ARCH/boot/dts/*.dtb $INSTALL/usr/share/bootloader
-    else
+    if [ "$PROJECT" = "RPi" -a "$ARCH" = "aarch64" ]; then
       cp -p arch/$TARGET_KERNEL_ARCH/boot/dts/broadcom/*.dtb $INSTALL/usr/share/bootloader
+    else
+      cp -p arch/$TARGET_KERNEL_ARCH/boot/dts/*.dtb $INSTALL/usr/share/bootloader
     fi
     rm -f $INSTALL/usr/share/bootloader/bcm283*.dtb
 


### PR DESCRIPTION
Previously tried to look at PLATFORM which isn't set.

I decided to check PROJECT as well because we're specifically copying broadcom files here, and we might want aarch64 for other RPis.

Also swapped the order as this is the 'special' case and it makes sense (to me at least) to have the default 'else' case as the previous behaviour.