### PR TITLE
duckstation: use specific version of the binary core

### DIFF
--- a/libretro_update.sh
+++ b/libretro_update.sh
@@ -129,9 +129,11 @@ do
     continue
   fi
   [ -n "$PKG_GIT_BRANCH" ] && GIT_HEAD="heads/$PKG_GIT_BRANCH" || GIT_HEAD="HEAD"
-  UPS_VERSION=`git ls-remote $PKG_SITE | grep ${GIT_HEAD}$ | awk '{ print substr($1,1,7) }'`
+  UPS_VERSION=`git ls-remote $PKG_SITE 2>/dev/null | grep ${GIT_HEAD}$ | awk '{ print substr($1,1,7) }'`
   if [ "$UPS_VERSION" == "$PKG_VERSION" ]; then
     echo "$PKG_NAME is up to date ($UPS_VERSION)"
+  elif [ "$UPS_VERSION" == "" ]; then
+    echo "$PKG_NAME does not use git - nothing changed"
   else
     i+=1
     echo "$PKG_NAME updated from $PKG_VERSION to $UPS_VERSION"

--- a/packages/libretro/duckstation/package.mk
+++ b/packages/libretro/duckstation/package.mk
@@ -1,33 +1,22 @@
+# PKG_VERSION is from https://www.duckstation.org/libretro/changelog.txt
+# Archive with binary core must be present on LAKKA_MIRROR. This is achieved
+# by a separate script that runs on LAKKA_MIRROR and downloads new versions
+# of the core.
+
 PKG_NAME="duckstation"
 PKG_ARCH="x86_64 arm aarch64"
 PKG_LICENSE="GPL"
-PKG_VERSION="Lakka33"
+PKG_VERSION="200fb85f"
 PKG_SITE="https://www.duckstation.org"
+PKG_SOURCE_DIR="${PKG_NAME}_${ARCH}-${PKG_VERSION}"
+PKG_SOURCE_NAME="${PKG_SOURCE_DIR}.zip"
+PKG_URL="${LAKKA_MIRROR}/${PKG_SOURCE_NAME}"
 PKG_SECTION="libretro"
 PKG_SHORTDESC="DuckStation is an simulator/emulator of the Sony PlayStation(TM) console, focusing on playability, speed, and long-term maintainability."
 PKG_TOOLCHAIN="manual"
 
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
-
-case ${ARCH} in
-aarch64)
-  binary_filename="duckstation_libretro_linux_aarch64.zip"
-  ;;
-arm)
-  binary_filename="duckstation_libretro_linux_armv7.zip"
-  ;;
-x86_64)
-  binary_filename="duckstation_libretro_linux_x64.zip"
-  ;;
-esac
-PKG_URL="https://www.duckstation.org/libretro/${binary_filename}"
-
-make_target() {
-  cd $PKG_BUILD
-  wget $PKG_URL
-  unzip $binary_filename
-}
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro


### PR DESCRIPTION
to have reproducible builds, we need to use the same version of the core, which cannot be guaranteed when downloading the core from upstream at build time. on the Lakka mirror server we will keep various versions of the binary core so we can re-download that specific version of the core at build time.