### PR TITLE
Amlogic: disable composite output on tvboxes

### DIFF
--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -26,6 +26,11 @@
   # kernel serial console
     EXTRA_CMDLINE="systemd.debug_shell=ttyAML0 console=ttyAML0,115200n8 console=tty0"
 
+  # On tvbox force HDMI output by disabling composite
+    if [ "$UBOOT_SYSTEM" = "box" ]; then
+      EXTRA_CMDLINE+=" video=Composite-1:d"
+    fi
+
 ################################################################################
 # setup build defaults
 ################################################################################


### PR DESCRIPTION
Disable composite output to force retroarch to start on HDMI.
Fixes #1659 