### PR TITLE
retroarch: eject + timezone patch

### DIFF
--- a/packages/libretro/retroarch/patches/retroarch-99-eject_disc.patch
+++ b/packages/libretro/retroarch/patches/retroarch-99-eject_disc.patch
@@ -1,0 +1,633 @@
+diff --git a/config.def.h b/config.def.h
+index 56999e908e..3a2bbc355e 100644
+--- a/config.def.h
++++ b/config.def.h
+@@ -552,6 +552,9 @@ static const bool menu_show_load_content       = true;
+ #ifdef HAVE_CDROM
+ static const bool menu_show_load_disc          = true;
+ static const bool menu_show_dump_disc          = true;
++#ifdef HAVE_LAKKA
++static const bool menu_show_eject_disc         = true;
++#endif /* HAVE_LAKKA */
+ #endif
+ static const bool menu_show_information        = true;
+ static const bool menu_show_configurations     = true;
+diff --git a/configuration.c b/configuration.c
+index f27376525b..44f17afcde 100644
+--- a/configuration.c
++++ b/configuration.c
+@@ -1631,6 +1631,9 @@ static struct config_bool_setting *populate_settings_bool(
+ #ifdef HAVE_CDROM
+    SETTING_BOOL("menu_show_load_disc",           &settings->bools.menu_show_load_disc, true, menu_show_load_disc, false);
+    SETTING_BOOL("menu_show_dump_disc",           &settings->bools.menu_show_dump_disc, true, menu_show_dump_disc, false);
++#ifdef HAVE_LAKKA
++   SETTING_BOOL("menu_show_eject_disc",          &settings->bools.menu_show_eject_disc, true, menu_show_eject_disc, false);
++#endif /* HAVE_LAKKA */
+ #endif
+    SETTING_BOOL("menu_show_information",         &settings->bools.menu_show_information, true, menu_show_information, false);
+    SETTING_BOOL("menu_show_configurations",      &settings->bools.menu_show_configurations, true, menu_show_configurations, false);
+diff --git a/configuration.h b/configuration.h
+index e03455679b..8834fee65f 100644
+--- a/configuration.h
++++ b/configuration.h
+@@ -586,6 +586,9 @@ typedef struct settings
+       bool menu_show_load_content;
+       bool menu_show_load_disc;
+       bool menu_show_dump_disc;
++#ifdef HAVE_LAKKA
++      bool menu_show_eject_disc;
++#endif
+       bool menu_show_information;
+       bool menu_show_configurations;
+       bool menu_show_help;
+diff --git a/intl/msg_hash_lbl.h b/intl/msg_hash_lbl.h
+index dca4d8c9ce..d69f030eeb 100644
+--- a/intl/msg_hash_lbl.h
++++ b/intl/msg_hash_lbl.h
+@@ -1670,6 +1670,12 @@ MSG_HASH(
+    MENU_ENUM_LABEL_DUMP_DISC,
+    "dump_disc"
+    )
++#ifdef HAVE_LAKKA
++MSG_HASH(
++   MENU_ENUM_LABEL_EJECT_DISC,
++   "eject_disc"
++   )
++#endif
+ MSG_HASH(
+    MENU_ENUM_LABEL_LOAD_CONTENT_SPECIAL,
+    "load_special"
+@@ -2318,6 +2324,12 @@ MSG_HASH(
+    MENU_ENUM_LABEL_DEFERRED_LOAD_DISC_LIST,
+    "deferred_load_disc_list"
+    )
++#ifdef HAVE_LAKKA
++MSG_HASH(
++   MENU_ENUM_LABEL_DEFERRED_EJECT_DISC,
++   "deferred_eject_disc"
++   )
++#endif
+ MSG_HASH(
+    MENU_ENUM_LABEL_DEFERRED_CURSOR_MANAGER_LIST_RDB_ENTRY_DEVELOPER,
+    "deferred_cursor_manager_list_rdb_entry_developer"
+@@ -3928,6 +3940,12 @@ MSG_HASH(
+    MENU_ENUM_LABEL_MENU_SHOW_DUMP_DISC,
+    "menu_show_dump_disc"
+    )
++#ifdef HAVE_LAKKA
++MSG_HASH(
++   MENU_ENUM_LABEL_MENU_SHOW_EJECT_DISC,
++   "menu_show_eject_disc"
++   )
++#endif
+ MSG_HASH(
+    MENU_ENUM_LABEL_MENU_SHOW_INFORMATION,
+    "menu_show_information"
+diff --git a/intl/msg_hash_us.h b/intl/msg_hash_us.h
+index 4c354ac29c..8e065b0566 100644
+--- a/intl/msg_hash_us.h
++++ b/intl/msg_hash_us.h
+@@ -91,6 +91,16 @@ MSG_HASH( /* FIXME Is a specific image format used? Is it determined automatical
+    MENU_ENUM_SUBLABEL_DUMP_DISC,
+    "Dump the physical media disc to internal storage. It will be saved as an image file."
+    )
++#ifdef HAVE_LAKKA
++MSG_HASH(
++   MENU_ENUM_LABEL_VALUE_EJECT_DISC,
++   "Eject Disc"
++   )
++MSG_HASH(
++   MENU_ENUM_SUBLABEL_EJECT_DISC,
++   "Ejects the disc from physical CD/DVD drive."
++   )
++#endif
+ MSG_HASH(
+    MENU_ENUM_LABEL_VALUE_PLAYLISTS_TAB,
+    "Playlists"
+@@ -4120,6 +4130,16 @@ MSG_HASH(
+    MENU_ENUM_SUBLABEL_MENU_SHOW_DUMP_DISC,
+    "Show the 'Dump Disc' option in the Main Menu."
+    )
++#ifdef HAVE_LAKKA
++MSG_HASH(
++   MENU_ENUM_LABEL_VALUE_MENU_SHOW_EJECT_DISC,
++   "Show 'Eject Disc'"
++   )
++MSG_HASH(
++   MENU_ENUM_SUBLABEL_MENU_SHOW_EJECT_DISC,
++   "Show the 'Eject Disc' option in the Main Menu."
++   )
++#endif
+ MSG_HASH(
+    MENU_ENUM_LABEL_VALUE_MENU_SHOW_ONLINE_UPDATER,
+    "Show 'Online Updater'"
+diff --git a/menu/cbs/menu_cbs_deferred_push.c b/menu/cbs/menu_cbs_deferred_push.c
+index e501810a01..e5465a04ce 100644
+--- a/menu/cbs/menu_cbs_deferred_push.c
++++ b/menu/cbs/menu_cbs_deferred_push.c
+@@ -113,6 +113,9 @@ GENERIC_DEFERRED_PUSH(deferred_push_configurations_list,            DISPLAYLIST_
+ GENERIC_DEFERRED_PUSH(deferred_push_load_content_special,           DISPLAYLIST_LOAD_CONTENT_LIST)
+ GENERIC_DEFERRED_PUSH(deferred_push_load_content_list,              DISPLAYLIST_LOAD_CONTENT_LIST)
+ GENERIC_DEFERRED_PUSH(deferred_push_dump_disk_list,                 DISPLAYLIST_DUMP_DISC)
++#ifdef HAVE_LAKKA
++GENERIC_DEFERRED_PUSH(deferred_push_eject_disc,                     DISPLAYLIST_EJECT_DISC)
++#endif
+ GENERIC_DEFERRED_PUSH(deferred_push_cdrom_info_detail_list,         DISPLAYLIST_CDROM_DETAIL_INFO)
+ GENERIC_DEFERRED_PUSH(deferred_push_load_disk_list,                 DISPLAYLIST_LOAD_DISC)
+ GENERIC_DEFERRED_PUSH(deferred_push_information_list,               DISPLAYLIST_INFORMATION_LIST)
+@@ -667,6 +670,9 @@ static int menu_cbs_init_bind_deferred_push_compare_label(
+ 
+    const deferred_info_list_t info_list[] = {
+       {MENU_ENUM_LABEL_DEFERRED_DUMP_DISC_LIST, deferred_push_dump_disk_list},
++#ifdef HAVE_LAKKA
++      {MENU_ENUM_LABEL_DEFERRED_EJECT_DISC, deferred_push_eject_disc},
++#endif
+       {MENU_ENUM_LABEL_DEFERRED_LOAD_DISC_LIST, deferred_push_load_disk_list},
+       {MENU_ENUM_LABEL_DEFERRED_FAVORITES_LIST, deferred_push_favorites_list},
+       {MENU_ENUM_LABEL_DEFERRED_DROPDOWN_BOX_LIST, deferred_push_dropdown_box_list},
+@@ -1255,6 +1261,11 @@ static int menu_cbs_init_bind_deferred_push_compare_label(
+          case MENU_ENUM_LABEL_DEFERRED_DUMP_DISC_LIST:
+             BIND_ACTION_DEFERRED_PUSH(cbs, deferred_push_dump_disk_list);
+             break;
++#ifdef HAVE_LAKKA
++         case MENU_ENUM_LABEL_DEFERRED_EJECT_DISC:
++            BIND_ACTION_DEFERRED_PUSH(cbs, deferred_push_eject_disc);
++            break;
++#endif
+          case MENU_ENUM_LABEL_DEFERRED_CDROM_INFO_DETAIL_LIST:
+             BIND_ACTION_DEFERRED_PUSH(cbs, deferred_push_cdrom_info_detail_list);
+             break;
+diff --git a/menu/cbs/menu_cbs_ok.c b/menu/cbs/menu_cbs_ok.c
+index db88a25fda..f96472ac4d 100644
+--- a/menu/cbs/menu_cbs_ok.c
++++ b/menu/cbs/menu_cbs_ok.c
+@@ -436,6 +436,10 @@ static enum msg_hash_enums action_ok_dl_to_enum(unsigned lbl)
+          return MENU_ENUM_LABEL_DEFERRED_ACCOUNTS_FACEBOOK_LIST;         
+       case ACTION_OK_DL_DUMP_DISC_LIST:
+          return MENU_ENUM_LABEL_DEFERRED_DUMP_DISC_LIST;
++#ifdef HAVE_LAKKA
++      case ACTION_OK_DL_EJECT_DISC:
++         return MENU_ENUM_LABEL_DEFERRED_EJECT_DISC;
++#endif
+       case ACTION_OK_DL_LOAD_DISC_LIST:
+          return MENU_ENUM_LABEL_DEFERRED_LOAD_DISC_LIST;
+       case ACTION_OK_DL_ACCOUNTS_YOUTUBE_LIST:
+@@ -1507,6 +1511,9 @@ int generic_action_ok_displaylist_push(const char *path,
+       case ACTION_OK_DL_IMAGES_LIST:
+       case ACTION_OK_DL_LOAD_DISC_LIST:
+       case ACTION_OK_DL_DUMP_DISC_LIST:
++#ifdef HAVE_LAKKA
++      case ACTION_OK_DL_EJECT_DISC:
++#endif
+       case ACTION_OK_DL_SHADER_PRESET_REMOVE:
+       case ACTION_OK_DL_SHADER_PRESET_SAVE:
+       case ACTION_OK_DL_CDROM_INFO_LIST:
+@@ -2713,6 +2720,17 @@ static int action_ok_dump_cdrom(const char *path,
+    return 0;
+ }
+ 
++#ifdef HAVE_LAKKA
++static int action_ok_eject_disc(const char *path,
++      const char *label, unsigned type, size_t idx, size_t entry_idx)
++{
++#ifdef HAVE_CDROM
++   system("eject & disown");
++#endif /* HAVE_CDROM */
++   return 0;
++}
++#endif /* HAVE_LAKKA */
++
+ static int action_ok_lookup_setting(const char *path,
+       const char *label, unsigned type, size_t idx, size_t entry_idx)
+ {
+@@ -5628,6 +5646,9 @@ DEFAULT_ACTION_OK_FUNC(action_ok_push_accounts_youtube_list, ACTION_OK_DL_ACCOUN
+ DEFAULT_ACTION_OK_FUNC(action_ok_push_accounts_twitch_list, ACTION_OK_DL_ACCOUNTS_TWITCH_LIST)
+ DEFAULT_ACTION_OK_FUNC(action_ok_push_accounts_facebook_list, ACTION_OK_DL_ACCOUNTS_FACEBOOK_LIST)
+ DEFAULT_ACTION_OK_FUNC(action_ok_push_dump_disc_list, ACTION_OK_DL_DUMP_DISC_LIST)
++#ifdef HAVE_LAKKA
++DEFAULT_ACTION_OK_FUNC(action_ok_push_eject_disc, ACTION_OK_DL_EJECT_DISC)
++#endif
+ DEFAULT_ACTION_OK_FUNC(action_ok_push_load_disc_list, ACTION_OK_DL_LOAD_DISC_LIST)
+ DEFAULT_ACTION_OK_FUNC(action_ok_open_archive, ACTION_OK_DL_OPEN_ARCHIVE)
+ DEFAULT_ACTION_OK_FUNC(action_ok_rgui_menu_theme_preset, ACTION_OK_DL_RGUI_MENU_THEME_PRESET)
+@@ -7732,6 +7753,9 @@ static int menu_cbs_init_bind_ok_compare_label(menu_file_list_cbs_t *cbs,
+          {MENU_ENUM_LABEL_ACCOUNTS_TWITCH,                     action_ok_push_accounts_twitch_list},
+          {MENU_ENUM_LABEL_ACCOUNTS_FACEBOOK,                   action_ok_push_accounts_facebook_list},
+          {MENU_ENUM_LABEL_DUMP_DISC,                           action_ok_push_dump_disc_list},
++#ifdef HAVE_LAKKA
++         {MENU_ENUM_LABEL_EJECT_DISC,                          action_ok_push_eject_disc},
++#endif
+          {MENU_ENUM_LABEL_LOAD_DISC,                           action_ok_push_load_disc_list},
+          {MENU_ENUM_LABEL_SHADER_OPTIONS,                      action_ok_push_default},
+          {MENU_ENUM_LABEL_CORE_OPTIONS,                        action_ok_push_default},
+@@ -7910,6 +7934,12 @@ static int menu_cbs_init_bind_ok_compare_type(menu_file_list_cbs_t *cbs,
+    {
+       BIND_ACTION_OK(cbs, action_ok_dump_cdrom);
+    }
++#ifdef HAVE_LAKKA
++   else if (type == MENU_SET_EJECT_DISC)
++   {
++      BIND_ACTION_OK(cbs, action_ok_eject_disc);
++   }
++#endif
+    else if (type == MENU_SET_CDROM_INFO)
+    {
+       BIND_ACTION_OK(cbs, action_ok_cdrom_info_list);
+diff --git a/menu/cbs/menu_cbs_sublabel.c b/menu/cbs/menu_cbs_sublabel.c
+index 4193cfe8d3..0c733ac768 100644
+--- a/menu/cbs/menu_cbs_sublabel.c
++++ b/menu/cbs/menu_cbs_sublabel.c
+@@ -397,6 +397,9 @@ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_sideload_core_list,            MENU_
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_core_manager_list,             MENU_ENUM_SUBLABEL_CORE_MANAGER_LIST)
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_load_disc,                  MENU_ENUM_SUBLABEL_LOAD_DISC)
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_dump_disc,                  MENU_ENUM_SUBLABEL_DUMP_DISC)
++#ifdef HAVE_LAKKA
++DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_eject_disc,                 MENU_ENUM_SUBLABEL_EJECT_DISC)
++#endif
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_content_list,                  MENU_ENUM_SUBLABEL_LOAD_CONTENT_LIST)
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_content_special,               MENU_ENUM_SUBLABEL_LOAD_CONTENT_SPECIAL)
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_load_content_history,          MENU_ENUM_SUBLABEL_LOAD_CONTENT_HISTORY)
+@@ -777,6 +780,9 @@ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_menu_show_load_core,
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_menu_show_load_content,                MENU_ENUM_SUBLABEL_MENU_SHOW_LOAD_CONTENT)
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_menu_show_load_disc,                   MENU_ENUM_SUBLABEL_MENU_SHOW_LOAD_DISC)
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_menu_show_dump_disc,                   MENU_ENUM_SUBLABEL_MENU_SHOW_DUMP_DISC)
++#ifdef HAVE_LAKKA
++DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_menu_show_eject_disc,                  MENU_ENUM_SUBLABEL_MENU_SHOW_EJECT_DISC)
++#endif
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_menu_show_information,                 MENU_ENUM_SUBLABEL_MENU_SHOW_INFORMATION)
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_menu_show_configurations,              MENU_ENUM_SUBLABEL_MENU_SHOW_CONFIGURATIONS)
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_menu_show_help,                        MENU_ENUM_SUBLABEL_MENU_SHOW_HELP)
+@@ -2276,6 +2282,11 @@ int menu_cbs_init_bind_sublabel(menu_file_list_cbs_t *cbs,
+          case MENU_ENUM_LABEL_DUMP_DISC:
+             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_dump_disc);
+             break;
++#ifdef HAVE_LAKKA
++         case MENU_ENUM_LABEL_EJECT_DISC:
++            BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_eject_disc);
++            break;
++#endif
+          case MENU_ENUM_LABEL_MENU_SHOW_LOAD_CONTENT:
+             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_menu_show_load_content);
+             break;
+@@ -2285,6 +2296,11 @@ int menu_cbs_init_bind_sublabel(menu_file_list_cbs_t *cbs,
+          case MENU_ENUM_LABEL_MENU_SHOW_DUMP_DISC:
+             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_menu_show_dump_disc);
+             break;
++#ifdef HAVE_LAKKA
++         case MENU_ENUM_LABEL_MENU_SHOW_EJECT_DISC:
++            BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_menu_show_eject_disc);
++            break;
++#endif
+          case MENU_ENUM_LABEL_MENU_SHOW_INFORMATION:
+             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_menu_show_information);
+             break;
+diff --git a/menu/cbs/menu_cbs_title.c b/menu/cbs/menu_cbs_title.c
+index 8f507e6057..465ad42ee5 100644
+--- a/menu/cbs/menu_cbs_title.c
++++ b/menu/cbs/menu_cbs_title.c
+@@ -582,6 +582,9 @@ DEFAULT_TITLE_MACRO(action_get_crt_switchres_settings_list,     MENU_ENUM_LABEL_
+ DEFAULT_TITLE_MACRO(action_get_configuration_settings_list,     MENU_ENUM_LABEL_VALUE_CONFIGURATION_SETTINGS)
+ DEFAULT_TITLE_MACRO(action_get_load_disc_list,                  MENU_ENUM_LABEL_VALUE_LOAD_DISC)
+ DEFAULT_TITLE_MACRO(action_get_dump_disc_list,                  MENU_ENUM_LABEL_VALUE_DUMP_DISC)
++#ifdef HAVE_LAKKA
++DEFAULT_TITLE_MACRO(action_get_eject_disc,                      MENU_ENUM_LABEL_VALUE_EJECT_DISC)
++#endif
+ DEFAULT_TITLE_MACRO(action_get_saving_settings_list,            MENU_ENUM_LABEL_VALUE_SAVING_SETTINGS)
+ DEFAULT_TITLE_MACRO(action_get_logging_settings_list,           MENU_ENUM_LABEL_VALUE_LOGGING_SETTINGS)
+ DEFAULT_TITLE_MACRO(action_get_frame_throttle_settings_list,    MENU_ENUM_LABEL_VALUE_FRAME_THROTTLE_SETTINGS)
+@@ -907,6 +910,9 @@ static int menu_cbs_init_bind_title_compare_label(menu_file_list_cbs_t *cbs,
+       {MENU_ENUM_LABEL_DEFERRED_CORE_RESTORE_BACKUP_LIST,             action_get_title_deferred_core_restore_backup_list},
+       {MENU_ENUM_LABEL_DEFERRED_CORE_DELETE_BACKUP_LIST,              action_get_title_deferred_core_delete_backup_list},
+       {MENU_ENUM_LABEL_DEFERRED_DUMP_DISC_LIST,                       action_get_dump_disc_list},
++#ifdef HAVE_LAKKA
++      {MENU_ENUM_LABEL_DEFERRED_EJECT_DISC,                           action_get_eject_disc},
++#endif
+       {MENU_ENUM_LABEL_DEFERRED_LOAD_DISC_LIST,                       action_get_load_disc_list},
+       {MENU_ENUM_LABEL_DEFERRED_CONFIGURATION_SETTINGS_LIST,          action_get_configuration_settings_list },
+       {MENU_ENUM_LABEL_DEFERRED_SAVING_SETTINGS_LIST,                 action_get_saving_settings_list},
+diff --git a/menu/drivers/materialui.c b/menu/drivers/materialui.c
+index b95bce261d..037481cbf2 100644
+--- a/menu/drivers/materialui.c
++++ b/menu/drivers/materialui.c
+@@ -9181,6 +9181,17 @@ static int materialui_list_push(void *data, void *userdata,
+                      false);
+             }
+ 
++#ifdef HAVE_LAKKA
++            if (settings->bools.menu_show_eject_disc)
++            {
++               MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(
++                     info->list,
++                     MENU_ENUM_LABEL_EJECT_DISC,
++                     PARSE_ACTION,
++                     false);
++            }
++#endif
++
+ #if defined(HAVE_NETWORKING)
+ #ifdef HAVE_LAKKA
+             MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(
+@@ -9961,6 +9972,9 @@ static void materialui_list_insert(
+       {
+          case MENU_SET_CDROM_INFO:
+          case MENU_SET_CDROM_LIST:
++#ifdef HAVE_LAKKA
++         case MENU_SET_EJECT_DISC:
++#endif
+          case MENU_SET_LOAD_CDROM_LIST:
+             node->icon_texture_index = MUI_TEXTURE_DISK;
+             node->icon_type          = MUI_ICON_TYPE_INTERNAL;
+@@ -10237,6 +10251,9 @@ static void materialui_list_insert(
+                   string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DISK_IMAGE_APPEND)) ||
+                   string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_LOAD_DISC)) ||
+                   string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DUMP_DISC)) ||
++#ifdef HAVE_LAKKA
++                  string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_EJECT_DISC)) ||
++#endif
+                   string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DISC_INFORMATION)) ||
+                   string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DISK_OPTIONS)) ||
+                   string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DISK_INDEX))
+diff --git a/menu/drivers/ozone/ozone.c b/menu/drivers/ozone/ozone.c
+index 06d414f7f0..ca2780d69b 100644
+--- a/menu/drivers/ozone/ozone.c
++++ b/menu/drivers/ozone/ozone.c
+@@ -1576,6 +1576,17 @@ static int ozone_list_push(void *data, void *userdata,
+                      false);
+             }
+ 
++#ifdef HAVE_LAKKA
++            if (settings->bools.menu_show_eject_disc)
++            {
++               MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(
++                     info->list,
++                     MENU_ENUM_LABEL_EJECT_DISC,
++                     PARSE_ACTION,
++                     false);
++            }
++#endif
++
+             MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(
+                   info->list,
+                   MENU_ENUM_LABEL_ADD_CONTENT_LIST,
+diff --git a/menu/drivers/ozone/ozone_texture.c b/menu/drivers/ozone/ozone_texture.c
+index 19db500552..65fa6155d4 100644
+--- a/menu/drivers/ozone/ozone_texture.c
++++ b/menu/drivers/ozone/ozone_texture.c
+@@ -46,6 +46,9 @@ uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
+    {
+       case MENU_ENUM_LABEL_LOAD_DISC:
+       case MENU_ENUM_LABEL_DUMP_DISC:
++#ifdef HAVE_LAKKA
++      case MENU_ENUM_LABEL_EJECT_DISC:
++#endif
+       case MENU_ENUM_LABEL_DISC_INFORMATION:
+          return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_DISC];
+       case MENU_ENUM_LABEL_CORE_OPTIONS:
+@@ -372,6 +375,9 @@ uintptr_t ozone_entries_icon_get_texture(ozone_handle_t *ozone,
+    {
+       case MENU_SET_CDROM_INFO:
+       case MENU_SET_CDROM_LIST:
++#ifdef HAVE_LAKKA
++      case MENU_SET_EJECT_DISC:
++#endif
+       case MENU_SET_LOAD_CDROM_LIST:
+          return ozone->icons_textures[OZONE_ENTRIES_ICONS_TEXTURE_DISC];
+       case FILE_TYPE_DIRECTORY:
+diff --git a/menu/drivers/xmb.c b/menu/drivers/xmb.c
+index 9a60aec701..3c0eae4da5 100644
+--- a/menu/drivers/xmb.c
++++ b/menu/drivers/xmb.c
+@@ -2569,6 +2569,9 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
+ 
+       case MENU_ENUM_LABEL_LOAD_DISC:
+       case MENU_ENUM_LABEL_DUMP_DISC:
++#ifdef HAVE_LAKKA
++      case MENU_ENUM_LABEL_EJECT_DISC:
++#endif
+       case MENU_ENUM_LABEL_DISC_INFORMATION:
+          return xmb->textures.list[XMB_TEXTURE_DISC];
+ 
+@@ -6767,6 +6770,9 @@ static int xmb_list_push(void *data, void *userdata,
+    bool menu_show_configurations   = settings->bools.menu_show_configurations;
+    bool menu_show_load_disc        = settings->bools.menu_show_load_disc;
+    bool menu_show_dump_disc        = settings->bools.menu_show_dump_disc;
++#ifdef HAVE_LAKKA
++   bool menu_show_eject_disc        = settings->bools.menu_show_eject_disc;
++#endif
+    bool menu_show_shutdown         = settings->bools.menu_show_shutdown;
+    bool menu_show_reboot           = settings->bools.menu_show_reboot;
+ #if !defined(IOS)
+@@ -6908,6 +6914,17 @@ static int xmb_list_push(void *data, void *userdata,
+                      false);
+             }
+ 
++#ifdef HAVE_LAKKA
++            if (menu_show_eject_disc)
++            {
++               MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(
++                     info->list,
++                     MENU_ENUM_LABEL_EJECT_DISC,
++                     PARSE_ACTION,
++                     false);
++            }
++#endif
++
+             MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(
+                   info->list,
+                   MENU_ENUM_LABEL_ADD_CONTENT_LIST,
+diff --git a/menu/menu_cbs.h b/menu/menu_cbs.h
+index c3ed953708..fe134345fb 100644
+--- a/menu/menu_cbs.h
++++ b/menu/menu_cbs.h
+@@ -204,6 +204,9 @@ enum
+    ACTION_OK_DL_MIDI_SETTINGS_LIST,
+    ACTION_OK_DL_LOAD_DISC_LIST,
+    ACTION_OK_DL_DUMP_DISC_LIST,
++#ifdef HAVE_LAKKA
++   ACTION_OK_DL_EJECT_DISC,
++#endif
+    ACTION_OK_DL_BROWSE_URL_START,
+    ACTION_OK_DL_CONTENT_SETTINGS,
+    ACTION_OK_DL_CDROM_INFO_DETAIL_LIST,
+diff --git a/menu/menu_displaylist.c b/menu/menu_displaylist.c
+index 6b0816ceb4..0554765e15 100644
+--- a/menu/menu_displaylist.c
++++ b/menu/menu_displaylist.c
+@@ -7709,6 +7709,9 @@ unsigned menu_displaylist_build_list(
+                {MENU_ENUM_LABEL_MENU_SHOW_LOAD_CONTENT,                                PARSE_ONLY_BOOL, true  },
+                {MENU_ENUM_LABEL_MENU_SHOW_LOAD_DISC,                                   PARSE_ONLY_BOOL, true  },
+                {MENU_ENUM_LABEL_MENU_SHOW_DUMP_DISC,                                   PARSE_ONLY_BOOL, true  },
++#ifdef HAVE_LAKKA
++               {MENU_ENUM_LABEL_MENU_SHOW_EJECT_DISC,                                  PARSE_ONLY_BOOL, true  },
++#endif
+                {MENU_ENUM_LABEL_MENU_SHOW_ONLINE_UPDATER,                              PARSE_ONLY_BOOL, true  },
+                {MENU_ENUM_LABEL_MENU_SHOW_CORE_UPDATER,                                PARSE_ONLY_BOOL, true  },
+                {MENU_ENUM_LABEL_MENU_SHOW_LEGACY_THUMBNAIL_UPDATER,                    PARSE_ONLY_BOOL, true  },
+@@ -9011,6 +9014,14 @@ unsigned menu_displaylist_build_list(
+                MENU_SET_CDROM_LIST);
+ #endif
+          break;
++#ifdef HAVE_LAKKA
++      case DISPLAYLIST_EJECT_DISC:
++#ifdef HAVE_CDROM
++         count = menu_displaylist_parse_disc_info(list,
++               MENU_SET_EJECT_DISC);
++#endif /* HAVE_CDROM */
++         break;
++#endif /* HAVE_LAKKA */
+       default:
+          break;
+    }
+@@ -11311,6 +11322,9 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
+       case DISPLAYLIST_BROWSE_URL_LIST:
+       case DISPLAYLIST_DISC_INFO:
+       case DISPLAYLIST_DUMP_DISC:
++#ifdef HAVE_LAKKA
++      case DISPLAYLIST_EJECT_DISC:
++#endif
+       case DISPLAYLIST_LOAD_CONTENT_LIST:
+       case DISPLAYLIST_LOAD_CONTENT_SPECIAL:
+       case DISPLAYLIST_OPTIONS_REMAPPINGS:
+@@ -11354,6 +11368,9 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
+                   break;
+                case DISPLAYLIST_DISC_INFO:
+                case DISPLAYLIST_DUMP_DISC:
++#ifdef HAVE_LAKKA
++               case DISPLAYLIST_EJECT_DISC:
++#endif
+                case DISPLAYLIST_MENU_SETTINGS_LIST:
+                case DISPLAYLIST_ADD_CONTENT_LIST:
+                case DISPLAYLIST_DROPDOWN_LIST_RESOLUTION:
+@@ -11412,6 +11429,9 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
+          {
+             case DISPLAYLIST_DISC_INFO:
+             case DISPLAYLIST_DUMP_DISC:
++#ifdef HAVE_LAKKA
++            case DISPLAYLIST_EJECT_DISC:
++#endif
+                info->need_clear   = true;
+                break;
+             default:
+@@ -11814,6 +11834,16 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
+                         PARSE_ACTION, false) == 0)
+                   count++;
+             }
++
++#ifdef HAVE_LAKKA
++            if (settings->bools.menu_show_eject_disc)
++            {
++               if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(info->list,
++                        MENU_ENUM_LABEL_EJECT_DISC,
++                        PARSE_ACTION, false) == 0)
++                  count++;
++            }
++#endif /* HAVE_LAKKA */
+ #endif
+ 
+ #if defined(HAVE_RGUI) || defined(HAVE_MATERIALUI)
+diff --git a/menu/menu_displaylist.h b/menu/menu_displaylist.h
+index f774bd356e..6dcfde8019 100644
+--- a/menu/menu_displaylist.h
++++ b/menu/menu_displaylist.h
+@@ -134,6 +134,9 @@ enum menu_displaylist_ctl_state
+    DISPLAYLIST_VIDEO_FONTS,
+    DISPLAYLIST_LOAD_DISC,
+    DISPLAYLIST_DUMP_DISC,
++#ifdef HAVE_LAKKA
++   DISPLAYLIST_EJECT_DISC,
++#endif
+    DISPLAYLIST_OVERLAYS,
+ #ifdef HAVE_VIDEO_LAYOUT
+    DISPLAYLIST_VIDEO_LAYOUT_PATH,
+diff --git a/menu/menu_driver.h b/menu/menu_driver.h
+index 0fa5eb1243..e88cafcb25 100644
+--- a/menu/menu_driver.h
++++ b/menu/menu_driver.h
+@@ -214,6 +214,7 @@ enum menu_settings_type
+ 
+    MENU_SET_CDROM_LIST,
+    MENU_SET_LOAD_CDROM_LIST,
++   MENU_SET_EJECT_DISC,
+    MENU_SET_CDROM_INFO,
+    MENU_SETTING_ACTION_DELETE_PLAYLIST,
+    MENU_SETTING_ACTION_PLAYLIST_MANAGER_RESET_CORES,
+diff --git a/menu/menu_setting.c b/menu/menu_setting.c
+index ec4492661b..625411726a 100644
+--- a/menu/menu_setting.c
++++ b/menu/menu_setting.c
+@@ -8545,7 +8545,17 @@ static bool setting_append_list(
+                         &group_info,
+                         &subgroup_info,
+                         parent_group);
++
++#ifdef HAVE_LAKKA
++                  CONFIG_ACTION(
++                        list, list_info,
++                        MENU_ENUM_LABEL_EJECT_DISC,
++                        MENU_ENUM_LABEL_VALUE_EJECT_DISC,
++                        &group_info,
++                        &subgroup_info,
++                        parent_group);
+                }
++#endif
+ 
+                string_list_free(drive_list);
+             }
+@@ -15239,6 +15249,23 @@ static bool setting_append_list(
+                   general_write_handler,
+                   general_read_handler,
+                   SD_FLAG_NONE);
++
++#ifdef HAVE_LAKKA
++            CONFIG_BOOL(
++                  list, list_info,
++                  &settings->bools.menu_show_eject_disc,
++                  MENU_ENUM_LABEL_MENU_SHOW_EJECT_DISC,
++                  MENU_ENUM_LABEL_VALUE_MENU_SHOW_EJECT_DISC,
++                  menu_show_eject_disc,
++                  MENU_ENUM_LABEL_VALUE_OFF,
++                  MENU_ENUM_LABEL_VALUE_ON,
++                  &group_info,
++                  &subgroup_info,
++                  parent_group,
++                  general_write_handler,
++                  general_read_handler,
++                  SD_FLAG_NONE);
++#endif /* HAVE_LAKKA */
+ #endif
+ 
+             CONFIG_BOOL(
+diff --git a/msg_hash.h b/msg_hash.h
+index 819411ec91..716d6dffeb 100644
+--- a/msg_hash.h
++++ b/msg_hash.h
+@@ -1082,6 +1082,9 @@ enum msg_hash_enums
+    MENU_LABEL(MENU_SHOW_LOAD_CONTENT),
+    MENU_LABEL(MENU_SHOW_LOAD_DISC),
+    MENU_LABEL(MENU_SHOW_DUMP_DISC),
++#ifdef HAVE_LAKKA
++   MENU_LABEL(MENU_SHOW_EJECT_DISC),
++#endif
+    MENU_LABEL(MENU_SHOW_INFORMATION),
+    MENU_LABEL(MENU_SHOW_CONFIGURATIONS),
+    MENU_LABEL(MENU_SHOW_HELP),
+@@ -1420,6 +1423,9 @@ enum msg_hash_enums
+    MENU_ENUM_LABEL_DEFERRED_CDROM_INFO_DETAIL_LIST,
+    MENU_ENUM_LABEL_DEFERRED_LOAD_DISC_LIST,
+    MENU_ENUM_LABEL_DEFERRED_DUMP_DISC_LIST,
++#ifdef HAVE_LAKKA
++   MENU_ENUM_LABEL_DEFERRED_EJECT_DISC,
++#endif
+    MENU_ENUM_LABEL_DEFERRED_REMAPPINGS_PORT_LIST,
+    MENU_ENUM_LABEL_DEFERRED_DROPDOWN_BOX_LIST,
+    MENU_ENUM_LABEL_DEFERRED_DROPDOWN_BOX_LIST_SPECIAL,
+@@ -2162,6 +2168,9 @@ enum msg_hash_enums
+    MENU_LABEL(LOAD_CONTENT_HISTORY),
+    MENU_LABEL(LOAD_DISC),
+    MENU_LABEL(DUMP_DISC),
++#ifdef HAVE_LAKKA
++   MENU_LABEL(EJECT_DISC),
++#endif
+    MENU_LABEL(NETWORK_INFORMATION),
+    MENU_LABEL(SYSTEM_INFORMATION),
+    MENU_LABEL(ACHIEVEMENT_LIST),

--- a/packages/libretro/retroarch/patches/retroarch-99-timezones.patch
+++ b/packages/libretro/retroarch/patches/retroarch-99-timezones.patch
@@ -1,0 +1,322 @@
+diff --git a/configuration.c b/configuration.c
+index f27376525b..29529577bb 100644
+--- a/configuration.c
++++ b/configuration.c
+@@ -1185,6 +1185,35 @@ const char *config_get_midi_driver_options(void)
+    return char_list_new_special(STRING_LIST_MIDI_DRIVERS, NULL);
+ }
+ 
++#ifdef HAVE_LAKKA
++const char *config_get_default_timezone(void)
++{
++   return DEFAULT_TIMEZONE;
++}
++
++const char *config_get_all_timezones(void)
++{
++   return char_list_new_special(STRING_LIST_TIMEZONES, NULL);
++}
++
++static void load_timezone(char *setting)
++{
++   snprintf(setting, TIMEZONE_LENGTH, "%s", DEFAULT_TIMEZONE);
++   char haystack[TIMEZONE_LENGTH+32];
++   static char *needle = "TIMEZONE=";
++   size_t needle_len = strlen(needle);
++   FILE *timezonefp = fopen(LAKKA_TIMEZONE_PATH, "r");
++   if (timezonefp != NULL)
++   {
++      fgets(haystack, sizeof(haystack), timezonefp);
++      fclose(timezonefp);
++      char *start = strstr(haystack, needle);
++      if (start != NULL)
++         snprintf(setting, TIMEZONE_LENGTH, "%s", start + needle_len);
++   }
++}
++#endif
++
+ bool config_overlay_enable_default(void)
+ {
+    if (g_defaults.overlay_set)
+@@ -2347,6 +2376,7 @@ void config_set_defaults(void *data)
+    configuration_set_bool(settings,
+          settings->bools.bluetooth_enable, filestream_exists(LAKKA_BLUETOOTH_PATH));
+    configuration_set_bool(settings, settings->bools.localap_enable, false);
++   load_timezone(settings->arrays.timezone);
+ #endif
+ 
+ #ifdef HAVE_MENU
+diff --git a/configuration.h b/configuration.h
+index e03455679b..e00d7fa893 100644
+--- a/configuration.h
++++ b/configuration.h
+@@ -29,6 +29,10 @@
+ #include "input/input_defines.h"
+ #include "led/led_defines.h"
+ 
++#ifdef HAVE_LAKKA
++#include "lakka.h"
++#endif
++
+ #define configuration_set_float(settings, var, newvar) \
+ { \
+    settings->modified = true; \
+@@ -381,6 +385,9 @@ typedef struct settings
+       char ai_service_url[PATH_MAX_LENGTH];
+ 
+       char crt_switch_timings[255];
++#ifdef HAVE_LAKKA
++      char timezone[TIMEZONE_LENGTH];
++#endif
+    } arrays;
+ 
+    struct
+@@ -1011,6 +1018,11 @@ void config_save_file_salamander(void);
+ 
+ settings_t *config_get_ptr(void);
+ 
++#ifdef HAVE_LAKKA
++const char *config_get_default_timezone(void);
++const char *config_get_all_timezones(void);
++#endif
++
+ RETRO_END_DECLS
+ 
+ #endif
+diff --git a/intl/msg_hash_lbl.h b/intl/msg_hash_lbl.h
+index dca4d8c9ce..c2b03d1b7f 100644
+--- a/intl/msg_hash_lbl.h
++++ b/intl/msg_hash_lbl.h
+@@ -195,6 +195,10 @@ MSG_HASH(
+    MENU_ENUM_LABEL_BLUETOOTH_ENABLE,
+    "bluetooth_enable"
+    )
++MSG_HASH(
++   MENU_ENUM_LABEL_TIMEZONE,
++   "timezone"
++   )
+ #endif
+ MSG_HASH(
+    MENU_ENUM_LABEL_BUILDBOT_ASSETS_URL,
+diff --git a/intl/msg_hash_us.c b/intl/msg_hash_us.c
+index 514aed48ae..f53507486c 100644
+--- a/intl/msg_hash_us.c
++++ b/intl/msg_hash_us.c
+@@ -2289,6 +2289,12 @@ int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
+             snprintf(s, len,
+                      "MIDI driver to use.");
+             break;
++#ifdef HAVE_LAKKA
++        case MENU_ENUM_LABEL_TIMEZONE:
++            snprintf(s, len,
++                     "Select time zone.");
++            break;
++#endif
+         case MENU_ENUM_LABEL_MIDI_INPUT:
+             snprintf(s, len,
+                      "Sets the input device (driver specific).\n"
+diff --git a/intl/msg_hash_us.h b/intl/msg_hash_us.h
+index 4c354ac29c..1da68860ba 100644
+--- a/intl/msg_hash_us.h
++++ b/intl/msg_hash_us.h
+@@ -12218,6 +12218,14 @@ MSG_HASH(
+    MENU_ENUM_SUBLABEL_LOCALAP_ENABLE,
+    "Enable or disable Wi-Fi Access Point."
+    )
++MSG_HASH(
++   MENU_ENUM_LABEL_VALUE_TIMEZONE,
++   "Time zone"
++   )
++MSG_HASH(
++   MENU_ENUM_SUBLABEL_TIMEZONE,
++   "Select your time zone. The change will take effect after reboot."
++   )
+ MSG_HASH(
+    MSG_LOCALAP_SWITCHING_OFF,
+    "Switching off Wi-Fi Access Point."
+diff --git a/lakka.h b/lakka.h
+index f098a1080c..3f369ff05c 100644
+--- a/lakka.h
++++ b/lakka.h
+@@ -24,6 +24,10 @@
+ #define LAKKA_UPDATE_DIR     "/storage/.update/"
+ #define LAKKA_CONNMAN_DIR    "/storage/.cache/connman/"
+ #define LAKKA_LOCALAP_PATH   "/storage/.cache/services/localap.conf"
++#define LAKKA_TIMEZONE_PATH  "/storage/.cache/timezone"
++
++#define DEFAULT_TIMEZONE "UTC"
++#define TIMEZONE_LENGTH 255
+ 
+ #include "switch_performance_profiles.h"
+ 
+diff --git a/list_special.h b/list_special.h
+index cbdbf0b877..ae245be6e3 100644
+--- a/list_special.h
++++ b/list_special.h
+@@ -56,6 +56,9 @@ enum string_list_type
+    STRING_LIST_RECORD_DRIVERS,
+    STRING_LIST_MIDI_DRIVERS,
+    STRING_LIST_SUPPORTED_CORES_PATHS,
++#ifdef HAVE_LAKKA
++   STRING_LIST_TIMEZONES,
++#endif
+    STRING_LIST_SUPPORTED_CORES_NAMES
+ };
+ 
+diff --git a/menu/cbs/menu_cbs_get_value.c b/menu/cbs/menu_cbs_get_value.c
+index 2b0d01e794..c734f81efe 100644
+--- a/menu/cbs/menu_cbs_get_value.c
++++ b/menu/cbs/menu_cbs_get_value.c
+@@ -1572,6 +1572,9 @@ static int menu_cbs_init_bind_get_string_representation_compare_label(
+          case MENU_ENUM_LABEL_BLUETOOTH_DRIVER:
+          case MENU_ENUM_LABEL_WIFI_DRIVER:
+          case MENU_ENUM_LABEL_MENU_DRIVER:
++#ifdef HAVE_LAKKA
++         case MENU_ENUM_LABEL_TIMEZONE:
++#endif
+             BIND_ACTION_GET_VALUE(cbs, menu_action_setting_disp_set_label);
+             break;
+          case MENU_ENUM_LABEL_CONNECT_BLUETOOTH:
+diff --git a/menu/cbs/menu_cbs_sublabel.c b/menu/cbs/menu_cbs_sublabel.c
+index 4193cfe8d3..6a6da555e9 100644
+--- a/menu/cbs/menu_cbs_sublabel.c
++++ b/menu/cbs/menu_cbs_sublabel.c
+@@ -227,6 +227,7 @@ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_ssh_enable,                    MENU_
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_samba_enable,                  MENU_ENUM_SUBLABEL_SAMBA_ENABLE )
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_bluetooth_enable,              MENU_ENUM_SUBLABEL_BLUETOOTH_ENABLE )
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_localap_enable,                MENU_ENUM_SUBLABEL_LOCALAP_ENABLE )
++DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_timezone,                      MENU_ENUM_SUBLABEL_TIMEZONE)
+ #endif
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_user_language,                 MENU_ENUM_SUBLABEL_USER_LANGUAGE)
+ DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_max_swapchain_images,          MENU_ENUM_SUBLABEL_VIDEO_MAX_SWAPCHAIN_IMAGES )
+@@ -3907,6 +3908,9 @@ int menu_cbs_init_bind_sublabel(menu_file_list_cbs_t *cbs,
+          case MENU_ENUM_LABEL_LOCALAP_ENABLE:
+             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_localap_enable);
+             break;
++         case MENU_ENUM_LABEL_TIMEZONE:
++            BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_timezone);
++            break;
+ #endif
+          case MENU_ENUM_LABEL_USER_LANGUAGE:
+             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_user_language);
+diff --git a/menu/menu_displaylist.c b/menu/menu_displaylist.c
+index 6b0816ceb4..3fa3362bbe 100644
+--- a/menu/menu_displaylist.c
++++ b/menu/menu_displaylist.c
+@@ -7688,6 +7688,7 @@ unsigned menu_displaylist_build_list(
+                {MENU_ENUM_LABEL_SAMBA_ENABLE,                                          PARSE_ONLY_BOOL},
+                {MENU_ENUM_LABEL_BLUETOOTH_ENABLE,                                      PARSE_ONLY_BOOL},
+                {MENU_ENUM_LABEL_LOCALAP_ENABLE,                                        PARSE_ONLY_BOOL},
++               {MENU_ENUM_LABEL_TIMEZONE,                                              PARSE_ONLY_STRING_OPTIONS},
+             };
+ 
+             for (i = 0; i < ARRAY_SIZE(build_list); i++)
+diff --git a/menu/menu_setting.c b/menu/menu_setting.c
+index ec4492661b..837f89b6e3 100644
+--- a/menu/menu_setting.c
++++ b/menu/menu_setting.c
+@@ -8019,6 +8019,19 @@ static void localap_enable_toggle_change_handler(void *data)
+ 
+    driver_wifi_tether_start_stop(enable, LAKKA_LOCALAP_PATH);
+ }
++
++static void timezone_change_handler(rarch_setting_t *setting)
++{
++   if (!setting)
++      return;
++
++   FILE *timezonefp = fopen(LAKKA_TIMEZONE_PATH, "w");
++   if (timezonefp != NULL)
++   {
++      fprintf(timezonefp, "TIMEZONE=%s", setting->value.target.string);
++      fclose(timezonefp);
++   }
++}
+ #endif
+ 
+ static bool setting_append_list_input_player_options(
+@@ -18567,6 +18580,23 @@ static bool setting_append_list(
+                   SD_FLAG_NONE);
+             (*list)[list_info->index - 1].change_handler = localap_enable_toggle_change_handler;
+ 
++            CONFIG_STRING_OPTIONS(
++                  list, list_info,
++                  settings->arrays.timezone,
++                  sizeof(settings->arrays.timezone),
++                  MENU_ENUM_LABEL_TIMEZONE,
++                  MENU_ENUM_LABEL_VALUE_TIMEZONE,
++                  config_get_default_timezone(),
++                  config_get_all_timezones(),
++                  &group_info,
++                  &subgroup_info,
++                  parent_group,
++                  general_read_handler,
++                  general_write_handler);
++            SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_IS_DRIVER);
++            (*list)[list_info->index - 1].action_ok    = setting_action_ok_mapped_string;
++            (*list)[list_info->index - 1].change_handler = timezone_change_handler;
++
+             END_SUB_GROUP(list, list_info, parent_group);
+             END_GROUP(list, list_info, parent_group);
+ #endif
+diff --git a/msg_hash.h b/msg_hash.h
+index 819411ec91..a7a987dd4b 100644
+--- a/msg_hash.h
++++ b/msg_hash.h
+@@ -1826,6 +1826,7 @@ enum msg_hash_enums
+    MENU_LABEL(SAMBA_ENABLE),
+    MENU_LABEL(BLUETOOTH_ENABLE),
+    MENU_LABEL(LOCALAP_ENABLE),
++   MENU_LABEL(TIMEZONE),
+ #endif
+    MENU_LABEL(NETPLAY_DELAY_FRAMES),
+    MENU_LABEL(NETPLAY_PUBLIC_ANNOUNCE),
+diff --git a/retroarch.c b/retroarch.c
+index 89d84e93ef..5473083514 100644
+--- a/retroarch.c
++++ b/retroarch.c
+@@ -277,6 +277,10 @@
+ /* Forward declarations */
+ #include "retroarch_fwd_decls.h"
+ 
++#ifdef HAVE_LAKKA
++#include "lakka.h"
++#endif
++
+ /* GLOBAL POINTER GETTERS */
+ 
+ #ifdef HAVE_NETWORKING
+@@ -8621,6 +8625,33 @@ struct string_list *string_list_new_special(enum string_list_type type,
+             string_list_append(s, opt, attr);
+          }
+          break;
++#ifdef HAVE_LAKKA
++      case STRING_LIST_TIMEZONES:
++         {
++            const char *opt  = DEFAULT_TIMEZONE;
++            *len            += strlen(opt) + 1;
++            string_list_append(s, opt, attr);
++            FILE *zones_file = popen("grep -v ^# /usr/share/zoneinfo/zone.tab | cut -f3 | sort && echo", "r");
++            if (zones_file != NULL)
++            {
++               char zone_desc[TIMEZONE_LENGTH];
++               while (fgets(zone_desc, TIMEZONE_LENGTH, zones_file))
++               {
++                  const size_t zone_desc_len = strlen(zone_desc);
++                  if (zone_desc_len > 0 && zone_desc[zone_desc_len-1] == '\n')
++                     zone_desc[zone_desc_len-1] = '\0';
++                  if (strlen(zone_desc) > 0)
++                  {
++                     const char *opt  = zone_desc;
++                     *len            += strlen(opt) + 1;
++                     string_list_append(s, opt, attr);
++                  }
++               }
++               pclose(zones_file);
++            }
++         }
++         break;
++#endif
+       case STRING_LIST_SUPPORTED_CORES_PATHS:
+          core_info_get_list(&core_info_list);
+ 


### PR DESCRIPTION
fixes #1261 and https://github.com/libretro/RetroArch/issues/5183

# CD ROM eject
adds new entry (where the entries for dumping CD is) to eject the disc - in case the CD drive has no physical button to eject the disc / the button does not work

# Time zone
adds new entry to Services sub-menu of Settings (where other Lakka specific settings are - enable/disable Samba/SSH/...) and allows the user to set the time zone from the GUI without needing access to the command line / file system