### PR TITLE
Remove unnecessary v11 target

### DIFF
--- a/scripts/uboot_helper
+++ b/scripts/uboot_helper
@@ -171,11 +171,7 @@ devices = \
       },
     },
     'OdroidGoAdvance': {
-       'odroidgo2_v11' : {
-        'dtb': 'rk3326-odroidgo2-linux-v11.dtb',
-        'config': 'odroidgoa_defconfig'
-      },
-       'odroidgo2': {
+      'odroidgo2': {
         'dtb': 'rk3326-odroidgo2-linux.dtb',
         'config': 'odroidgoa_defconfig'
       },


### PR DESCRIPTION
Official OGAs are all included in the odroidgo2 target (and DTB is
selected via boot.ini and u-boot cooperation).