### PR TITLE
linux: build noveau as module

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -217,7 +217,7 @@ pre_make_target() {
   # enable nouveau driver when required
   if [ ! "${LINUX}" = "L4T" ]; then
     if listcontains "${GRAPHIC_DRIVERS}" "nouveau"; then
-      ${PKG_BUILD}/scripts/config --enable CONFIG_DRM_NOUVEAU
+      ${PKG_BUILD}/scripts/config --module CONFIG_DRM_NOUVEAU
       ${PKG_BUILD}/scripts/config --enable CONFIG_DRM_NOUVEAU_BACKLIGHT
       ${PKG_BUILD}/scripts/config --set-val CONFIG_NOUVEAU_DEBUG 5
       ${PKG_BUILD}/scripts/config --set-val CONFIG_NOUVEAU_DEBUG_DEFAULT 3


### PR DESCRIPTION
issue reported on discord. in dmesg it showed that it could not find nvidia firmware:
```
[    0.910062] fb0: switching to nouveaufb from EFI VGA
[    0.910088] Console: switching to colour dummy device 80x25
[    0.910094] nouveau 0000:08:00.0: vgaarb: deactivate vga console
[    0.910119] nouveau 0000:08:00.0: NVIDIA GM206 (126010a1)
[    1.002317] nouveau 0000:08:00.0: bios: version 84.06.0d.00.41
[    1.002425] nouveau 0000:08:00.0: acr: firmware unavailable
[    1.002427] nouveau 0000:08:00.0: pmu: firmware unavailable
[    1.002461] nouveau 0000:08:00.0: gr: firmware unavailable
[    1.002779] nouveau 0000:08:00.0: fb: 2048 MiB GDDR5
[    1.002797] nouveau 0000:08:00.0: bus: MMIO write of 80000078 FAULT at 10eb14 [ IBUS ]
```
the user was stuck in the console and retroarch could not start:
```
MESA-LOADER: failed to open kms_swrast: /usr/lib/dri/kms_swrast_dri.so: cannot open shared object file: No such file or directory (search paths /usr/lib/dri, suffix _dri)
failed to load driver: kms_swrast
MESA-LOADER: failed to open swrast: /usr/lib/dri/swrast_dri.so: cannot open shared object file: No such file or directory (search paths /usr/lib/dri, suffix _dri)
failed to load swrast driver
[WARN] [KMS]: Couldn't create GBM device.
[WARN] [DRM]: Couldn't get device resources.
[ERROR] [KMS]: Couldn't find a suitable DRM device.
[INFO] [GL]: Found GL context: "null".
[INFO] [GL]: Detecting screen resolution: 320x240.
[INFO] [GL]: Vendor: (null), Renderer: (null).
[INFO] [GL]: Version: (null).
Segmentation fault
```
as firmware was a first suspect, image excluding amdgpu firmwares but including nvidia firmwares in kernel as external firmwares was built and retroarch started successfully. problem is that adding additional firmwares to external firmwares in kernel causes the build to fail due to "too long argument" (list of firmwares). after setting the driver to be built as module, which is then loaded at later time of the boot, when the kernel firmware overlays are available, the driver found the required firmwares and retroarch started successfully.