### PR TITLE
Fix Genesis Wide .so filename

### DIFF
--- a/packages/libretro/genesis_plus_gx_wide/package.mk
+++ b/packages/libretro/genesis_plus_gx_wide/package.mk
@@ -17,5 +17,5 @@ pre_make_target() {
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro
-  cp genesis_plus_gx_wide_libretro.so $INSTALL/usr/lib/libretro/genesis_plus_gx_libretro.so
+  cp genesis_plus_gx_wide_libretro.so $INSTALL/usr/lib/libretro/genesis_plus_gx_wide_libretro.so
 }


### PR DESCRIPTION
It was overwritting in some cases the wrong .so file. This enables both
emulators to be built