### PR TITLE
Generic: linux: fix 'Argument list too long' for built-in firmware

### DIFF
--- a/projects/Generic/patches/linux/linux-777-Makefile-build-firmware-built-in-arg-list-squeeze.patch
+++ b/projects/Generic/patches/linux/linux-777-Makefile-build-firmware-built-in-arg-list-squeeze.patch
@@ -1,0 +1,15 @@
+Temporary workaround for 'Argument list too long'
+error with kernel-firmware above 20190514.
+
+--- a/scripts/Makefile.build
++++ b/scripts/Makefile.build
+@@ -380,7 +380,7 @@
+ ifdef builtin-target
+ 
+ quiet_cmd_ar_builtin = AR      $@
+-      cmd_ar_builtin = rm -f $@; $(AR) cDPrST $@ $(real-prereqs)
++      cmd_ar_builtin = rm -f $@; $(if $(findstring drivers/base/firmware_loader/builtin/built-in.a,$@),$(AR) cDPrST $@ $(sort $(foreach f,$(real-prereqs),$(dir $(f))*.o)),$(AR) cDPrST $@ $(real-prereqs))
+ 
+ 
+ $(builtin-target): $(real-obj-y) FORCE
+ 	$(call if_changed,ar_builtin)


### PR DESCRIPTION
Patch: Temporary workaround for 'Argument list too long'
error with kernel-firmware above 20190514.