### PR TITLE
NXP/iMX6: use HCI UART driver for BCM4330 in Wandboard C1

### DIFF
--- a/projects/NXP/devices/iMX6/filesystem/usr/lib/udev/rules.d/80-wandboard-bluetooth-firmware.rules
+++ b/projects/NXP/devices/iMX6/filesystem/usr/lib/udev/rules.d/80-wandboard-bluetooth-firmware.rules
@@ -4,7 +4,5 @@
 
 ACTION=="add", SUBSYSTEM=="sdio", ATTR{vendor}=="0x02d0", ATTR{device}=="0x4329", \
   TAG+="systemd", ENV{SYSTEMD_WANTS}+="hciattach-ttymxc2@bcm43xx.service"
-ACTION=="add", SUBSYSTEM=="sdio", ATTR{vendor}=="0x02d0", ATTR{device}=="0x4330", \
-  TAG+="systemd", ENV{SYSTEMD_WANTS}+="hciattach-ttymxc2@bcm43xx.service"
 ACTION=="add", SUBSYSTEM=="sdio", ATTR{vendor}=="0x02d0", ATTR{device}=="0x4339", \
   TAG+="systemd", ENV{SYSTEMD_WANTS}+="hciattach-ttymxc2@bcm43xx.service"

--- a/projects/NXP/devices/iMX6/linux/linux.arm.conf
+++ b/projects/NXP/devices/iMX6/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.4.66 Kernel Configuration
+# Linux/arm 5.4.72 Kernel Configuration
 #
 
 #
@@ -1090,9 +1090,10 @@ CONFIG_BT_DEBUGFS=y
 #
 # Bluetooth device drivers
 #
+CONFIG_BT_BCM=m
 # CONFIG_BT_HCIBTUSB is not set
 # CONFIG_BT_HCIBTSDIO is not set
-CONFIG_BT_HCIUART=y
+CONFIG_BT_HCIUART=m
 CONFIG_BT_HCIUART_SERDEV=y
 CONFIG_BT_HCIUART_H4=y
 # CONFIG_BT_HCIUART_NOKIA is not set
@@ -1101,7 +1102,7 @@ CONFIG_BT_HCIUART_H4=y
 # CONFIG_BT_HCIUART_LL is not set
 # CONFIG_BT_HCIUART_3WIRE is not set
 # CONFIG_BT_HCIUART_INTEL is not set
-# CONFIG_BT_HCIUART_BCM is not set
+CONFIG_BT_HCIUART_BCM=y
 # CONFIG_BT_HCIUART_QCA is not set
 # CONFIG_BT_HCIUART_AG6XX is not set
 # CONFIG_BT_HCIUART_MRVL is not set

--- a/projects/NXP/devices/iMX6/patches/linux/linux-004-imx6qdl-wandboard-revc1-dtb.patch
+++ b/projects/NXP/devices/iMX6/patches/linux/linux-004-imx6qdl-wandboard-revc1-dtb.patch
@@ -1,0 +1,19 @@
+Add bluetooth node to uart3.
+
+--- a/arch/arm/boot/dts/imx6qdl-wandboard-revc1.dtsi
++++ b/arch/arm/boot/dts/imx6qdl-wandboard-revc1.dtsi
+@@ -28,6 +28,14 @@
+ 	};
+ };
+ 
++&uart3 {
++	bluetooth {
++		compatible = "brcm,bcm4330-bt";
++		max-speed = <3000000>;
++		shutdown-gpios = <&gpio5 30 GPIO_ACTIVE_LOW>;	/* BT_REG_ON */
++	};
++};
++
+ &usdhc2 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_usdhc2>;


### PR DESCRIPTION
- remove hciattach service start for BCM4330 from udev rule
- configure HCI UART driver as module, enable Broadcom protocol
- add BCM4330 bluetooth node to Wandboard c1 device tree