### PR TITLE
duckstation: add binary core

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -202,6 +202,7 @@ DISTRO_SRC="http://sources.libreelec.tv/$LIBREELEC_VERSION"
 " dolphin "\
 " dosbox "\
 " dosbox-svn "\
+" duckstation "\
 " emux-sms"\
 " easyrpg "\
 " fbneo "\

--- a/packages/libretro/duckstation/package.mk
+++ b/packages/libretro/duckstation/package.mk
@@ -1,0 +1,23 @@
+PKG_NAME="duckstation"
+PKG_ARCH="aarch64"
+PKG_LICENSE="GPL"
+PKG_VERSION="Lakka33"
+PKG_SITE="https://www.duckstation.org"
+PKG_URL="https://www.duckstation.org/libretro/duckstation_libretro_linux_aarch64.zip"
+PKG_SECTION="libretro"
+PKG_SHORTDESC="DuckStation is an simulator/emulator of the Sony PlayStation(TM) console, focusing on playability, speed, and long-term maintainability."
+PKG_TOOLCHAIN="manual"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+make_target() {
+  cd $PKG_BUILD
+  wget $PKG_URL
+  unzip duckstation_libretro_linux_aarch64.zip
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/libretro
+  cp $PKG_BUILD/duckstation_libretro.so $INSTALL/usr/lib/libretro/
+}


### PR DESCRIPTION
Works on rpi4 at least.

There's a bit of a caveat when it comes to versions and re-building in that it won't get redownloaded unless we change the (arbitrary) PKG_VERSION or delete the .stamps and build directories