### PR TITLE
libretro: play: Rollback for older CMake

### DIFF
--- a/packages/libretro/play/package.mk
+++ b/packages/libretro/play/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="play"
-PKG_VERSION="695cb21"
+PKG_VERSION="772bc53"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/jpd002/Play-"


### PR DESCRIPTION
The updated version of Play! requires CMake version 3.15, which is not yet available on our infrastructure. This change rolls back to the previous version of Play!.