### PR TITLE
rpi4: disable 4k output on upgrades too

### DIFF
--- a/projects/RPi/devices/RPi4/config/distroconfig.txt
+++ b/projects/RPi/devices/RPi4/config/distroconfig.txt
@@ -7,3 +7,5 @@ dtoverlay=rpivid-v4l2
 disable_overscan=1
 disable_splash=1
 dtparam=audio=on
+hdmi_max_pixel_freq:0=200000000
+hdmi_max_pixel_freq:1=200000000


### PR DESCRIPTION
It was done here: https://github.com/libretro/Lakka-LibreELEC/commit/58dafbe511f79172468bed305b0d2b267f9127d5

but that might get overwritten with this version