### PR TITLE
duckstation : Enable arm platform and update to latest version

### DIFF
--- a/packages/libretro/duckstation/package.mk
+++ b/packages/libretro/duckstation/package.mk
@@ -19,9 +19,9 @@
 ################################################################################
 
 PKG_NAME="duckstation"
-PKG_VERSION="101907a"
+PKG_VERSION="b49067d"
 PKG_REV="1"
-PKG_ARCH="x86_64 aarch64"
+PKG_ARCH="x86_64 arm aarch64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/stenzek/duckstation"
 PKG_URL="$PKG_SITE.git"

--- a/packages/libretro/duckstation/package.mk
+++ b/packages/libretro/duckstation/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="duckstation"
-PKG_VERSION="b49067d"
+PKG_VERSION="d1a42df"
 PKG_REV="1"
 PKG_ARCH="x86_64 arm aarch64"
 PKG_LICENSE="GPLv3"


### PR DESCRIPTION
> 2020/11/21: AArch32/armv7 recompiler added. Android and Linux builds will follow after further testing, but for now you can build it yourself.

[Source](https://github.com/stenzek/duckstation#latest-news)