### PR TITLE
ntfs-3g_ntfsprogs: fix download location

### DIFF
--- a/packages/sysutils/ntfs-3g_ntfsprogs/package.mk
+++ b/packages/sysutils/ntfs-3g_ntfsprogs/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="ntfs-3g_ntfsprogs"
-PKG_VERSION="2017.3.23AR.5"
-PKG_SHA256="04ccf583b495806cefb71850e5899e50aed5e7bf23365259f2badaa9af21e5ed"
+PKG_VERSION="2021.8.22"
+PKG_SHA256="5cb9fa93bf2b9685e3f1b598861f6082786e76562989a5752c7379dbe0e989a2"
 PKG_LICENSE="GPL"
-PKG_SITE="https://jp-andre.pagesperso-orange.fr/"
-PKG_URL="https://jp-andre.pagesperso-orange.fr/${PKG_NAME}-${PKG_VERSION}.tgz"
+PKG_SITE="https://github.com/tuxera/ntfs-3g"
+PKG_URL="${PKG_SITE}/archive/refs/tags/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain fuse libgcrypt"
 PKG_LONGDESC="A NTFS driver with read and write support."
 PKG_TOOLCHAIN="autotools"


### PR DESCRIPTION
It's moved to github: https://jp-andre.pagesperso-orange.fr/advanced-ntfs-3g.html

LibreELEC have removed it (https://github.com/LibreELEC/LibreELEC.tv/commit/f6e648aad8c5725f22a60fd6ffded6e7cdd33566) possibly because there's a kernel implementation in 5.15 but we're on 5.10