### PR TITLE
rpi: change HandlePowerKey action to poweroff

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -198,7 +198,11 @@ post_makeinstall_target() {
 
   # tune logind.conf
   sed -e "s,^.*HandleLidSwitch=.*$,HandleLidSwitch=ignore,g" -i $INSTALL/etc/systemd/logind.conf
-  sed -e "s,^.*HandlePowerKey=.*$,HandlePowerKey=ignore,g" -i $INSTALL/etc/systemd/logind.conf
+  if [ "$PROJECT" = "RPi" ]; then
+    sed -e "s,^.*HandlePowerKey=.*$,HandlePowerKey=poweroff,g" -i $INSTALL/etc/systemd/logind.conf
+  else
+    sed -e "s,^.*HandlePowerKey=.*$,HandlePowerKey=ignore,g" -i $INSTALL/etc/systemd/logind.conf
+  fi
 
   # fix ordering cycle for overlay mounts
   if [ "$DISTRO" = "Lakka" ]; then


### PR DESCRIPTION
Try suggested fix for https://github.com/libretro/Lakka-LibreELEC/issues/1174

I don't have a switch to test this with but it doesn't seem like a dangerous change.