### PR TITLE
add cec-mini-kb package

### DIFF
--- a/packages/lakka/lakka_tools/cec_mini_kb/package.mk
+++ b/packages/lakka/lakka_tools/cec_mini_kb/package.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# 2021 Giovanni Cascione
+
+PKG_NAME="cec_mini_kb"
+PKG_VERSION="be4289751bd80470c33847073a790b83356696db"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://github.com/spleen1981/cec-mini-kb"
+PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain libcec"
+PKG_LONGDESC="Small utility to use a CEC remote controller as a mini keyboard"
+PKG_TOOLCHAIN="make"
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/bin/
+  cp -v cec-mini-kb ${INSTALL}/usr/bin/
+}
+
+post_install() {
+  enable_service cec-mini-kb.service
+}

--- a/packages/lakka/lakka_tools/cec_mini_kb/system.d/cec-mini-kb.service
+++ b/packages/lakka/lakka_tools/cec_mini_kb/system.d/cec-mini-kb.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=cec-mini-kb
+DefaultDependencies=no
+
+[Service]
+ExecStart=/usr/bin/cec-mini-kb --poweroff "shutdown -P now"
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/lakka/package.mk
+++ b/packages/lakka/package.mk
@@ -35,3 +35,7 @@ fi
 if [ "${DEVICE}" != "Switch" -a "${DEVICE}" != "GPICase" -a "${DEVICE}" != "Pi02GPi" ]; then
   PKG_DEPENDS_TARGET+=" xbox360_controllers_shutdown"
 fi
+
+if [ "${CEC_FRAMEWORK_SUPPORT}" = yes ]; then
+  PKG_DEPENDS_TARGET+=" cec_mini_kb"
+fi


### PR DESCRIPTION
Add a small utility to use a CEC remote controller as a mini keyboard (libcec+uinput), to navigate RetroArch GUI and shutdown the system along with TV.