### PR TITLE
libretro: mame2003-plus: Update to the latest

### DIFF
--- a/packages/libretro/mame2003-plus/package.mk
+++ b/packages/libretro/mame2003-plus/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame2003-plus"
-PKG_VERSION="5ad3eaf"
+PKG_VERSION="2bc0992"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2003-plus-libretro"


### PR DESCRIPTION
This updates the mame2003-plus core to the latest as investigation on TickerBoard failing on #1577.