### PR TITLE
Add support for PineH64 Model B

### DIFF
--- a/projects/Allwinner/devices/H6/patches/linux/21-pineh64-model-b-wifi-bt.patch
+++ b/projects/Allwinner/devices/H6/patches/linux/21-pineh64-model-b-wifi-bt.patch
@@ -1,0 +1,101 @@
+From 23fa74407f0c71e06e10cb55ca64722b97d924f0 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Thu, 29 Oct 2020 20:58:55 +0100
+Subject: [PATCH] arm64: dts: allwinner: h6: PineH64 model B: Add wifi
+
+PineH64 model B contains RTL8723CS wifi+bt combo module.
+
+Since bluetooth support is not yet squared away, only wifi is enabled
+for now.
+
+Acked-by: Chen-Yu Tsai <wens@csie.org>
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ .../dts/allwinner/sun50i-h6-pine-h64-model-b.dts  | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64-model-b.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64-model-b.dts
+index f4c8966a6497..7fea1e4e2d49 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64-model-b.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64-model-b.dts
+@@ -10,6 +10,12 @@ / {
+ 	compatible = "pine64,pine-h64-model-b", "allwinner,sun50i-h6";
+ 
+ 	/delete-node/ reg_gmac_3v3;
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&r_pio 1 3 GPIO_ACTIVE_LOW>; /* PM3 */
++		post-power-on-delay-ms = <200>;
++	};
+ };
+ 
+ &hdmi_connector {
+@@ -19,3 +25,12 @@ &hdmi_connector {
+ &emac {
+ 	phy-supply = <&reg_aldo2>;
+ };
++
++&mmc1 {
++	vmmc-supply = <&reg_cldo3>;
++	vqmmc-supply = <&reg_aldo1>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++};
+-- 
+2.29.1
+
+From 1f08c8dbef8c4f9590e1de0169e1d004a23ed721 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Thu, 29 Oct 2020 21:04:24 +0100
+Subject: [PATCH 2/2] pineh64 model b - bluetooth wip
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ .../dts/allwinner/sun50i-h6-pine-h64-model-b.dts | 16 ++++++++++++++++
+ drivers/bluetooth/hci_h5.c                       |  3 +++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64-model-b.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64-model-b.dts
+index 3f42b8b29b0f..99732e5850c2 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64-model-b.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-pine-h64-model-b.dts
+@@ -33,3 +33,19 @@ &mmc1 {
+ 	non-removable;
+ 	status = "okay";
+ };
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	uart-has-rtscts;
++	status = "okay";
++
++	bluetooth {
++		compatible = "realtek,rtl8723bs-bt";
++		device-wakeup-gpios = <&r_pio 1 2 GPIO_ACTIVE_HIGH>; /* PM2 */
++		host-wakeup-gpios = <&r_pio 1 1 GPIO_ACTIVE_HIGH>; /* PM1 */
++		enable-gpios = <&r_pio 1 4 GPIO_ACTIVE_HIGH>; /* PM4 */
++		firmware-postfix = "OBDA8723";
++		max-speed = <1500000>;
++	};
++};
+diff --git a/drivers/bluetooth/hci_h5.c b/drivers/bluetooth/hci_h5.c
+index a10d710fc3f1..c2fcb3429277 100644
+--- a/drivers/bluetooth/hci_h5.c
++++ b/drivers/bluetooth/hci_h5.c
+@@ -821,6 +821,9 @@ static int h5_serdev_probe(struct serdev_device *serdev)
+ 		if (!data)
+ 			return -ENODEV;
+ 
++		of_property_read_string(dev->of_node,
++					"firmware-postfix", &h5->id);
++
+ 		h5->vnd = (const struct h5_vnd *)data;
+ 	}
+ 
+-- 
+2.29.1
+

--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -111,6 +111,10 @@ devices = \
         'dtb': 'sun50i-h6-pine-h64.dtb',
         'config': 'pine_h64_defconfig'
       },
+      'pine-h64-model-b': {
+        'dtb': 'sun50i-h6-pine-h64-model-b.dtb',
+        'config': 'pine_h64_defconfig'
+      },
     },
   },
   'Amlogic': {


### PR DESCRIPTION
This was originally proposed in PR https://github.com/libretro/Lakka-LibreELEC/pull/1010 but closed at the time due to missing device support in Linux 5.4 version. Now Lakka has been updated to Linux 5.9 version which does have support for this device.