### PR TITLE
filter out melonds

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -224,7 +224,6 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 " mame2003-plus "\
 " mame2010 "\
 " mame2015 "\
-" melonds "\
 " meowpc98 "\
 " mesen "\
 " mesen-s "\
@@ -478,7 +477,6 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
       LIBRETRO_CORES="${LIBRETRO_CORES// mame2003-plus /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// mame2010 /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// mame2015 /}"
-      LIBRETRO_CORES="${LIBRETRO_CORES// melonds /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// meowpc98 /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// mesen-s /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// mesen /}"
@@ -511,4 +509,8 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
     if [ "$DEVICE" = "RPi" -o "$DEVICE" = "Gamegirl" -o "$DEVICE" = "GPICase" ]; then
       LIBRETRO_CORES+=" mame2000  fbalpha2012 "
     fi
+  fi
+# add melonds to x86_64
+  if [ "$ARCH" = "x86_64" ]; then
+    LIBRETRO_CORES+=" melonds "
   fi


### PR DESCRIPTION
melonds will be added to build plan for all targets, so does mesa.

and the targets which don't use mesa will not config mesa correctly.
thus build failed.

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>