### PR TITLE
RPi: enable wii-u-gc-adapter and mk_arcade_joystick on all RPi devices except GPICase

### DIFF
--- a/packages/lakka/RPi/package.mk
+++ b/packages/lakka/RPi/package.mk
@@ -27,7 +27,7 @@ PKG_SITE="https://github.com/libretro/Lakka-LibreELEC"
 PKG_URL=""
 PKG_DEPENDS_TARGET="retroarch"
 
-if [ "$DEVICE" = "RPi" -o "$DEVICE" = "RPi2" -o "$DEVICE" = "RPi4" ] ; then
+if [ "$DEVICE" != "GPICase" ] ; then
   PKG_DEPENDS_TARGET+=" wii-u-gc-adapter wiringPi mk_arcade_joystick_rpi joycond"
 fi
 


### PR DESCRIPTION
As RPi3.aarch64 was added as separate platform, these packages are not
included. As we have dropped support for Gamegirl, it is easier to make
the condition DEVICE is not GPICase, as all other RPi devices should
include these packages.

Fixes #1151 