### PR TITLE
Install pci-utils everywhere

### DIFF
--- a/packages/sysutils/pciutils/package.mk
+++ b/packages/sysutils/pciutils/package.mk
@@ -26,9 +26,7 @@ makeinstall_target() {
   make $PKG_MAKE_OPTS DESTDIR=$SYSROOT_PREFIX install
   make $PKG_MAKE_OPTS DESTDIR=$SYSROOT_PREFIX install-lib
   make $PKG_MAKE_OPTS DESTDIR=$INSTALL install-lib
-  if [ "$TARGET_ARCH" = x86_64 -o "$TARGET_ARCH" = i386 ]; then
-    make $PKG_MAKE_OPTS DESTDIR=$INSTALL install
-  fi
+  make $PKG_MAKE_OPTS DESTDIR=$INSTALL install
 }
 
 post_makeinstall_target() {


### PR DESCRIPTION
This was recently enabled for all architectures but only gets installed for x86. Let's install it everywhere.

Main motivation: flashing rpi-eeprom