### PR TITLE
citra: Update to latest version of Citra

### DIFF
--- a/packages/libretro/citra/package.mk
+++ b/packages/libretro/citra/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="citra"
-PKG_VERSION="b1959d0"
+PKG_VERSION="0a837db"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPLv2+"


### PR DESCRIPTION
This updates to the latest version of Citra, at https://github.com/libretro/citra/commit/0a837dbfcf0a435eb05b2bef5ad5b05210fbcc80 .
