### PR TITLE
swantstation: default to sw renderer when no OGL

### DIFF
--- a/packages/libretro/swanstation/package.mk
+++ b/packages/libretro/swanstation/package.mk
@@ -50,6 +50,14 @@ PKG_CMAKE_OPTS_TARGET="-DCMAKE_BUILD_TYPE=Release \
                        -DUSE_DRMKMS=ON \
                        -DBUILD_LIBRETRO_CORE=ON"
 
+# Compile with software renderer as default for devices not suporting OpenGL
+if [ "$PROJECT" = "Generic" -o "$DEVICE" = "RPi4" -o "$DEVICE" = "Switch" ]; then
+  PKG_PATCH_DIRS=""
+else
+  PKG_PATCH_DIRS="no_opengl"
+fi
+
+
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro
   cp swanstation_libretro.so $INSTALL/usr/lib/libretro/

--- a/packages/libretro/swanstation/patches/no_opengl/swanstation-01-default_sw_renderer.patch
+++ b/packages/libretro/swanstation/patches/no_opengl/swanstation-01-default_sw_renderer.patch
@@ -1,0 +1,13 @@
+diff --git a/src/duckstation-libretro/libretro_host_interface.cpp b/src/duckstation-libretro/libretro_host_interface.cpp
+index ed81e0c5..8b1aaac6 100644
+--- a/src/duckstation-libretro/libretro_host_interface.cpp
++++ b/src/duckstation-libretro/libretro_host_interface.cpp
+@@ -657,7 +657,7 @@ static std::array<retro_core_option_definition, 64> s_option_definitions = {{
+ #ifdef WIN32
+    "D3D11"
+ #else
+-   "OpenGL"
++   "Software"
+ #endif
+   },
+   {"duckstation_GPU.UseThread",


### PR DESCRIPTION
This patch makes SwanStation to compile with default  GPU renderer set to Software, so it can be started on platforms without OpenGL support. For platforms with OpenGL support this patch is reversed during post-patch.