### PR TITLE
rpi: make bcm2835-driver use the same version as bcm2835-bootloader

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="1df55790fb191704c0ce630d4d0713a8beb43a7d"
-PKG_SHA256="9be26aae349616aa2cfa82c11f3188efb848e36d6ebe401f5d8682e376483d56"
+PKG_VERSION="6c3d7745680f10802a7a5ed201e5252a3520e696"
+#PKG_SHA256=""
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
-PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="https://github.com/raspberrypi/firmware/archive/$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain dtc"
 PKG_LONGDESC="OpenMAX-bcm2835: OpenGL-ES and OpenMAX driver for BCM2835"
 PKG_TOOLCHAIN="manual"


### PR DESCRIPTION
This is what my previous PR was trying to solve. It gets files from the same package, but we fetch it from libreelec currently meaning we're limited in which commits we can pin to.

This change just fetches the exact same package and the exact same version as bcm2835-bootloader (https://github.com/libretro/Lakka-LibreELEC/blob/master/packages/tools/bcm2835-bootloader/package.mk#L6). In the future we can merge them.