### PR TITLE
Fix retroarch recording/streaming In Lakka 3.x

### DIFF
--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -157,6 +157,8 @@ pre_make_target() {
   if [ "$LAKKA_NIGHTLY" = yes ]; then
     HAVE_LAKKA_NIGHTLY="HAVE_LAKKA_NIGHTLY=1"
   fi
+  CFLAGS=${CFLAGS/"-Os"/"-O2"}
+  CFLAGS=${CFLAGS/"-O3"/"-O2"}
 }
 
 make_target() {

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -10,6 +10,9 @@ PKG_LICENSE="LGPLv2.1+"
 PKG_SITE="https://ffmpeg.org"
 PKG_URL="https://github.com/xbmc/FFmpeg/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain zlib bzip2 openssl speex"
+if [ "$DISTRO" = "Lakka" ]; then
+  PKG_DEPENDS_TARGET+=" libx264 lame rtmpdump"
+fi
 PKG_LONGDESC="FFmpeg is a complete, cross-platform solution to record, convert and stream audio and video."
 PKG_BUILD_FLAGS="-gold"
 
@@ -102,26 +105,7 @@ pre_configure_target() {
 }
 
 configure_target() {
-  ./configure --prefix="/usr" \
-              --cpu="$TARGET_CPU" \
-              --arch="$TARGET_ARCH" \
-              --enable-cross-compile \
-              --cross-prefix="$TARGET_PREFIX" \
-              --sysroot="$SYSROOT_PREFIX" \
-              --sysinclude="$SYSROOT_PREFIX/usr/include" \
-              --target-os="linux" \
-              --nm="$NM" \
-              --ar="$AR" \
-              --as="$CC" \
-              --cc="$CC" \
-              --ld="$CC" \
-              --host-cc="$HOST_CC" \
-              --host-cflags="$HOST_CFLAGS" \
-              --host-ldflags="$HOST_LDFLAGS" \
-              --extra-cflags="$CFLAGS" \
-              --extra-ldflags="$LDFLAGS" \
-              --extra-libs="$PKG_FFMPEG_LIBS" \
-              --disable-static \
+  CONFIG_OPTIONS_STANDARD_FFMPEG=" --disable-static \
               --enable-shared \
               --enable-gpl \
               --disable-version3 \
@@ -208,7 +192,48 @@ configure_target() {
               --disable-altivec \
               $PKG_FFMPEG_FPU \
               --disable-symver \
-              $PKG_FFMPEG_NVMPI
+              $PKG_FFMPEG_NVMPI"
+
+if [  "$DISTRO" = "Lakka" ]; then
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--disable-encoders "/"--enable-encoders "}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--enable-encoder=ac3 "/""}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--enable-encoder=aac "/""}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--enable-encoder=wmav2 "/""}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--enable-encoder=mjpeg "/""}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--enable-encoder=png "/""}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--disable-muxers "/"--enable-muxers "}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--enable-muxer=spdif "/""}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--enable-muxer=adts "/""}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--enable-muxer=asf "/""}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--enable-muxer=ipod "/""}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--enable-muxer=mpegts "/""}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--disable-libmp3lame "/"--enable-libmp3lame "}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--disable-librtmp  "/"--enable-librtmp "}
+    CONFIG_OPTIONS_STANDARD_FFMPEG=${CONFIG_OPTIONS_STANDARD_FFMPEG/"--disable-libx264 "/"--enable-libx264 "}
+  fi
+
+
+./configure --prefix="/usr" \
+              --cpu="$TARGET_CPU" \
+              --arch="$TARGET_ARCH" \
+              --enable-cross-compile \
+              --cross-prefix="$TARGET_PREFIX" \
+              --sysroot="$SYSROOT_PREFIX" \
+              --sysinclude="$SYSROOT_PREFIX/usr/include" \
+              --target-os="linux" \
+              --nm="$NM" \
+              --ar="$AR" \
+              --as="$CC" \
+              --cc="$CC" \
+              --ld="$CC" \
+              --host-cc="$HOST_CC" \
+              --host-cflags="$HOST_CFLAGS" \
+              --host-ldflags="$HOST_LDFLAGS" \
+              --extra-cflags="$CFLAGS" \
+              --extra-ldflags="$LDFLAGS" \
+              --extra-libs="$PKG_FFMPEG_LIBS" \
+              --pkg-config="$TOOLCHAIN/bin/pkg-config" \
+              $CONFIG_OPTION_STANDARD_FFMPEG
 }
 
 post_makeinstall_target() {

--- a/packages/multimedia/libx264/package.mk
+++ b/packages/multimedia/libx264/package.mk
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
+# Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
+PKG_NAME="libx264"
+PKG_VERSION="6d10612ab0007f8f60dd2399182efd696da3ffe4"
+PKG_LICENSE="Videolan(?)"
+PKG_SITE="https://code.videolan.org/videolan/x264"
+PKG_URL="${PKG_SITE}".git
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Software based x264 decoder/encoder"
+PKG_TOOLCHAIN="configure"
+
+PKG_CONFIGURE_OPTS_TARGET+="--cross-prefix=${TARGET_PREFIX} \
+              --sysroot=${SYSROOT_PREFIX} \
+              --disable-asm"


### PR DESCRIPTION
This is untested by me in 3.x, but the same patch works in 4.x, I just rebased it on 3.x tree, so it would get into a pr build, so it can be tested on other boards.