### PR TITLE
rpi2/3/4: use drivers compiled for these platforms rather than armv6

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -13,10 +13,10 @@ PKG_LONGDESC="OpenMAX-bcm2835: OpenGL-ES and OpenMAX driver for BCM2835"
 PKG_TOOLCHAIN="manual"
 
 # Set SoftFP ABI or HardFP ABI
-if [ "${TARGET_FLOAT}" = "soft" ]; then
-  PKG_FLOAT="softfp"
-else
+if [ "${PROJECT}" = "RPi" -a "${DEVICE}" = "RPi" ]; then
   PKG_FLOAT="hardfp"
+else
+  PKG_FLOAT="."
 fi
 
 makeinstall_target() {


### PR DESCRIPTION
I think this might be slightly more efficient for later RPis, based on https://github.com/raspberrypi/firmware/blob/master/README.md

I'm going to redo this to build them ourselves from https://github.com/raspberrypi/userland which should fix vcgencmd on aarch64 but that's not ready yet.