### PR TITLE
retroarch: build with gles 3 minor version support [WIP]

### DIFF
--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -73,7 +73,7 @@ RETROARCH_GL=""
 
 if [ "$DEVICE" = "OdroidGoAdvance" ]; then
   PKG_DEPENDS_TARGET+=" librga libpng"
-  RETROARCH_GL="--enable-kms --enable-odroidgo2 --disable-x11 --disable-wayland --enable-opengles --enable-opengles3 --disable-mali_fbdev"
+  RETROARCH_GL="--enable-kms --enable-odroidgo2 --disable-x11 --disable-wayland --enable-opengles --enable-opengles3 --enable-opengles3_2 --disable-mali_fbdev"
 elif [ "$OPENGL_SUPPORT" = "yes" ]; then
   RETROARCH_GL="--enable-kms"
 elif [ "$OPENGLES" = "odroidc1-mali" ] || [ "$OPENGLES" = "opengl-meson" ] || [ "$OPENGLES" = "opengl-meson8" ] || [ "$OPENGLES" = "opengl-meson-t82x" ] || [ "$OPENGLES" = "allwinner-fb-mali" ]; then
@@ -87,6 +87,9 @@ elif [ "$OPENGLES" = "allwinner-mali" ]; then
 elif [ "$OPENGLES" = "mesa" ]; then
   if [ "$PROJECT" = "RPi" ]; then
     RETROARCH_GL="--disable-x11 --enable-opengles --disable-videocore --enable-kms --enable-egl --disable-wayland"
+    if [ "$DEVICE" = "RPi4" ]; then
+      RETROARCH_GL+=" --enable-opengles3 --enable-opengles3_1"
+    fi
   else
     RETROARCH_GL="--enable-opengles --enable-kms --disable-x11"
   fi


### PR DESCRIPTION
See https://github.com/libretro/RetroArch/pull/11181

This is UNTESTED, so feel free to close and consider it as advisory :) I don't have a lakka dev environment/spare SD. Just something I was meaning to eventually do after above PR was merged. It's only really relevant for things like swanstation that actually use the API to determine GLES version support. see https://github.com/stenzek/duckstation/issues/694. You can see if it's working via the presence of GLES 3.x items in a verbose log (regardless of what core retroarch is running).

I don't know if any of these other devices need updating. I imagine a few are gles3.x