### PR TITLE
melonds: fix commit id

### DIFF
--- a/packages/libretro/melonds/package.mk
+++ b/packages/libretro/melonds/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="melonds"
-PKG_VERSION="289d544"
+PKG_VERSION="b8e1eca"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/melonds"


### PR DESCRIPTION
Referenced commit id `289d544` does not exist in https://github.com/libretro/melonds, updated to `b8e1eca`