### PR TITLE
rpi4: disable openlara

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -81,7 +81,6 @@ targets="\
 	Rockchip|RK3328|arm|image \
 	Rockchip|RK3399|arm|image \
 	Rockchip|TinkerBoard|arm|image \
-	RPi|Gamegirl|arm|image \
 	RPi|GPICase|arm|image \
 	RPi|RPi|arm|image \
 	RPi|RPi2|arm|image \

--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -442,7 +442,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 # disable some cores
   if [ "$PROJECT" = "RPi" ]; then
     LIBRETRO_CORES="${LIBRETRO_CORES// yabasanshiro /}"
-    if [ "$DEVICE" = "RPi" -o "$DEVICE" = "Gamegirl" -o "$DEVICE" = "GPICase" ]; then
+    if [ "$DEVICE" = "RPi" -o "$DEVICE" = "GPICase" ]; then
       LIBRETRO_CORES="${LIBRETRO_CORES// 4do /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// beetle-bsnes /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// beetle-psx /}"
@@ -483,9 +483,14 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
       LIBRETRO_CORES="${LIBRETRO_CORES// vbam /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// virtualjaguar /}"
       LIBRETRO_CORES="${LIBRETRO_CORES// yabause /}"
-    elif [ "$DEVICE" = "RPi2" ]; then
+    fi
+    if [ "$DEVICE" = "RPi2" ]; then
       LIBRETRO_CORES="${LIBRETRO_CORES// play /}"
-    elif [ "$DEVICE" = "RPi4" -a "$ARCH" = "aarch64" ]; then
+    fi
+    if [ "$DEVICE" = "RPi4" ]; then
+      LIBRETRO_CORES="${LIBRETRO_CORES// openlara /}"
+    fi
+    if [ "$DEVICE" = "RPi4" -a "$ARCH" = "aarch64" ]; then
       LIBRETRO_CORES="${LIBRETRO_CORES// mame2015 /}"
     fi
   elif [ "$PROJECT" = "Amlogic" -o "$PROJECT" = "Rockchip" -o "$PROJECT" = "Allwinner" ]; then


### PR DESCRIPTION
It doesn't build with the latest mesa. It can be re-enabled once it's either fixed or mesa is updated