### PR TITLE
 fix linux u-boot build under host gcc 10 

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -512,3 +512,4 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
       LIBRETRO_CORES+=" mame2000  fbalpha2012 "
     fi
   fi
+LIBRETRO_CORES="${LIBRETRO_CORES// chailove /}"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -123,6 +123,9 @@ post_patch() {
       [ -f "$f" ] && cp -v $f $PKG_BUILD/arch/$TARGET_KERNEL_ARCH/boot/dts/overlays || true
     done
   fi
+
+  #host gcc 10 build issue
+  sed -i '/YYLTYPE yylloc/d' $PKG_BUILD/scripts/dtc/dtc-lexer.l
 }
 
 make_host() {

--- a/packages/tools/u-boot/patches/yacc.patch
+++ b/packages/tools/u-boot/patches/yacc.patch
@@ -1,0 +1,46 @@
+commit e33a814e772cdc36436c8c188d8c42d019fda639
+Author: Dirk Mueller <dmueller@suse.com>
+Date:   Tue Jan 14 18:53:41 2020 +0100
+
+    scripts/dtc: Remove redundant YYLOC global declaration
+    
+    gcc 10 will default to -fno-common, which causes this error at link
+    time:
+    
+      (.text+0x0): multiple definition of `yylloc'; dtc-lexer.lex.o (symbol from plugin):(.text+0x0): first defined here
+    
+    This is because both dtc-lexer as well as dtc-parser define the same
+    global symbol yyloc. Before with -fcommon those were merged into one
+    defintion. The proper solution would be to to mark this as "extern",
+    however that leads to:
+    
+      dtc-lexer.l:26:16: error: redundant redeclaration of 'yylloc' [-Werror=redundant-decls]
+       26 | extern YYLTYPE yylloc;
+          |                ^~~~~~
+    In file included from dtc-lexer.l:24:
+    dtc-parser.tab.h:127:16: note: previous declaration of 'yylloc' was here
+      127 | extern YYLTYPE yylloc;
+          |                ^~~~~~
+    cc1: all warnings being treated as errors
+    
+    which means the declaration is completely redundant and can just be
+    dropped.
+    
+    Signed-off-by: Dirk Mueller <dmueller@suse.com>
+    Signed-off-by: David Gibson <david@gibson.dropbear.id.au>
+    [robh: cherry-pick from upstream]
+    Cc: stable@vger.kernel.org
+    Signed-off-by: Rob Herring <robh@kernel.org>
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index 5c6c3fd557d7..b3b7270300de 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -23,7 +23,6 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
fix linux u-boot build under host gcc 10

Debian 11 has gcc 10, thus Lakka build failed.

port upstream patch to fix build issue is Debian 11.

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e33a814e772cdc36436c8c188d8c42d019fda639

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>