### PR TITLE
RPi: build GPU tools

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -69,4 +69,19 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/opt/vc
     ln -sf /usr/bin ${INSTALL}/opt/vc/bin
     ln -sf /usr/lib ${INSTALL}/opt/vc/lib
+
+  # remove pre-built binaries in case they will be provided by the rpi_userland package
+  if listcontains "${ADDITIONAL_PACKAGES}" "rpi_userland" ; then
+    rm -f ${INSTALL}/usr/lib/libbcm_host.so
+    rm -f ${INSTALL}/usr/lib/libdebug_sym.so
+    rm -f ${INSTALL}/usr/lib/libdtovl.so
+    rm -f ${INSTALL}/usr/lib/libvchiq_arm.so
+    rm -f ${INSTALL}/usr/lib/libvcos.so
+    rm -f ${INSTALL}/usr/bin/dtmerge
+    rm -f ${INSTALL}/usr/bin/dtoverlay
+    rm -f ${INSTALL}/usr/bin/tvservice
+    rm -f ${INSTALL}/usr/bin/vcgencmd
+    rm -f ${INSTALL}/usr/bin/vchiq_test
+    rm -f ${INSTALL}/usr/bin/vcmailbox
+  fi
 }

--- a/packages/tools/rpi_userland/package.mk
+++ b/packages/tools/rpi_userland/package.mk
@@ -1,0 +1,22 @@
+PKG_NAME="rpi_userland"
+PKG_VERSION="97bc8180ad682b004ea224d1db7b8e108eda4397"
+PKG_ARCH="arm aarch64"
+PKG_LICENSE="BSD3"
+PKG_SITE="https://github.com/raspberrypi/userland"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Source code for ARM side libraries for interfacing to Raspberry Pi GPU."
+PKG_TOOLCHAIN="cmake"
+PKG_CMAKE_OPTS_TARGET="-DARM64=ON"
+
+if [ "${ARCH}" = "arm" ]; then
+  PKG_CMAKE_OPTS_TARGET="-DARM64=OFF"
+fi
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+    cp -v ${PKG_BUILD}/build/bin/* ${INSTALL}/usr/bin
+
+  mkdir -p $INSTALL/usr/lib
+    cp -v ${PKG_BUILD}/build/lib/* ${INSTALL}/usr/lib
+}

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -150,5 +150,9 @@
   # e.g. ADDITIONAL_PACKAGES="PACKAGE1 PACKAGE2"
     ADDITIONAL_PACKAGES+=" python-raspberry-gpio"
 
+    if [ "$ARCH" = "aarch64" ]; then
+      ADDITIONAL_PACKAGES+=" rpi_userland"
+    fi
+
   # debug tty path
     DEBUG_TTY="/dev/console"


### PR DESCRIPTION
solves incompatibility on aarch64 targets with binaries provided by
bcm2835-driver for 32-bit ARM.

fixes #1496
