### PR TITLE
Switch: Add proper USB3 disable, and enable it by default

### DIFF
--- a/packages/lakka/lakka_tools/joycond/package.mk
+++ b/packages/lakka/lakka_tools/joycond/package.mk
@@ -1,9 +1,16 @@
 PKG_NAME="joycond"
-PKG_VERSION="2d3f553060291f1bfee2e49fc2ca4a768b289df8"
-PKG_SHA256="34ba2a4ffd35f2b2bbebd8ce47d17f2238d991bc6262653d0617b28f864e4b63"
 PKG_DEPENDS_TARGET="toolchain cmake:host libevdev systemd"
 PKG_SITE="https://github.com/DanielOgorchock/joycond"
-PKG_URL="https://github.com/DanielOgorchock/joycond/archive/${PKG_VERSION}.tar.gz"
+if [ "${PROJECT}" = "L4T" -a "${DEVICE}" = "Switch" ]; then
+  PKG_VERSION="031f04311a912514cea9deb020512ee6d7063398"
+  PKG_SHA256="fd1d3decad34941f7ec0ff5606c931cad3a7b5e644d70550cf602f3e833e66d8"
+  PKG_URL="https://gitlab.com/switchroot/userspace/joycond/-/archive/031f04311a912514cea9deb020512ee6d7063398/joycond-031f04311a912514cea9deb020512ee6d7063398.tar.gz"
+fi
+else
+  PKG_VERSION="2d3f553060291f1bfee2e49fc2ca4a768b289df8"
+  PKG_SHA256="34ba2a4ffd35f2b2bbebd8ce47d17f2238d991bc6262653d0617b28f864e4b63"
+  PKG_URL="https://github.com/DanielOgorchock/joycond/archive/${PKG_VERSION}.tar.gz"
+fi
 PKG_LONGDESC="Joycon service"
 
 PKG_TOOLCHAIN="cmake-make"

--- a/projects/L4T/devices/Switch/initramfs/platform_init
+++ b/projects/L4T/devices/Switch/initramfs/platform_init
@@ -7,9 +7,6 @@ echo 0 > /sys/class/graphics/fb0/blank;
 #sysfs poke for reboot2payload
 echo 1 > /sys/devices/r2p/default_payload_ready
 
-#Disable USB3 to fix joycons
-echo 0xffffffff > /sys/devices/70090000.xusb/downgrade_usb3
-
 #Set up Schedutil
 
 CPU_SCHEDUTIL_GOV=0

--- a/projects/L4T/devices/Switch/packages/switch-bootloader/assets/boot.txt
+++ b/projects/L4T/devices/Switch/packages/switch-bootloader/assets/boot.txt
@@ -6,6 +6,7 @@ setenv uartb "no_console_suspend console=ttyS1,115200,8n1"
 setenv cec_enable 0
 setenv performance_mode 0
 setenv dock_freq_switch_enabled 0
+setenv usb3_disable 0
 
 load mmc 1:1 0x83000000 @DISTRO_PATH@/KERNEL
 load mmc 1:1 0x8d000000 @DISTRO_PATH@/tegra210-icosa.dtb
@@ -107,6 +108,31 @@ if load mmc 1:1 ${fdtovaddr} @DISTRO_PATH@/uenv.txt && env import -t ${fdtovaddr
 		# Add additional bootargs for Serial USB
 		if test ${ov} = usb_logging; then setenv bootargs_extra ${usblogging} ${bootargs_extra}; echo Enabled usb serial logging; fi
 	done
+fi
+
+# Prepare display panel id from Nyx.
+cp.b 0xED838002 0xED838001 0x1
+mw.b 0xED838002 0x0 0x1
+
+# Get display panel handle.
+if itest.w *0xED838000 == 0xf20; then echo Display is INNO; fdt get value DHANDLE /host1x/dsi/panel-i-720p-6-2 phandle
+elif itest.w *0xED838000 == 0xf30; then echo Display is AUO; fdt get value DHANDLE /host1x/dsi/panel-a-720p-6-2 phandle
+elif itest.b *0xED838000 == 0x10; then echo Display is JDI; fdt get value DHANDLE /host1x/dsi/panel-j-720p-6-2 phandle
+else echo Display is Unknown; fi
+
+# Set new active display panel handle.
+if test -n ${DHANDLE}; then echo Setting Display panel; fdt resize 8192; fdt set /host1x/dsi nvidia,active-panel <$DHANDLE>; fi
+
+# Disable USB3
+if test ${usb3_disable} = 1; then
+  echo USB3 Disabled
+  fdt get value DHANDLE_USB2 /xusb_padctl@7009f000/pads/usb2/lanes/usb2-0 phandle
+  fdt set /xusb@70090000 phys <DHANDLE_USB2>
+  fdt set /xusb@70090000 phy-names usb2-0
+  fdt set /xudc@700d0000 phys <DHANDLE_USB2>
+  fdt set /xudc@700d0000 phy-names usb2
+  fdt set /xusb_padctl@7009f000/ports/usb2-0 nvidia,usb3-port-fake <0xffffffff>
+  fdt set /xusb_padctl@7009f000/ports/usb3-0 status disabled
 fi
 
 setenv bootargs ${bootargs_extra} "boot=/dev/mmcblk0p1 BOOT_IMAGE=@DISTRO_PATH@/KERNEL SYSTEM_IMAGE=@DISTRO_PATH@/SYSTEM ${@DISTRO_PATH@_boot_options} nofsck fat32-boot cec_enabled=${cec_enable} \

--- a/projects/L4T/devices/Switch/packages/switch-bootloader/assets/uenv.txt
+++ b/projects/L4T/devices/Switch/packages/switch-bootloader/assets/uenv.txt
@@ -45,6 +45,10 @@
 # Has a few minor caveots current implementation only changes clocks if they are on default handheld/dock hos clocks
 # As I didnt want to interfer with preset overclock settings in such a case even enabled, this should do nothing.
 #
+# usb3_disable
+# 0:off 1:on
+# Enabling this cleans up interference that causes issues with 2.4ghz wifi/bluetooth connections
+# By default this is enabled, disable if you want to use USB3, but know it degrades bluetooth, and wifi on 2.4ghz
 # =========================================================
 
 overlays=
@@ -56,3 +60,4 @@ uartb=no_console_suspend console=ttyS1,115200,8n1
 cec_enable=1
 performance_mode=0
 dock_freq_switch_enabled=0
+usb3_disable=1


### PR DESCRIPTION
Additionally add proper panel detection support which somehow got overlooked in previous updates.

USB3 disable fixes a lot of bluetooth/wifi 2.4ghz network issues, so I enabled it by default, but it is easily disabled by users who would prefer faster usb support over better wifi/joycon reliability.