### PR TITLE
[LakkaV3] fix build for 32-bit Generic

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -72,7 +72,9 @@ targets="\
 	Allwinner|H6|arm|image \
 	Amlogic|AMLG12|arm|image \
 	Amlogic|AMLGX|arm|image \
+	Generic||i386|image \
 	Generic||x86_64|image \
+	L4T|Switch|aarch64|image \
 	NXP|iMX6|arm|image \
 	OdroidXU3||arm|image \
 	Rockchip|MiQi|arm|image \
@@ -84,7 +86,6 @@ targets="\
 	RPi|RPi|arm|image \
 	RPi|RPi2|arm|image \
 	RPi|RPi4|aarch64|image \
-	L4T|Switch|aarch64|image \
 	"
 
 # set the number of total build jobs and initialize counter for current build job

--- a/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
+++ b/packages/addons/addon-depends/multimedia-tools-depends/mpg123/package.mk
@@ -10,10 +10,11 @@ PKG_URL="http://downloads.sourceforge.net/sourceforge/mpg123/mpg123-$PKG_VERSION
 PKG_DEPENDS_TARGET="toolchain alsa-lib"
 PKG_LONGDESC="A console based real time MPEG Audio Player for Layer 1, 2 and 3."
 
-if [ "$ARCH" = "x86_64" ];then
+PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
+                           --enable-static"
+
+if [ "$DISTRO" = "Lakka" ]; then
   PKG_BUILD_FLAGS="+pic"
+  PKG_CONFIGURE_OPTS_TARGET+=" --with-pic"
 fi
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
-                           --with-pic \
-                           --enable-static"

--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -24,7 +24,7 @@ PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="$PKG_SITE.git"
-PKG_DEPENDS_TARGET="toolchain alsa-lib freetype zlib retroarch-assets retroarch-overlays core-info retroarch-joypad-autoconfig lakka-update libretro-database ffmpeg libass libvdpau libxkbfile xkeyboard-config libxkbcommon joyutils sixpair empty libretro-cores"
+PKG_DEPENDS_TARGET="toolchain alsa-lib freetype zlib retroarch-assets retroarch-overlays core-info retroarch-joypad-autoconfig lakka-update libretro-database ffmpeg libass libvdpau libxkbfile xkeyboard-config libxkbcommon joyutils sixpair empty libretro-cores glsl-shaders"
 PKG_PRIORITY="optional"
 PKG_SECTION="libretro"
 PKG_SHORTDESC="Reference frontend for the libretro API."
@@ -32,12 +32,6 @@ PKG_LONGDESC="RetroArch is the reference frontend for the libretro API. Popular 
 
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
-
-if [ "$PROJECT" == "Generic" ] || [ "$DEVICE" == "RPi4" ]; then
-  PKG_DEPENDS_TARGET+=" slang-shaders glsl-shaders $VULKAN"
-else
-  PKG_DEPENDS_TARGET+=" glsl-shaders"
-fi
 
 if [ "$OPENGLES_SUPPORT" = yes ]; then
   PKG_DEPENDS_TARGET+=" $OPENGLES"
@@ -49,7 +43,7 @@ fi
 
 if [ ! $PROJECT == "L4T" ]; then
   if [ "$VULKAN_SUPPORT" = yes ]; then
-    PKG_DEPENDS_TARGET+=" $VULKAN"
+    PKG_DEPENDS_TARGET+=" slang-shaders $VULKAN"
   fi
 else
   :


### PR DESCRIPTION
- retroarch: add VULKAN only when have VULKAN_SUPPORT
- mpg123: build with PIC for all targets

backport of #1317 