### PR TITLE
create / get libretro tarball

### DIFF
--- a/create_libretro_tarballs.sh
+++ b/create_libretro_tarballs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Creates .tar.xz archives of cloned libretro repositories for future re-use
+# in case original repository goes awol or is force-pushed, so a build can
+# be reproduced.
+
+# Get list of libretro packages
+for pkg in packages/libretro/*
+do
+
+	pkg=$(basename ${pkg})
+
+	# Is there a folder for this package in sources?
+	if [ -d sources/${pkg} ]
+	then
+		# Is anything in that folder?
+		for dir in sources/${pkg}/${pkg}-*
+		do
+			# Is it a folder?
+			if [ -d ${dir} ]
+			then
+				# Skip in case a tarball was already created
+				if [ ! -f ${dir}.tar.xz ]
+				then
+					# Create a tarball in separate process, so the main loop does not change working directory
+					(
+					cd sources/${pkg}
+					name=$(basename ${dir})
+					echo $pkg - creating ${name}.tar.xz
+					tar -pcJf ${name}.tar.xz ${name}
+					)
+				fi
+			fi
+		done
+	fi
+done
+

--- a/get_libretro_tarball.sh
+++ b/get_libretro_tarball.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# This script downloads a tarball of libretro package (packages/libretro) and extracts
+# this tarball to sources/<package> folder.
+# It is usefull in cases when the core repository was force-pushed and it is not possible
+# to clone / checkout the the desired commit, which breaks the build.
+
+# Where are the tarballs hosted
+URL="https://nightly.builds.lakka.tv"
+
+# Check arguments and print usage
+[ $# -ne 1 ] && {
+	echo "Usage:"
+	echo "$0 <package>"
+	echo ""
+	echo "Downloads tarballs from ${URL} and extracts it in sources/<package> folder"
+	exit 1
+}
+
+PKG=${1}
+
+# Check if there is such package
+[ ! -d packages/libretro/${PKG} ] && {
+	echo "There is no package '${PKG}' in packages/libretro"
+	exit 2
+}
+
+# Check if we have package.mk
+[ ! -f packages/libretro/${PKG}/package.mk ] && {
+	echo "Missing package.mk in packages/libretro/${PKG}"
+	exit 3
+}
+
+# Import package properties
+source packages/libretro/${PKG}/package.mk 2>&1 >/dev/null
+
+# Check for package version
+[ -z "${PKG_VERSION}" ] && {
+	echo "No PKG_VERSION set in packages/libretro/${PKG}/package.mk"
+	exit 4
+}
+
+LINK=${URL}/sources/${PKG}/${PKG}-${PKG_VERSION}.tar.xz
+FILENAME=sources/${PKG}/${PKG}-${PKG_VERSION}.tar.xz
+
+# Do not continue when a tarball is already present in the sources folder
+# (also safety catch in case this script is started on the server, where the tarballs are hosted)
+[ -f ${FILENAME} ] && {
+	echo "There is already ${FILENAME} - remove it and try again"
+	exit 5
+}
+
+# Create folder in case it does not exist already
+if [ ! -d sources/${PKG} ]
+then
+	if [ ! -f sources/${PKG} ]
+	then
+		mkdir -p sources/${PKG}
+	else
+		echo "Cannot create folder sources/$PKG - file exists"
+		exit 6
+	fi
+fi
+
+# Check if we have wget and tar
+for PRG in wget tar
+do
+	[ -z "$(which ${PRG} 2>/dev/null)" ] && {
+		echo "Please install ${PRG}"
+		exit 7
+	}
+done
+
+# Download the tarball
+echo "Downloading to ${FILENAME} ..."
+wget --quiet -O ${FILENAME} ${LINK}
+
+[ ${?} -gt 0 ] && {
+	echo "Error downloading ${LINK}"
+	exit 8
+}
+
+# Extract the tarball
+echo "Extracting..."
+tar xf ${FILENAME} -C sources/${PKG}
+
+[ ${?} -gt 0 ] && exit $?
+
+# And we are done
+echo "Done"
+


### PR DESCRIPTION
two new tools:
create_libretro_tarballs.sh: creates a tarball of already existing
folder with cloned repository for future re-use

get_libretro_tarball.sh: retrieves a tarball from a mirror in case a
specific version cannot be checked-out by the buildsystem

create_libretro_tarballs.sh should be run by the mainteners on regular
basis, so there are backups of most versions of used libretro
packages/cores

get_libretro_tarball.sh should be run by a builder in case the build
errors due to non-existent hash in cloned repository