### PR TITLE
Rotate cores on GPiCase

### DIFF
--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -259,6 +259,7 @@ makeinstall_target() {
     sed -i -e "s/# audio_out_rate = 48000/audio_out_rate = 44100/" $INSTALL/etc/retroarch.cfg
     sed -i -e "s/# video_font_size = 32/video_font_size = 16/" $INSTALL/etc/retroarch.cfg
     sed -i -e "s/# video_scale_integer = false/video_scale_integer = true/" $INSTALL/etc/retroarch.cfg
+    sed -i -e "s/video_rotation = \"0\"/video_rotation = \"3\"/" $INSTALL/etc/retroarch.cfg
   fi
 
   if [ "$PROJECT" == "NXP" -a "$DEVICE" == "iMX6" ]; then


### PR DESCRIPTION
RA is rotated 90 CCW. Rotate 270 to fix in all the cores.

This doesn't fix RA Menus as that requires a solution to https://github.com/libretro/RetroArch/issues/6770.