### PR TITLE
libretro: Update RetroArch to 1.10.0 and Libretro cores to latest

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # v3.7
-* Update RetroArch to 1.9.14
+* Update RetroArch to 1.10.0
 * Update libretro cores to the latest
+* Add [small utility](https://github.com/spleen1981/xbox360-controllers-shutdown) to turn off Xbox360 controllers
+* Fix AML aarch64 cores compilation
 
 # v3.6
 * Update RetroArch to 1.9.13.1

--- a/packages/libretro/81/package.mk
+++ b/packages/libretro/81/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="81"
-PKG_VERSION="7e8153c"
+PKG_VERSION="86d7d5a"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/beetle-lynx/package.mk
+++ b/packages/libretro/beetle-lynx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-lynx"
-PKG_VERSION="5d1ce06"
+PKG_VERSION="d7e4891"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-pce-fast/package.mk
+++ b/packages/libretro/beetle-pce-fast/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-pce-fast"
-PKG_VERSION="f49139e"
+PKG_VERSION="edefc86"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-pce/package.mk
+++ b/packages/libretro/beetle-pce/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-pce"
-PKG_VERSION="31878a7"
+PKG_VERSION="bada12b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/beetle-psx/package.mk
+++ b/packages/libretro/beetle-psx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-psx"
-PKG_VERSION="4a0cab1"
+PKG_VERSION="a5139d8"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-psx-libretro"

--- a/packages/libretro/beetle-supergrafx/package.mk
+++ b/packages/libretro/beetle-supergrafx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-supergrafx"
-PKG_VERSION="18eac95"
+PKG_VERSION="39f1a04"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-supergrafx-libretro"

--- a/packages/libretro/beetle-wswan/package.mk
+++ b/packages/libretro/beetle-wswan/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="beetle-wswan"
-PKG_VERSION="ea00c1d"
+PKG_VERSION="18df235"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-wswan-libretro"

--- a/packages/libretro/bluemsx/package.mk
+++ b/packages/libretro/bluemsx/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="bluemsx"
-PKG_VERSION="cfc1df4"
+PKG_VERSION="5dfdb75"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/blueMSX-libretro"

--- a/packages/libretro/cap32/package.mk
+++ b/packages/libretro/cap32/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="cap32"
-PKG_VERSION="06ba0e5"
+PKG_VERSION="b8f09a0"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-cap32"

--- a/packages/libretro/chailove/package.mk
+++ b/packages/libretro/chailove/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="chailove"
-PKG_VERSION="1ae544b"
+PKG_VERSION="9604633"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/libretro/libretro-chailove"

--- a/packages/libretro/core-info/package.mk
+++ b/packages/libretro/core-info/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="core-info"
-PKG_VERSION="3c3e2d6"
+PKG_VERSION="165d3a0"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-core-info"

--- a/packages/libretro/dinothawr/package.mk
+++ b/packages/libretro/dinothawr/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="dinothawr"
-PKG_VERSION="2e78902"
+PKG_VERSION="d9ed9c8"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/libretro/Dinothawr"

--- a/packages/libretro/dolphin/package.mk
+++ b/packages/libretro/dolphin/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="dolphin"
-PKG_VERSION="48066c8"
+PKG_VERSION="3b19e6d"
 PKG_ARCH="x86_64 aarch64"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/dolphin"

--- a/packages/libretro/dosbox-pure/package.mk
+++ b/packages/libretro/dosbox-pure/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="dosbox-pure"
-PKG_VERSION="3d0266b"
+PKG_VERSION="d22a43d"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/dosbox-pure"

--- a/packages/libretro/dosbox-svn/package.mk
+++ b/packages/libretro/dosbox-svn/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="dosbox-svn"
-PKG_VERSION="ba9e181"
+PKG_VERSION="4f2b9ca"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/ecwolf/package.mk
+++ b/packages/libretro/ecwolf/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="ecwolf"
-PKG_VERSION="30c4192"
+PKG_VERSION="21d2f0a"
 PKG_ARCH="any"
 PKG_LICENSE="Unknown"
 PKG_SITE="https://github.com/libretro/ecwolf"

--- a/packages/libretro/fbneo/package.mk
+++ b/packages/libretro/fbneo/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fbneo"
-PKG_VERSION="7f80e61"
+PKG_VERSION="6046f32"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/libretro/fbneo"

--- a/packages/libretro/fceumm/package.mk
+++ b/packages/libretro/fceumm/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fceumm"
-PKG_VERSION="02b5bbf"
+PKG_VERSION="3923dd5"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/libretro-fceumm"

--- a/packages/libretro/flycast/package.mk
+++ b/packages/libretro/flycast/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="flycast"
-PKG_VERSION="e61951a"
+PKG_VERSION="4e21391"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/flyinghead/flycast"

--- a/packages/libretro/freeintv/package.mk
+++ b/packages/libretro/freeintv/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="freeintv"
-PKG_VERSION="0058a09"
+PKG_VERSION="d58caf2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"

--- a/packages/libretro/fuse-libretro/package.mk
+++ b/packages/libretro/fuse-libretro/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="fuse-libretro"
-PKG_VERSION="23f7db5"
+PKG_VERSION="bfacfc0"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/fuse-libretro"

--- a/packages/libretro/gambatte/package.mk
+++ b/packages/libretro/gambatte/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="gambatte"
-PKG_VERSION="ef2a160"
+PKG_VERSION="0eeb15d"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/gambatte-libretro"

--- a/packages/libretro/gearboy/package.mk
+++ b/packages/libretro/gearboy/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="gearboy"
-PKG_VERSION="8910d6f"
+PKG_VERSION="2ce4231"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/drhelius/Gearboy"

--- a/packages/libretro/gearsystem/package.mk
+++ b/packages/libretro/gearsystem/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="gearsystem"
-PKG_VERSION="8a28a28"
+PKG_VERSION="005afd2"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/drhelius/Gearsystem"

--- a/packages/libretro/glsl-shaders/package.mk
+++ b/packages/libretro/glsl-shaders/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="glsl-shaders"
-PKG_VERSION="f57cc73"
+PKG_VERSION="a2afb95"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/gpsp/package.mk
+++ b/packages/libretro/gpsp/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="gpsp"
-PKG_VERSION="7b181cb6ff319df9c9be00dae3ab0afafd63de52"
+PKG_VERSION="e554360"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/gpsp"

--- a/packages/libretro/handy/package.mk
+++ b/packages/libretro/handy/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="handy"
-PKG_VERSION="c5cccb5"
+PKG_VERSION="fc5c02e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Zlib"

--- a/packages/libretro/hatari/package.mk
+++ b/packages/libretro/hatari/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="hatari"
-PKG_VERSION="cea06ee"
+PKG_VERSION="79d1288"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/kronos/package.mk
+++ b/packages/libretro/kronos/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="kronos"
-PKG_VERSION="146f429"
+PKG_VERSION="9bb35a8"
 PKG_GIT_CLONE_BRANCH="kronos"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/yabause"

--- a/packages/libretro/libretro-database/package.mk
+++ b/packages/libretro/libretro-database/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="libretro-database"
-PKG_VERSION="c65232b"
+PKG_VERSION="18589ea"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/lutro/package.mk
+++ b/packages/libretro/lutro/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="lutro"
-PKG_VERSION="777515a"
+PKG_VERSION="ba4b4f2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/libretro/mame/package.mk
+++ b/packages/libretro/mame/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame"
-PKG_VERSION="031ac78"
+PKG_VERSION="ec47e94"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"

--- a/packages/libretro/mame2003-plus/package.mk
+++ b/packages/libretro/mame2003-plus/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mame2003-plus"
-PKG_VERSION="2bc0992"
+PKG_VERSION="3f608e3"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/mame2003-plus-libretro"

--- a/packages/libretro/mame2015/package.mk
+++ b/packages/libretro/mame2015/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="mame2015"
-PKG_VERSION="ef41361"
+PKG_VERSION="e6a7aa4"
 PKG_REV="1"
 PKG_ARCH="x86_64 aarch64 arm"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/mame2016/package.mk
+++ b/packages/libretro/mame2016/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mame2016"
-PKG_VERSION="69711c2"
+PKG_VERSION="bcff804"
 PKG_ARCH="x86_64 aarch64 arm"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/mame2016-libretro"

--- a/packages/libretro/melonds/package.mk
+++ b/packages/libretro/melonds/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="melonds"
-PKG_VERSION="1ad6572"
+PKG_VERSION="e6e16ed"
 PKG_ARCH="x86_64 aarch64"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/melonds"

--- a/packages/libretro/mgba/package.mk
+++ b/packages/libretro/mgba/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mgba"
-PKG_VERSION="ea57ba2"
+PKG_VERSION="0104bb8"
 PKG_ARCH="any"
 PKG_LICENSE="MPLv2.0"
 PKG_SITE="https://github.com/libretro/mgba"

--- a/packages/libretro/mu/package.mk
+++ b/packages/libretro/mu/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mu"
-PKG_VERSION="be844bf"
+PKG_VERSION="2954a42"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/mupen64plus_next/package.mk
+++ b/packages/libretro/mupen64plus_next/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="mupen64plus_next"
-PKG_VERSION="018ee72"
+PKG_VERSION="350f90a"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/mupen64plus-libretro-nx"

--- a/packages/libretro/nestopia/package.mk
+++ b/packages/libretro/nestopia/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="nestopia"
-PKG_VERSION="b4e4c8f"
+PKG_VERSION="def66a5"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/nestopia"

--- a/packages/libretro/np2kai/package.mk
+++ b/packages/libretro/np2kai/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="np2kai"
-PKG_VERSION="3e8fedc"
+PKG_VERSION="2b09ea6"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/libretro/nxengine/package.mk
+++ b/packages/libretro/nxengine/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="nxengine"
-PKG_VERSION="4e2ea9f"
+PKG_VERSION="45bae99"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/nxengine-libretro"

--- a/packages/libretro/opera/package.mk
+++ b/packages/libretro/opera/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="opera"
-PKG_VERSION="aa868e6"
+PKG_VERSION="3849c96"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL with additional notes"

--- a/packages/libretro/parallel-n64/package.mk
+++ b/packages/libretro/parallel-n64/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="parallel-n64"
-PKG_VERSION="0a67445"
+PKG_VERSION="28c4572"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/parallel-n64"

--- a/packages/libretro/pcsx2/package.mk
+++ b/packages/libretro/pcsx2/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pcsx2"
-PKG_VERSION="26890da"
+PKG_VERSION="7d741b5"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/pcsx_rearmed/package.mk
+++ b/packages/libretro/pcsx_rearmed/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pcsx_rearmed"
-PKG_VERSION="589bd99"
+PKG_VERSION="dfe6947"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/pcsx_rearmed"

--- a/packages/libretro/picodrive/package.mk
+++ b/packages/libretro/picodrive/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="picodrive"
-PKG_VERSION="d44605c"
+PKG_VERSION="50b8b47"
 PKG_ARCH="any"
 PKG_LICENSE="MAME"
 PKG_SITE="https://github.com/libretro/picodrive"

--- a/packages/libretro/pocketcdg/package.mk
+++ b/packages/libretro/pocketcdg/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pocketcdg"
-PKG_VERSION="bcbd8dc"
+PKG_VERSION="c7b3aad"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/libretro/ppsspp/package.mk
+++ b/packages/libretro/ppsspp/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="ppsspp"
-PKG_VERSION="e1ff730"
+PKG_VERSION="77502db"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/hrydgard/ppsspp"

--- a/packages/libretro/prboom/package.mk
+++ b/packages/libretro/prboom/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="prboom"
-PKG_VERSION="a439904"
+PKG_VERSION="4191903"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/puae/package.mk
+++ b/packages/libretro/puae/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="puae"
-PKG_VERSION="3ec4903"
+PKG_VERSION="5dad957"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-uae"

--- a/packages/libretro/quicknes/package.mk
+++ b/packages/libretro/quicknes/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="quicknes"
-PKG_VERSION="2e7aca5"
+PKG_VERSION="176520b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPLv2.1+"

--- a/packages/libretro/retroarch-assets/package.mk
+++ b/packages/libretro/retroarch-assets/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch-assets"
-PKG_VERSION="9c22505"
+PKG_VERSION="6320719"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/retroarch-joypad-autoconfig/package.mk
+++ b/packages/libretro/retroarch-joypad-autoconfig/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch-joypad-autoconfig"
-PKG_VERSION="28a69b2"
+PKG_VERSION="6285b70"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="retroarch"
-PKG_VERSION="06a2367"
+PKG_VERSION="b71be7e"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/RetroArch"

--- a/packages/libretro/sameboy/package.mk
+++ b/packages/libretro/sameboy/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="sameboy"
-PKG_VERSION="685c6c8"
+PKG_VERSION="b154b7d"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"
 PKG_SITE="https://github.com/libretro/sameboy"

--- a/packages/libretro/scummvm/package.mk
+++ b/packages/libretro/scummvm/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="scummvm"
-PKG_VERSION="63e5757"
+PKG_VERSION="80cb726"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/scummvm"

--- a/packages/libretro/slang-shaders/package.mk
+++ b/packages/libretro/slang-shaders/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="slang-shaders"
-PKG_VERSION="505f464"
+PKG_VERSION="1cf765b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/snes9x/package.mk
+++ b/packages/libretro/snes9x/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x"
-PKG_VERSION="fb93aed"
+PKG_VERSION="c557884"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"
 PKG_SITE="https://github.com/libretro/snes9x"

--- a/packages/libretro/snes9x2005/package.mk
+++ b/packages/libretro/snes9x2005/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x2005"
-PKG_VERSION="88a46f7"
+PKG_VERSION="01564ac"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/snes9x2005_plus/package.mk
+++ b/packages/libretro/snes9x2005_plus/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="snes9x2005_plus"
-PKG_VERSION="88a46f7"
+PKG_VERSION="01564ac"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"

--- a/packages/libretro/stella/package.mk
+++ b/packages/libretro/stella/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="stella"
-PKG_VERSION="ab1768a"
+PKG_VERSION="8875e04"
 PKG_ARCH="any"
 PKG_REV="1"
 PKG_LICENSE="GPL2"

--- a/packages/libretro/swanstation/package.mk
+++ b/packages/libretro/swanstation/package.mk
@@ -2,7 +2,7 @@
 # Copyright (C) 2021-present Lakka Team)
 
 PKG_NAME="swanstation"
-PKG_VERSION="8951ed1"
+PKG_VERSION="bbd7398"
 PKG_LICENSE="GPL-3.0-or-later"
 PKG_SITE="https://github.com/libretro/swanstation"
 PKG_URL="$PKG_SITE.git"

--- a/packages/libretro/tic80/package.mk
+++ b/packages/libretro/tic80/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="tic80"
-PKG_VERSION="600341d"
+PKG_VERSION="e463cc6"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/nesbox/TIC-80"

--- a/packages/libretro/vbam/package.mk
+++ b/packages/libretro/vbam/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="vbam"
-PKG_VERSION="972f151"
+PKG_VERSION="65b5aff"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/visualboyadvance-m/visualboyadvance-m"

--- a/packages/libretro/vice/package.mk
+++ b/packages/libretro/vice/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="vice"
-PKG_VERSION="9a0ca16"
+PKG_VERSION="ed7acff"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/vice-libretro"

--- a/packages/libretro/yabause/package.mk
+++ b/packages/libretro/yabause/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="yabause"
-PKG_VERSION="0f9381b"
+PKG_VERSION="d50f64e"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/yabause"


### PR DESCRIPTION
- Updates RetroArch to 1.10.0 and to latest cores.
- Keep Play! core [commit](https://github.com/libretro/Lakka-LibreELEC/pull/1579).
- Update Changelog.