### PR TITLE
Fix easyrpg core runtime error (missing icu4c libraries)

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/icu/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/icu/package.mk
@@ -29,7 +29,3 @@ configure_package() {
 
   PKG_CONFIGURE_SCRIPT="${PKG_BUILD}/source/configure"
 }
-
-post_makeinstall_target() {
-  rm -rf $INSTALL
-}

--- a/packages/devel/liblcf/patches/liblcf-02-add-icu-compile-defs.patch
+++ b/packages/devel/liblcf/patches/liblcf-02-add-icu-compile-defs.patch
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt	2020-12-20 15:19:33.535997406 +0100
++++ b/CMakeLists.txt	2020-12-20 15:21:56.337546477 +0100
+@@ -259,7 +259,9 @@
+ else()
+ 	find_package(ICU COMPONENTS i18n uc data REQUIRED)
+ 	target_link_libraries(lcf ICU::i18n ICU::uc ICU::data)
+-	target_compile_definitions(lcf PRIVATE LCF_SUPPORT_ICU=1)
++	INCLUDE(FindPkgConfig)
++	pkg_get_variable(ICUDEFS icu-i18n DEFS)
++	target_compile_definitions(lcf PRIVATE LCF_SUPPORT_ICU=1 ${ICUDEFS})
+ 	list(APPEND LIBLCF_DEPS "icu-i18n")
+ endif()
+ 


### PR DESCRIPTION
Fixes #1141 
Add the missing ICU shared libraries and fixed the following bug:

ICU can be compiled with or without symbol renaming support. Apps need to consider this by including a switch in the compiler options. This information is stored in the icu pkgconfig file. Libclf does not check for this and assumes that symbol renaming is enabled. In the case of Lakka it is disabled though, leading to a runtime error where the libicu.so* symbols cannot be found due to a naming mismatch.