### PR TITLE
Fix missing icudata library and runtime error

### DIFF
--- a/packages/addons/addon-depends/chrome-depends/icu/package.mk
+++ b/packages/addons/addon-depends/chrome-depends/icu/package.mk
@@ -2,29 +2,27 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="icu"
-PKG_VERSION="61.1"
-PKG_SHA256="d007f89ae8a2543a53525c74359b65b36412fa84b3349f1400be6dcf409fafef"
+PKG_VERSION="68.1"
+PKG_SHA256="a9f2e3d8b4434b8e53878b4308bd1e6ee51c9c7042e2b1a376abefb6fbb29f2d"
 PKG_LICENSE="Custom"
 PKG_SITE="http://www.icu-project.org"
-PKG_URL="http://download.icu-project.org/files/icu4c/${PKG_VERSION}/icu4c-${PKG_VERSION//./_}-src.tgz"
+PKG_URL="https://github.com/unicode-org/icu/releases/download/release-${PKG_VERSION//./-}/icu4c-${PKG_VERSION//./_}-src.tgz"
 PKG_DEPENDS_HOST="toolchain:host"
 PKG_DEPENDS_TARGET="toolchain icu:host"
 PKG_LONGDESC="International Components for Unicode library."
 
 PKG_ICU_OPTS="--disable-extras \
               --disable-icuio \
-              --disable-layout \
+              --disable-layoutex \
               --disable-renaming \
               --disable-samples \
-              --disable-tests \
-              --disable-tools"
+              --disable-tests"
 
-PKG_CONFIGURE_OPTS_HOST="--enable-static \
-                         --disable-shared \
-                         $PKG_ICU_OPTS"
+PKG_CONFIGURE_OPTS_HOST="$PKG_ICU_OPTS"
 
 configure_package() {
-  PKG_CONFIGURE_OPTS_TARGET="--with-cross-build=$PKG_BUILD/.$HOST_NAME \
+  PKG_CONFIGURE_OPTS_TARGET="--disable-tools
+                             --with-cross-build=$PKG_BUILD/.$HOST_NAME \
                              $PKG_ICU_OPTS"
 
   PKG_CONFIGURE_SCRIPT="${PKG_BUILD}/source/configure"

--- a/packages/addons/addon-depends/chrome-depends/icu/patches/icu-01_ldflags.patch
+++ b/packages/addons/addon-depends/chrome-depends/icu/patches/icu-01_ldflags.patch
@@ -1,0 +1,12 @@
+Fix a runtime error on some devices. Without this patch, code from the icu libraries might fail to run with a message "internal error", and ldd will output "not a dynamic executable" on them.
+--- a/source/config/mh-linux	2020-04-22 19:49:10.000000000 +0200
++++ b/source/config/mh-linux	2020-09-05 17:58:05.635014182 +0200
+@@ -23,7 +23,7 @@
+ LD_RPATH_PRE = -Wl,-rpath,
+ 
+ ## These are the library specific LDFLAGS
+-LDFLAGSICUDT=-nodefaultlibs -nostdlib
++#LDFLAGSICUDT=-nodefaultlibs -nostdlib
+ 
+ ## Compiler switch to embed a library name
+ # The initial tab in the next line is to prevent icu-config from reading it.


### PR DESCRIPTION
The previous icu package built an empty libicudata.so library and was missing a patch from upstream LibreELEC that fixes a runtime error on some platforms. This should fix #1189.