### PR TITLE
beetle-saturn: update and add the core back to list

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -180,6 +180,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 " beetle-pce "\
 " beetle-pcfx "\
 " beetle-psx "\
+" beetle-saturn "\
 " beetle-supafaust "\
 " beetle-supergrafx "\
 " beetle-vb "\

--- a/packages/libretro/beetle-saturn/package.mk
+++ b/packages/libretro/beetle-saturn/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-saturn"
-PKG_VERSION="f36c7fe"
+PKG_VERSION="923ea6b"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv2"


### PR DESCRIPTION
was removed due to size constraints of the parition. as the partition
size was increased, the core can be included again.

fixes #1309
