### PR TITLE
Fix console rotation on OGA family and rumble on boot too

### DIFF
--- a/packages/linux/patches/odroidgoA-4.4/linux-998-rg351v-dts.patch
+++ b/packages/linux/patches/odroidgoA-4.4/linux-998-rg351v-dts.patch
@@ -125,18 +125,18 @@ index 0000000..c31f607
 +		regulator-max-microvolt = <3800000>;
 +	};
 +
-+	vcc_host: vcc_host {
++/*	vcc_host: vcc_host {
 +		compatible = "regulator-fixed";
 +		regulator-name = "vcc_host";
 +		regulator-min-microvolt = <5000000>;
 +		regulator-max-microvolt = <5000000>;
 +
-+		gpio = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio0 RK_PB7 GPIO_ACTIVE_LOW>;
 +		enable-active-high;
 +		regulator-always-on;
 +		vin-supply = <&vccsys>;
 +	};
-+
++*/
 +};
 +
 +

--- a/projects/Rockchip/devices/OdroidGoAdvance/options
+++ b/projects/Rockchip/devices/OdroidGoAdvance/options
@@ -37,18 +37,23 @@
     MALI_FAMILY="g31"
 
   # kernel serial console
-    EXTRA_CMDLINE="console=ttyFIQ0 console=tty0 net.iframes=0 fbcon=rotate:3 ssh"
+    function extra_cmdline() {
+      EXTRA_CMDLINE="console=ttyFIQ0 console=tty0 net.iframes=0 ssh"
+      if [[ "$UBOOT_SYSTEM" != "gameforce-chi" && "$UBOOT_SYSTEM" != "rg351v" ]]; then
+        EXTRA_CMDLINE="${EXTRA_CMDLINE} fbcon=rotate:3"
+      fi
+    }
     
   # Custom libmali package
     OPENGLES="mali-odroidgo2"
 
   # Linux and U-Boot
-   LINUX="odroidgoA-4.4"
+    LINUX="odroidgoA-4.4"
    
   # additional packages to install
     ADDITIONAL_PACKAGES="dtc odroidgo2-utils"
 
   # Remove some broken drivers
-  ADDITIONAL_DRIVERS="${ADDITIONAL_DRIVERS//RTL8192CU/}"
-  ADDITIONAL_DRIVERS="${ADDITIONAL_DRIVERS//RTL8192EU/}"
-  ADDITIONAL_DRIVERS="${ADDITIONAL_DRIVERS//RTL8812AU/}"
+    ADDITIONAL_DRIVERS="${ADDITIONAL_DRIVERS//RTL8192CU/}"
+    ADDITIONAL_DRIVERS="${ADDITIONAL_DRIVERS//RTL8192EU/}"
+    ADDITIONAL_DRIVERS="${ADDITIONAL_DRIVERS//RTL8812AU/}"

--- a/scripts/image
+++ b/scripts/image
@@ -330,6 +330,11 @@ if [ "${1}" = "release" -o "${1}" = "mkimage" -o "${1}" = "noobs" ]; then
         rm ${STAMPS_INSTALL}/u-boot/install_target
         UBOOT_SYSTEM="${UBOOT_SYSTEM}" ${SCRIPTS}/install u-boot
 
+        # Re-calculate some variables related to u-boot
+        if pkg_call_exists extra_cmdline; then
+          extra_cmdline
+        fi
+
         # Re-run bootloader/release
         if find_file_path bootloader/release ${BOOTLOADER_DIR}/release; then
           echo "Running ${FOUND_PATH}"


### PR DESCRIPTION
This adds a new function hook that can be defined for devices that have
slightly different cmdline within the same configuration.
Remove vcchost regulator since it is not used and just makes the rumble
go crazy during kernel boot.