### PR TITLE
Add kernel install locks to prevent race conditions

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-imx/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-imx/package.mk
@@ -11,9 +11,13 @@ PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Firmware for brcm bluetooth chips used in some Freescale iMX based devices."
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   mkdir -p $INSTALL/usr/bin
     cp -av brcm_patchram_plus $INSTALL/usr/bin/
 
   mkdir -p $INSTALL/$(get_kernel_overlay_dir)/lib/firmware/
     cp -av firmware/brcm $INSTALL/$(get_kernel_overlay_dir)/lib/firmware/
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }

--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -13,7 +13,11 @@ PKG_LONGDESC="Firmware for brcm bluetooth chips used on RaspberryPi devices."
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   DESTDIR=$INSTALL/$(get_kernel_overlay_dir) ./install
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }
 
 post_makeinstall_target() {

--- a/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware/package.mk
@@ -11,6 +11,8 @@ PKG_LONGDESC="Broadcom SDIO firmware used with LibreELEC"
 PKG_TOOLCHAIN="manual"
 
 post_makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   FW_TARGET_DIR=$INSTALL/$(get_full_firmware_dir)
 
   if find_file_path firmwares/$PKG_NAME.dat; then
@@ -41,6 +43,8 @@ post_makeinstall_target() {
 
   mkdir -p $INSTALL/usr/bin
     cp $PKG_DIR/scripts/brcmfmac-firmware-setup $INSTALL/usr/bin
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }
 
 post_install() {

--- a/packages/linux-firmware/dvb-firmware/package.mk
+++ b/packages/linux-firmware/dvb-firmware/package.mk
@@ -13,7 +13,11 @@ PKG_LONGDESC="dvb-firmware: firmwares for various DVB drivers"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   PKG_FW_DIR="$INSTALL/$(get_kernel_overlay_dir)/lib/firmware"
   mkdir -p "$PKG_FW_DIR"
     cp -a "$PKG_BUILD/firmware/"* "$PKG_FW_DIR"
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }

--- a/packages/linux-firmware/firmware-dragonboard/package.mk
+++ b/packages/linux-firmware/firmware-dragonboard/package.mk
@@ -23,6 +23,8 @@ make_target() {
 }
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   mkdir -p $INSTALL/$(get_full_firmware_dir)/qcom/venus-1.8/
     cp -a linux-board-support-package-v${PKG_VERSION%.0}/proprietary-linux/* $INSTALL/$(get_full_firmware_dir)
     cp -a linux-board-support-package-v${PKG_VERSION%.0}/proprietary-linux/venus* $INSTALL/$(get_full_firmware_dir)/qcom/venus-1.8/
@@ -33,4 +35,6 @@ makeinstall_target() {
                                     ::image/mba.mbn \
                                     ::image/wcnss.* \
                                     $INSTALL/$(get_full_firmware_dir)
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }

--- a/packages/linux-firmware/firmware-imx/package.mk
+++ b/packages/linux-firmware/firmware-imx/package.mk
@@ -19,7 +19,11 @@ unpack() {
 }
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   mkdir -p $INSTALL/$(get_full_firmware_dir)
     cp -P firmware/vpu/vpu_fw_imx6d.bin $INSTALL/$(get_full_firmware_dir)
     cp -P firmware/vpu/vpu_fw_imx6q.bin $INSTALL/$(get_full_firmware_dir)
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }

--- a/packages/linux-firmware/firmware-realtek/package.mk
+++ b/packages/linux-firmware/firmware-realtek/package.mk
@@ -11,5 +11,9 @@ PKG_LONGDESC="realtek-firmware: firmwares for various realtek WLAN drivers"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   DESTDIR=$INSTALL/$(get_kernel_overlay_dir) ./install
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }

--- a/packages/linux-firmware/iwlwifi-firmware/package.mk
+++ b/packages/linux-firmware/iwlwifi-firmware/package.mk
@@ -13,5 +13,9 @@ PKG_LONGDESC="iwlwifi-firmware: firmwares for various Intel WLAN drivers"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   DESTDIR=$INSTALL/$(get_kernel_overlay_dir) ./install
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }

--- a/packages/linux-firmware/kernel-firmware/package.mk
+++ b/packages/linux-firmware/kernel-firmware/package.mk
@@ -13,6 +13,8 @@ PKG_TOOLCHAIN="manual"
 
 # Install additional miscellaneous drivers
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   FW_TARGET_DIR=$INSTALL/$(get_full_firmware_dir)
 
   if find_file_path config/kernel-firmware.dat; then
@@ -62,4 +64,6 @@ makeinstall_target() {
 
   # Cleanup - which may be project or device specific
   find_file_path scripts/cleanup.sh && ${FOUND_PATH} ${FW_TARGET_DIR} || true
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }

--- a/packages/linux-firmware/meson-firmware/package.mk
+++ b/packages/linux-firmware/meson-firmware/package.mk
@@ -12,6 +12,8 @@ PKG_LONGDESC="meson-firmware: Amlogic microcode firmware for the V4L2 mem2mem vd
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   FW_TARGET_DIR=$INSTALL/$(get_full_firmware_dir)
 
   if find_file_path config/$PKG_NAME.dat; then
@@ -40,4 +42,6 @@ makeinstall_target() {
       done
     done < ${fwlist}
   done
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }

--- a/packages/linux-firmware/misc-firmware/package.mk
+++ b/packages/linux-firmware/misc-firmware/package.mk
@@ -13,5 +13,9 @@ PKG_LONGDESC="misc-firmware: firmwares for various drivers"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   DESTDIR=$INSTALL/$(get_kernel_overlay_dir) ./install
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }

--- a/packages/linux-firmware/rockchip-firmware/package.mk
+++ b/packages/linux-firmware/rockchip-firmware/package.mk
@@ -12,6 +12,8 @@ PKG_LONGDESC="rockchip firmware"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   mkdir -p $INSTALL/usr/lib/libreelec
     cp $PKG_DIR/scripts/* $INSTALL/usr/lib/libreelec
 
@@ -41,4 +43,6 @@ makeinstall_target() {
 
   mkdir -p $INSTALL/$(get_full_firmware_dir)/rockchip
     cp -v $(get_build_dir rkbin)/firmware/rockchip/dptx.bin $INSTALL/$(get_full_firmware_dir)/rockchip
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }

--- a/packages/linux-firmware/wlan-firmware/package.mk
+++ b/packages/linux-firmware/wlan-firmware/package.mk
@@ -12,5 +12,9 @@ PKG_LONGDESC="wlan-firmware: firmwares for various WLAN drivers"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
+  acquire_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
+
   DESTDIR=$INSTALL/$(get_kernel_overlay_dir) ./install
+
+  release_exclusive_lock "${PKG_NAME:install}" "exclusive-install" "firmware-install"
 }


### PR DESCRIPTION
This uses the locking mechanism provided by the build system to grab a lock
(namely firmware-install) every time a firmware needs to be installed.

This is similar to the mechanism that python uses (exec_thread_safe)
but less restrictive since we do not grab a global lock.