### PR TITLE
libretro: Update RetroArch to 1.9.14 + cores to latest

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# v3.6
+# v3.7
 * Update RetroArch to 1.9.14
 * Update libretro cores to the latest
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # v3.6
+* Update RetroArch to 1.9.14
+* Update libretro cores to the latest
+
+# v3.6
 * Update RetroArch to 1.9.13.1
 * Update libretro cores to latest
 * Add new libretro core: `ecwolf`

--- a/distributions/Lakka/version
+++ b/distributions/Lakka/version
@@ -2,5 +2,4 @@
   LIBREELEC_VERSION="devel"
 
 # OS_VERSION: OS Version
-  OS_VERSION="3.6"
-
+  OS_VERSION="3.7"

--- a/packages/libretro/81/package.mk
+++ b/packages/libretro/81/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="81"
-PKG_VERSION="30344d3"
+PKG_VERSION="7e8153c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/beetle-lynx/package.mk
+++ b/packages/libretro/beetle-lynx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-lynx"
-PKG_VERSION="b84c79b"
+PKG_VERSION="5d1ce06"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-ngp/package.mk
+++ b/packages/libretro/beetle-ngp/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-ngp"
-PKG_VERSION="f969af2"
+PKG_VERSION="f7c3931"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-pce-fast/package.mk
+++ b/packages/libretro/beetle-pce-fast/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-pce-fast"
-PKG_VERSION="81d4c9d"
+PKG_VERSION="f49139e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-pce/package.mk
+++ b/packages/libretro/beetle-pce/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-pce"
-PKG_VERSION="b04ae2f"
+PKG_VERSION="31878a7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-pcfx/package.mk
+++ b/packages/libretro/beetle-pcfx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-pcfx"
-PKG_VERSION="a1f1734"
+PKG_VERSION="6d2b11e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-psx/package.mk
+++ b/packages/libretro/beetle-psx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-psx"
-PKG_VERSION="04ff92b"
+PKG_VERSION="4a0cab1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-psx-libretro"

--- a/packages/libretro/beetle-saturn/package.mk
+++ b/packages/libretro/beetle-saturn/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-saturn"
-PKG_VERSION="e1119e9"
+PKG_VERSION="e6ba71f"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-supafaust/package.mk
+++ b/packages/libretro/beetle-supafaust/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-supafaust"
-PKG_VERSION="69553ca"
+PKG_VERSION="bdb2877"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/supafaust"

--- a/packages/libretro/beetle-supergrafx/package.mk
+++ b/packages/libretro/beetle-supergrafx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-supergrafx"
-PKG_VERSION="5906266"
+PKG_VERSION="18eac95"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-supergrafx-libretro"

--- a/packages/libretro/beetle-vb/package.mk
+++ b/packages/libretro/beetle-vb/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-vb"
-PKG_VERSION="aeb8e07"
+PKG_VERSION="aa77198"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-vb-libretro"

--- a/packages/libretro/beetle-wswan/package.mk
+++ b/packages/libretro/beetle-wswan/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-wswan"
-PKG_VERSION="0c7faaf"
+PKG_VERSION="ea00c1d"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-wswan-libretro"

--- a/packages/libretro/cannonball/package.mk
+++ b/packages/libretro/cannonball/package.mk
@@ -18,7 +18,7 @@
 ################################################################################
 
 PKG_NAME="cannonball"
-PKG_VERSION="36f695e"
+PKG_VERSION="81f9b56"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/cannonball"

--- a/packages/libretro/cap32/package.mk
+++ b/packages/libretro/cap32/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="cap32"
-PKG_VERSION="b647a3a"
+PKG_VERSION="06ba0e5"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-cap32"

--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="e300ec2"
+PKG_VERSION="1ae544b"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/libretro/libretro-chailove"

--- a/packages/libretro/core-info/package.mk
+++ b/packages/libretro/core-info/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="core-info"
-PKG_VERSION="b2b9b76"
+PKG_VERSION="3c3e2d6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-core-info"

--- a/packages/libretro/dolphin/package.mk
+++ b/packages/libretro/dolphin/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="dolphin"
-PKG_VERSION="3370f76"
+PKG_VERSION="48066c8"
 PKG_ARCH="x86_64 aarch64"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/dolphin"

--- a/packages/libretro/fbneo/package.mk
+++ b/packages/libretro/fbneo/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fbneo"
-PKG_VERSION="4f02ebd"
+PKG_VERSION="7f80e61"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/libretro/fbneo"

--- a/packages/libretro/fceumm/package.mk
+++ b/packages/libretro/fceumm/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fceumm"
-PKG_VERSION="a918869"
+PKG_VERSION="02b5bbf"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-fceumm"

--- a/packages/libretro/flycast/package.mk
+++ b/packages/libretro/flycast/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="flycast"
-PKG_VERSION="ae670ea"
+PKG_VERSION="e9bc945"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/flycast"

--- a/packages/libretro/flycast/package.mk
+++ b/packages/libretro/flycast/package.mk
@@ -44,10 +44,9 @@ if [ "$OPENGLES_SUPPORT" = yes ]; then
 fi
 
 PKG_CMAKE_OPTS_TARGET="-DLIBRETRO=ON \
-		      -DUSE_OPENMP=OFF \ 
-		      -DUSE_GLES=ON \ 
-                       -DCMAKE_BUILD_TYPE=Release \
-                       --target flycast_libretro"
+                        -DUSE_OPENMP=OFF \ 
+                        -DCMAKE_BUILD_TYPE=Release \
+                        --target flycast_libretro"
 
 if [ "$OPENGL_SUPPORT" = no -a "$OPENGLES_SUPPORT" = yes ]; then
   PKG_CMAKE_OPTS_TARGET+=" -DUSING_GLES=ON"

--- a/packages/libretro/gambatte/package.mk
+++ b/packages/libretro/gambatte/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="gambatte"
-PKG_VERSION="b0c79f0"
+PKG_VERSION="ef2a160"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/gambatte-libretro"

--- a/packages/libretro/gearboy/package.mk
+++ b/packages/libretro/gearboy/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="gearboy"
-PKG_VERSION="cd9c5f7"
+PKG_VERSION="8910d6f"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/drhelius/Gearboy"

--- a/packages/libretro/gearsystem/package.mk
+++ b/packages/libretro/gearsystem/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="gearsystem"
-PKG_VERSION="ae1beb2"
+PKG_VERSION="8a28a28"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/drhelius/Gearsystem"

--- a/packages/libretro/gpsp/package.mk
+++ b/packages/libretro/gpsp/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="gpsp"
-PKG_VERSION="c2c57a6"
+PKG_VERSION="2419b77"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/gpsp"

--- a/packages/libretro/handy/package.mk
+++ b/packages/libretro/handy/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="handy"
-PKG_VERSION="e7b4e32"
+PKG_VERSION="c5cccb5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Zlib"

--- a/packages/libretro/libretro-database/package.mk
+++ b/packages/libretro/libretro-database/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="libretro-database"
-PKG_VERSION="0692794"
+PKG_VERSION="ec58b9d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/mame2003-plus/package.mk
+++ b/packages/libretro/mame2003-plus/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame2003-plus"
-PKG_VERSION="d438aee"
+PKG_VERSION="5ad3eaf"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2003-plus-libretro"

--- a/packages/libretro/mame2016/package.mk
+++ b/packages/libretro/mame2016/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mame2016"
-PKG_VERSION="d53c379"
+PKG_VERSION="69711c2"
 PKG_ARCH="x86_64 aarch64 arm"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/mame2016-libretro"

--- a/packages/libretro/mgba/package.mk
+++ b/packages/libretro/mgba/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mgba"
-PKG_VERSION="033e067"
+PKG_VERSION="ea57ba2"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2.0"
 PKG_SITE="https://github.com/libretro/mgba"

--- a/packages/libretro/mu/package.mk
+++ b/packages/libretro/mu/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mu"
-PKG_VERSION="7ead066"
+PKG_VERSION="be844bf"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/neocd/package.mk
+++ b/packages/libretro/neocd/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="neocd"
-PKG_VERSION="33b8f9c"
+PKG_VERSION="83d10f3"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv3"
 PKG_SITE="https://github.com/libretro/neocd_libretro"

--- a/packages/libretro/nestopia/package.mk
+++ b/packages/libretro/nestopia/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="nestopia"
-PKG_VERSION="ea6f1c0"
+PKG_VERSION="b4e4c8f"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/nestopia"

--- a/packages/libretro/nxengine/package.mk
+++ b/packages/libretro/nxengine/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="nxengine"
-PKG_VERSION="7bf5e62"
+PKG_VERSION="4e2ea9f"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/nxengine-libretro"

--- a/packages/libretro/o2em/package.mk
+++ b/packages/libretro/o2em/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="o2em"
-PKG_VERSION="c039e83"
+PKG_VERSION="f105024"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Artistic License"

--- a/packages/libretro/opera/package.mk
+++ b/packages/libretro/opera/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="opera"
-PKG_VERSION="d8aa7ce"
+PKG_VERSION="aa868e6"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL with additional notes"

--- a/packages/libretro/pcsx2/package.mk
+++ b/packages/libretro/pcsx2/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pcsx2"
-PKG_VERSION="10cc4e2"
+PKG_VERSION="26890da"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/picodrive/package.mk
+++ b/packages/libretro/picodrive/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="picodrive"
-PKG_VERSION="9cb99ce"
+PKG_VERSION="d44605c"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/picodrive"

--- a/packages/libretro/play/package.mk
+++ b/packages/libretro/play/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="play"
-PKG_VERSION="6859937"
+PKG_VERSION="695cb21"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/jpd002/Play-"

--- a/packages/libretro/pocketcdg/package.mk
+++ b/packages/libretro/pocketcdg/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pocketcdg"
-PKG_VERSION="71cc5e8"
+PKG_VERSION="bcbd8dc"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/libretro/pokemini/package.mk
+++ b/packages/libretro/pokemini/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pokemini"
-PKG_VERSION="b24883d"
+PKG_VERSION="0e0adda"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/ppsspp/package.mk
+++ b/packages/libretro/ppsspp/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="ppsspp"
-PKG_VERSION="ce0a45c"
+PKG_VERSION="e1ff730"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/hrydgard/ppsspp"

--- a/packages/libretro/prboom/package.mk
+++ b/packages/libretro/prboom/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="prboom"
-PKG_VERSION="0f5927d"
+PKG_VERSION="a439904"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/prosystem/package.mk
+++ b/packages/libretro/prosystem/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="prosystem"
-PKG_VERSION="f8652c7"
+PKG_VERSION="89e6df7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/puae/package.mk
+++ b/packages/libretro/puae/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="puae"
-PKG_VERSION="f151bab"
+PKG_VERSION="3ec4903"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-uae"

--- a/packages/libretro/px68k/package.mk
+++ b/packages/libretro/px68k/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="px68k"
-PKG_VERSION="ea6e5a7"
+PKG_VERSION="b309941"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Unknown"

--- a/packages/libretro/quicknes/package.mk
+++ b/packages/libretro/quicknes/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="quicknes"
-PKG_VERSION="71b8000"
+PKG_VERSION="2e7aca5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"

--- a/packages/libretro/retroarch-joypad-autoconfig/package.mk
+++ b/packages/libretro/retroarch-joypad-autoconfig/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch-joypad-autoconfig"
-PKG_VERSION="dbb3252"
+PKG_VERSION="28a69b2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch"
-PKG_VERSION="fca72f6"
+PKG_VERSION="06a2367"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/RetroArch"

--- a/packages/libretro/sameboy/package.mk
+++ b/packages/libretro/sameboy/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="sameboy"
-PKG_VERSION="68f67b3"
+PKG_VERSION="685c6c8"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/libretro/sameboy"

--- a/packages/libretro/slang-shaders/package.mk
+++ b/packages/libretro/slang-shaders/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="slang-shaders"
-PKG_VERSION="72eb5c1"
+PKG_VERSION="505f464"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/stella/package.mk
+++ b/packages/libretro/stella/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="stella"
-PKG_VERSION="cb02e45"
+PKG_VERSION="ab1768a"
 PKG_ARCH="any"
 PKG_REV="1"
 PKG_LICENSE="GPL2"

--- a/packages/libretro/stella2014/package.mk
+++ b/packages/libretro/stella2014/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="stella2014"
-PKG_VERSION="2f4855d"
+PKG_VERSION="934c7a2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/swanstation/package.mk
+++ b/packages/libretro/swanstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present Lakka Team)
 
 PKG_NAME="swanstation"
-PKG_VERSION="b6f76ff"
+PKG_VERSION="8951ed1"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://github.com/libretro/swanstation"
 PKG_URL="$PKG_SITE.git"

--- a/packages/libretro/tic80/package.mk
+++ b/packages/libretro/tic80/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="tic80"
-PKG_VERSION="2646b62"
+PKG_VERSION="600341d"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/nesbox/TIC-80"

--- a/packages/libretro/tyrquake/package.mk
+++ b/packages/libretro/tyrquake/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="tyrquake"
-PKG_VERSION="19aa11e"
+PKG_VERSION="423a217"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/uae4arm/package.mk
+++ b/packages/libretro/uae4arm/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="uae4arm"
-PKG_VERSION="4d2e723"
+PKG_VERSION="96fd90b"
 PKG_REV="1"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"

--- a/packages/libretro/vbam/package.mk
+++ b/packages/libretro/vbam/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="vbam"
-PKG_VERSION="89028de"
+PKG_VERSION="972f151"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/visualboyadvance-m/visualboyadvance-m"

--- a/packages/libretro/vice/package.mk
+++ b/packages/libretro/vice/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="vice"
-PKG_VERSION="c2b8877"
+PKG_VERSION="9a0ca16"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vice-libretro"

--- a/packages/libretro/virtualjaguar/package.mk
+++ b/packages/libretro/virtualjaguar/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="virtualjaguar"
-PKG_VERSION="fa689cc"
+PKG_VERSION="d1b1b28"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/virtualjaguar-libretro"

--- a/packages/libretro/yabause/package.mk
+++ b/packages/libretro/yabause/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="yabause"
-PKG_VERSION="811f9e8"
+PKG_VERSION="0f9381b"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/yabause"


### PR DESCRIPTION
This updates RetroArch to 1.9.14, along with brings in the latest cores.