### PR TITLE
libretro-database: Update to the latest RDB files

### DIFF
--- a/packages/libretro/libretro-database/package.mk
+++ b/packages/libretro/libretro-database/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="libretro-database"
-PKG_VERSION="ec58b9d"
+PKG_VERSION="c65232b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
This updates libretro-database to the latest. Looks like there was a file that fails to check out on the current commit, so updating should fix it.