### PR TITLE
Added the RPi.GPIO Python library to the RPi Project

### DIFF
--- a/packages/python/utils/python-raspberry-gpio/package.mk
+++ b/packages/python/utils/python-raspberry-gpio/package.mk
@@ -1,20 +1,6 @@
-################################################################################
-#      This file is part of OpenELEC - http://www.openelec.tv
-#      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
-#
-#  OpenELEC is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 2 of the License, or
-#  (at your option) any later version.
-#
-#  OpenELEC is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
-################################################################################
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="python-raspberry-gpio"
 PKG_VERSION="0.7.0"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -143,5 +143,10 @@
       DRIVER_ADDONS=""
     fi
 
+  # additional packages to install:
+  # Space separated list is supported,
+  # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
+    ADDITIONAL_PACKAGES="python-raspberry-gpio"
+
   # debug tty path
     DEBUG_TTY="/dev/console"


### PR DESCRIPTION
Following my feature request #1227 , after some tests is proves nearly impossible to have pip in Lakka. The efforts required to make it work makes adding python packages on a per-user basis easier. However RPi.GPIO is still a vital  package as it allows a lot of stuff, including safe shutdown scripts for cases with power buttons. While there are a lot of precompiled RPi.GPIO floating around, these only account for arm compilations, not aarch64. For such a core Pi Python component, I feel like having it compile with Lakka would be a benefit.

I've forked and am working on a safe shutdown script that could serve as the basis for multiple cases for Lakka users (mine is for Retroflag's but it would be easy to fork and adapt it).

Fix #1227

RPi.GPIO package upgraded to SPDX format. Being unsure whether credits should go to Stephan Raue, the LibreElec team, both and/or the Lakka team, I templated one of the SPDX files,