### PR TITLE
GPiCase: add extra cmdline args needed for audio

### DIFF
--- a/projects/RPi/devices/GPICase/options
+++ b/projects/RPi/devices/GPICase/options
@@ -14,3 +14,6 @@
     EXFAT="no"
     NTFS3G="no"
     HFSTOOLS="no"
+
+  # Enable Audio through Broadcom chip (legacy sound path that overlay uses)
+    EXTRA_CMDLINE="snd_bcm2835.enable_hdmi=1 snd_bcm2835.enable_headphones=1 snd_bcm2835.enable_compat_alsa=1"


### PR DESCRIPTION
Audio uses legacy path through Broadcom fw so enable it with cmdline.