### PR TITLE
buildsystem: use an update lock when updating image and sysroot

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -1260,6 +1260,13 @@ enable_service() {
 
 
 ### MULTI-THREADED FUNCTION HELPERS ###
+# flocks: 94 (pkg_lock_status)
+#         95 (scripts/pkgbuild)
+#         96 (acquire_exclusive_lock)
+#         97 (acquire_update_lock)
+#         98 (pkg_lock)
+#         99 (scripts/get)
+
 # Test build type so that these functions are a no-op during non-multithreaded builds.
 
 # Prevent concurrent modifications to a package (unpack) or
@@ -1435,6 +1442,20 @@ exec_thread_safe() {
   result=$?
   release_exclusive_lock "${PKG_NAME:exec}" "execcmd"
   return ${result}
+}
+
+# A lightweight target specific lock (eg. image, sysroot)
+acquire_update_lock() {
+  is_sequential_build && return 0
+
+  exec 97>"${THREAD_CONTROL}/locks/.update.${1}"
+  flock --exclusive 97
+}
+
+release_update_lock() {
+  is_sequential_build && return 0
+
+  flock --unlock 97 2>/dev/null
 }
 
 # Use distribution functions if any

--- a/config/functions
+++ b/config/functions
@@ -699,6 +699,11 @@ do_autoreconf() {
   fi
 }
 
+# True if this is a sequential build, false if multithreaded
+is_sequential_build() {
+  [ "${MTWITHLOCKS}" != "yes" ] && return 0 || return 1
+}
+
 
 ### PACKAGE HELPERS ###
 # get variable ($2) for package ($1).
@@ -1255,7 +1260,7 @@ enable_service() {
 
 
 ### MULTI-THREADED FUNCTION HELPERS ###
-# Test MTWITHLOCKS so that these functions are a no-op during non-multithreaded builds.
+# Test build type so that these functions are a no-op during non-multithreaded builds.
 
 # Prevent concurrent modifications to a package (unpack) or
 # package:target (install/build).
@@ -1263,7 +1268,7 @@ enable_service() {
 # If a package is already locked and the owner is ourselves
 # then assume we already have the required lock.
 pkg_lock() {
-  [ "${MTWITHLOCKS}" != "yes" ] && return 0
+  is_sequential_build && return 0
 
   local pkg="$1" task="$2" parent_pkg="$3"
   local this_job="${MTJOBID}"
@@ -1304,7 +1309,7 @@ EOF
 
 # Log additional information for a locked package.
 pkg_lock_status() {
-  [ "${MTWITHLOCKS}" != "yes" ] && return 0
+  is_sequential_build && return 0
 
   local status="$1" pkg="$2" task="$3" msg="$4"
   local this_job="${MTJOBID}" line idwidth
@@ -1337,7 +1342,7 @@ pkg_lock_status() {
 }
 
 update_dashboard() {
-  [ "${MTWITHLOCKS}" != "yes" ] && return 0
+  is_sequential_build && return 0
 
   local status="$1" pkg="$2" task="$3" msg="$4"
   local line sedline preamble num elapsed projdevarch
@@ -1387,7 +1392,7 @@ update_dashboard() {
 # Thread concurrency helpers to avoid concurrency issues with some code,
 # eg. when Python installs directly into $TOOLCHAIN.
 acquire_exclusive_lock() {
-  [ "${MTWITHLOCKS}" != "yes" ] && return 0
+  is_sequential_build && return 0
 
   local pkg="$1" task="$2" lockfile="${3:-global}"
   local this_job="${MTJOBID}"
@@ -1412,7 +1417,7 @@ acquire_exclusive_lock() {
 }
 
 release_exclusive_lock() {
-  [ "${MTWITHLOCKS}" != "yes" ] && return 0
+  is_sequential_build && return 0
 
   local pkg="$1" task="$2" lockfile="${3:-global}"
 

--- a/scripts/build
+++ b/scripts/build
@@ -437,8 +437,13 @@ for i in $(find "${SYSROOT_PREFIX}" -type l 2>/dev/null); do
 done
 
 # Transfer the new sysroot content to the shared sysroot
+acquire_update_lock sysroot
+
 mkdir -p "${PKG_ORIG_SYSROOT_PREFIX}"
 cp -PRf "${SYSROOT_PREFIX}"/* "${PKG_ORIG_SYSROOT_PREFIX}"
+
+release_update_lock
+
 rm -rf "${SYSROOT_PREFIX}"
 
 export SYSROOT_PREFIX="${PKG_ORIG_SYSROOT_PREFIX}"

--- a/scripts/install
+++ b/scripts/install
@@ -60,6 +60,8 @@ pkg_lock_status "ACTIVE" "${PKG_NAME}:${TARGET}" "install"
 
 build_msg "CLR_INSTALL" "INSTALL" "${PKG_NAME} $(print_color CLR_TARGET "(${TARGET})")" "indent"
 
+acquire_update_lock image
+
 mkdir -p ${INSTALL}
 
 if [ "${TARGET}" = "target" ] ; then
@@ -146,6 +148,8 @@ fi
 if [ "${TARGET}" = "target" ] ; then
   pkg_call_exists post_install && pkg_call post_install
 fi
+
+release_update_lock
 
 touch ${STAMP}
 


### PR DESCRIPTION
cp (and potentially mkdir -p) are not atomic, and we have seen situations where two packages
concurrently copying the same file (eg. the udev rule for xf86-video-nvidia and
xf86-video-nvidia-legacy) will succeed for one package but the other package fails with
a "file exists" error (as the file didn't exist when it checked, but does exist when it
actually copies the file). Not even cp -f will avoid this issue.

There are several workarounds, but the most practical (and general) solution is to ensure
sequential updates of the image and shared sysroot directories.

This is part of PR 4092 from LE upstream.