### PR TITLE
Add svg version of Lakka logo

### DIFF
--- a/distributions/Lakka/Lakka.svg
+++ b/distributions/Lakka/Lakka.svg
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg3767"
+   width="341.20667"
+   height="448.64215"
+   viewBox="0 0 341.20667 448.64215"
+   sodipodi:docname="Lakka.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata3773">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3771" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1015"
+     id="namedview3769"
+     showgrid="false"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:zoom="1.1835937"
+     inkscape:cx="-150.97688"
+     inkscape:cy="229.19979"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3767"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <g
+     id="g4653"
+     transform="translate(-0.40807951)">
+    <g
+       transform="matrix(0.99220577,0,0,1,-167.87107,-149.11362)"
+       id="g94"
+       style="fill:#27ae60;fill-opacity:1">
+      <circle
+         id="path89"
+         cx="341.54456"
+         cy="576.63367"
+         r="21.122114"
+         style="fill:#27ae60;fill-opacity:1" />
+    </g>
+    <rect
+       y="290.40167"
+       x="150.05394"
+       height="137.11838"
+       width="41.914959"
+       id="rect91"
+       style="fill:#27ae60;fill-opacity:1" />
+  </g>
+  <g
+     id="g107"
+     style="fill:#2ecc71;fill-opacity:1"
+     transform="translate(-533.67838,-154.18292)">
+    <circle
+       style="fill:#2ecc71;fill-opacity:1;stroke-width:1.07507455"
+       r="85.551666"
+       cy="430.46866"
+       cx="789.33337"
+       id="path3795-3-3" />
+    <rect
+       style="fill:#2ecc71;fill-opacity:1;stroke-width:0.92675924"
+       y="430.46866"
+       x="789.33337"
+       height="85.551666"
+       width="85.551674"
+       id="rect3849-3" />
+  </g>
+  <circle
+     id="path3795-3-6"
+     cx="255.655"
+     cy="149.16116"
+     r="85.551666"
+     style="fill:#e67e22;fill-opacity:1;stroke-width:1.07507455" />
+  <g
+     id="g103"
+     style="fill:#2ecc71;fill-opacity:1"
+     transform="translate(-533.11502,-153.33804)">
+    <circle
+       style="fill:#2ecc71;fill-opacity:1;stroke-width:1.07507455"
+       r="85.551666"
+       cy="429.62378"
+       cx="618.66669"
+       id="path3795-3-5" />
+    <rect
+       style="fill:#2ecc71;fill-opacity:1;stroke-width:0.92072731"
+       y="430.72678"
+       x="533.12213"
+       height="84.448669"
+       width="85.544556"
+       id="rect3849" />
+  </g>
+  <circle
+     id="path3795-3-7"
+     cx="85.551666"
+     cy="150.00604"
+     r="85.551666"
+     style="fill:#d35400;fill-opacity:1;stroke-width:1.07507455" />
+  <circle
+     id="path3795-3"
+     cx="170.60333"
+     cy="212.9194"
+     r="85.551666"
+     style="fill:#f39c12;fill-opacity:1;stroke-width:1.07507455" />
+  <circle
+     id="path3795"
+     cx="170.60333"
+     cy="85.551666"
+     r="85.551666"
+     style="fill:#f1c40f;fill-opacity:1;stroke-width:1.07507455" />
+</svg>


### PR DESCRIPTION
I'd assumed there was one somewhere but couldn't see one. This is useful if we want to render to different sizes e.g. for websites, high-resolution splash screens etc. I'm not a vector drawing expert so I'm sure this could be improved.

It's possible someone already has this - @kivutar I hear you made the original?