### PR TITLE
mupen64plus-nx: add wildcard to catch all rpi4 variants

### DIFF
--- a/packages/libretro/mupen64plus_next/package.mk
+++ b/packages/libretro/mupen64plus_next/package.mk
@@ -68,7 +68,7 @@ make_target() {
     RPi3)
       make platform=rpi3-mesa
       ;;
-    RPi4|RPi4-PiBoyDmg)
+    RPi4*)
       make platform=rpi4 GLES3=1 FORCE_GLES3=1
       ;;
     iMX6)


### PR DESCRIPTION
This means we don't have to edit it for other possibly upcoming targets