### PR TITLE
Fix retroarch tmp- mount paths

### DIFF
--- a/packages/lakka/libretro_cores/cannonball/package.mk
+++ b/packages/lakka/libretro_cores/cannonball/package.mk
@@ -10,7 +10,7 @@ PKG_TOOLCHAIN="make"
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v cannonball_libretro.so ${INSTALL}/usr/lib/libretro/
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/cannonball/res/
-    cp -v res/{tilemap.bin,tilepatch.bin} docs/license.txt ${INSTALL}/usr/share/retroarch-system/cannonball/res/
-    cp -v roms/roms.txt ${INSTALL}/usr/share/retroarch-system/cannonball/
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/cannonball/res/
+    cp -v res/{tilemap.bin,tilepatch.bin} docs/license.txt ${INSTALL}/usr/share/retroarch/system/cannonball/res/
+    cp -v roms/roms.txt ${INSTALL}/usr/share/retroarch/system/cannonball/
 }

--- a/packages/lakka/libretro_cores/dinothawr/package.mk
+++ b/packages/lakka/libretro_cores/dinothawr/package.mk
@@ -14,6 +14,6 @@ fi
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v dinothawr_libretro.so ${INSTALL}/usr/lib/libretro/
-  mkdir -p ${INSTALL}/usr/share/retroarch-system
-    cp -rv dinothawr ${INSTALL}/usr/share/retroarch-system/
+  mkdir -p ${INSTALL}/usr/share/retroarch/system
+    cp -rv dinothawr ${INSTALL}/usr/share/retroarch/system/
 }

--- a/packages/lakka/libretro_cores/dolphin/package.mk
+++ b/packages/lakka/libretro_cores/dolphin/package.mk
@@ -32,6 +32,6 @@ PKG_CMAKE_OPTS_TARGET="-DENABLE_X11=OFF \
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v ${PKG_BUILD}/.${TARGET_NAME}/dolphin_libretro.so ${INSTALL}/usr/lib/libretro/
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/dolphin-emu
-    cp -vr ${PKG_BUILD}/Data/Sys ${INSTALL}/usr/share/retroarch-system/dolphin-emu/
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/dolphin-emu
+    cp -vr ${PKG_BUILD}/Data/Sys ${INSTALL}/usr/share/retroarch/system/dolphin-emu/
 }

--- a/packages/lakka/libretro_cores/ecwolf/package.mk
+++ b/packages/lakka/libretro_cores/ecwolf/package.mk
@@ -24,7 +24,7 @@ makeinstall_target() {
     echo "************************************************************"
   else
     echo "Packaging ecwolf.pk3..."
-    mkdir -p ${INSTALL}/usr/share/retroarch-system
-      7z a -mx9 -tzip ${INSTALL}/usr/share/retroarch-system/ecwolf.pk3 "${PKG_BUILD}/wadsrc/static/"* >/dev/null
+    mkdir -p ${INSTALL}/usr/share/retroarch/system
+      7z a -mx9 -tzip ${INSTALL}/usr/share/retroarch/system/ecwolf.pk3 "${PKG_BUILD}/wadsrc/static/"* >/dev/null
   fi
 }

--- a/packages/lakka/libretro_cores/fbneo/package.mk
+++ b/packages/lakka/libretro_cores/fbneo/package.mk
@@ -31,6 +31,6 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/usr/share/libretro-database/fbneo
     cp -vr dats/* ${INSTALL}/usr/share/libretro-database/fbneo
 
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/fbneo
-    cp metadata/hiscore.dat ${INSTALL}/usr/share/retroarch-system/fbneo
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/fbneo
+    cp metadata/hiscore.dat ${INSTALL}/usr/share/retroarch/system/fbneo
 }

--- a/packages/lakka/libretro_cores/mame/package.mk
+++ b/packages/lakka/libretro_cores/mame/package.mk
@@ -39,6 +39,6 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v mame_libretro.so ${INSTALL}/usr/lib/libretro/
 
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/mame
-    cp -vr artwork samples ${INSTALL}/usr/share/retroarch-system/mame
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/mame
+    cp -vr artwork samples ${INSTALL}/usr/share/retroarch/system/mame
 }

--- a/packages/lakka/libretro_cores/mame2003_plus/package.mk
+++ b/packages/lakka/libretro_cores/mame2003_plus/package.mk
@@ -18,9 +18,9 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/usr/share/libretro-database/mame2003-plus
     cp -v metadata/mame2003-plus.xml ${INSTALL}/usr/share/libretro-database/mame2003-plus
 
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/mame2003-plus/samples
-    cp -rv metadata/artwork ${INSTALL}/usr/share/retroarch-system/mame2003-plus
-    cp -v metadata/{cheat,hiscore,history}.dat ${INSTALL}/usr/share/retroarch-system/mame2003-plus
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/mame2003-plus/samples
+    cp -rv metadata/artwork ${INSTALL}/usr/share/retroarch/system/mame2003-plus
+    cp -v metadata/{cheat,hiscore,history}.dat ${INSTALL}/usr/share/retroarch/system/mame2003-plus
     # something must be in a folder in order to include it in the image, so why not some instructions
-    echo "Put your samples here." > ${INSTALL}/usr/share/retroarch-system/mame2003-plus/samples/readme.txt
+    echo "Put your samples here." > ${INSTALL}/usr/share/retroarch/system/mame2003-plus/samples/readme.txt
 }

--- a/packages/lakka/libretro_cores/nxengine/package.mk
+++ b/packages/lakka/libretro_cores/nxengine/package.mk
@@ -10,6 +10,6 @@ PKG_TOOLCHAIN="make"
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v nxengine_libretro.so ${INSTALL}/usr/lib/libretro/
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/nxengine
-    cp -vr datafiles/* ${INSTALL}/usr/share/retroarch-system/nxengine
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/nxengine
+    cp -vr datafiles/* ${INSTALL}/usr/share/retroarch/system/nxengine
 }

--- a/packages/lakka/libretro_cores/play/package.mk
+++ b/packages/lakka/libretro_cores/play/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="play"
-PKG_VERSION="18c5282dcd0dfdadc81986b441091707fd1b6206"
+PKG_VERSION="825b8cc50dabf46093c1bb6aefd82e3b294c01d0"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/jpd002/Play-"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/libretro_cores/ppsspp/package.mk
+++ b/packages/lakka/libretro_cores/ppsspp/package.mk
@@ -53,6 +53,6 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v lib/ppsspp_libretro.so ${INSTALL}/usr/lib/libretro/
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/PPSSPP
-    cp -rv assets/* ${INSTALL}/usr/share/retroarch-system/PPSSPP/
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/PPSSPP
+    cp -rv assets/* ${INSTALL}/usr/share/retroarch/system/PPSSPP/
 }

--- a/packages/lakka/libretro_cores/prboom/package.mk
+++ b/packages/lakka/libretro_cores/prboom/package.mk
@@ -10,6 +10,6 @@ PKG_TOOLCHAIN="make"
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v prboom_libretro.so ${INSTALL}/usr/lib/libretro/
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/
-    cp -v prboom.wad ${INSTALL}/usr/share/retroarch-system/
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/
+    cp -v prboom.wad ${INSTALL}/usr/share/retroarch/system/
 }

--- a/packages/lakka/libretro_cores/puae/package.mk
+++ b/packages/lakka/libretro_cores/puae/package.mk
@@ -10,6 +10,6 @@ PKG_TOOLCHAIN="make"
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v puae_libretro.so ${INSTALL}/usr/lib/libretro/
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/uae_data
-    cp -vR ${PKG_BUILD}/sources/uae_data/* ${INSTALL}/usr/share/retroarch-system/uae_data/
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/uae_data
+    cp -vR ${PKG_BUILD}/sources/uae_data/* ${INSTALL}/usr/share/retroarch/system/uae_data/
 }

--- a/packages/lakka/libretro_cores/puae2021/package.mk
+++ b/packages/lakka/libretro_cores/puae2021/package.mk
@@ -11,6 +11,6 @@ PKG_TOOLCHAIN="make"
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v puae2021_libretro.so ${INSTALL}/usr/lib/libretro/
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/uae_data
-    cp -vR ${PKG_BUILD}/sources/uae_data/* ${INSTALL}/usr/share/retroarch-system/uae_data/
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/uae_data
+    cp -vR ${PKG_BUILD}/sources/uae_data/* ${INSTALL}/usr/share/retroarch/system/uae_data/
 }

--- a/packages/lakka/libretro_cores/scummvm/package.mk
+++ b/packages/lakka/libretro_cores/scummvm/package.mk
@@ -20,13 +20,13 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v ../backends/platform/libretro/build/scummvm_libretro.so ${INSTALL}/usr/lib/libretro/
 
-  # unpack files to retroarch-system folder and create basic ini file
+  # unpack files to retroarch/system folder and create basic ini file
   if [ -f ${PKG_BUILD}/backends/platform/libretro/aux-data/scummvm.zip ]; then
-    mkdir -p ${INSTALL}/usr/share/retroarch-system
+    mkdir -p ${INSTALL}/usr/share/retroarch/system
       unzip ${PKG_BUILD}/backends/platform/libretro/aux-data/scummvm.zip \
-            -d ${INSTALL}/usr/share/retroarch-system
+            -d ${INSTALL}/usr/share/retroarch/system
 
-      cat << EOF > ${INSTALL}/usr/share/retroarch-system/scummvm.ini
+      cat << EOF > ${INSTALL}/usr/share/retroarch/system/scummvm.ini
 [scummvm]
 extrapath=/tmp/system/scummvm/extra
 browser_lastpath=/tmp/system/scummvm/extra

--- a/packages/lakka/libretro_cores/xrick/package.mk
+++ b/packages/lakka/libretro_cores/xrick/package.mk
@@ -16,6 +16,6 @@ pre_make_target() {
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v xrick_libretro.so ${INSTALL}/usr/lib/libretro/
-  mkdir -p ${INSTALL}/usr/share/retroarch-system/xrick
-    cp -v data.zip ${INSTALL}/usr/share/retroarch-system/xrick
+  mkdir -p ${INSTALL}/usr/share/retroarch/system/xrick
+    cp -v data.zip ${INSTALL}/usr/share/retroarch/system/xrick
 }

--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -164,8 +164,8 @@ makeinstall_target() {
     cp -v ${PKG_DIR}/scripts/retroarch-config ${INSTALL}/usr/lib/retroarch
 
   # System overlay
-  mkdir -p ${INSTALL}/usr/share/retroarch-system
-    touch ${INSTALL}/usr/share/retroarch-system/.placeholder
+  mkdir -p ${INSTALL}/usr/share/retroarch/system
+    touch ${INSTALL}/usr/share/retroarch/system/.placeholder
 
   # General configuration
   mkdir -p ${INSTALL}/etc

--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -212,7 +212,7 @@ makeinstall_target() {
   echo 'video_smooth = "false"' >> ${INSTALL}/etc/retroarch.cfg
   echo 'video_aspect_ratio_auto = "true"' >> ${INSTALL}/etc/retroarch.cfg
   echo 'video_threaded = "true"' >> ${INSTALL}/etc/retroarch.cfg
-  echo 'video_font_path = "/usr/share/retroarch-assets/xmb/monochrome/font.ttf"' >> ${INSTALL}/etc/retroarch.cfg
+  echo 'video_font_path = "/usr/share/retroarch/assets/xmb/monochrome/font.ttf"' >> ${INSTALL}/etc/retroarch.cfg
   echo 'video_font_size = "32"' >> ${INSTALL}/etc/retroarch.cfg
   echo 'video_filter_dir = "/usr/share/video_filters"' >> ${INSTALL}/etc/retroarch.cfg
   echo 'video_gpu_screenshot = "false"' >> ${INSTALL}/etc/retroarch.cfg

--- a/packages/lakka/retroarch_base/retroarch/system.d/tmp-assets.mount
+++ b/packages/lakka/retroarch_base/retroarch/system.d/tmp-assets.mount
@@ -9,7 +9,7 @@ DefaultDependencies=no
 What=none
 Where=/tmp/assets
 Type=overlay
-Options=lowerdir=/usr/share/retroarch-assets,upperdir=/storage/assets,workdir=/storage/.tmp/assets-workdir
+Options=lowerdir=/usr/share/retroarch/assets,upperdir=/storage/assets,workdir=/storage/.tmp/assets-workdir
 
 [Install]
 WantedBy=retroarch.target

--- a/packages/lakka/retroarch_base/retroarch/system.d/tmp-overlays.mount
+++ b/packages/lakka/retroarch_base/retroarch/system.d/tmp-overlays.mount
@@ -9,7 +9,7 @@ DefaultDependencies=no
 What=none
 Where=/tmp/overlays
 Type=overlay
-Options=lowerdir=/usr/share/retroarch-overlays,upperdir=/storage/overlays,workdir=/storage/.tmp/overlays-workdir
+Options=lowerdir=/usr/share/retroarch/overlays,upperdir=/storage/overlays,workdir=/storage/.tmp/overlays-workdir
 
 [Install]
 WantedBy=retroarch.target

--- a/packages/lakka/retroarch_base/retroarch/system.d/tmp-system.mount
+++ b/packages/lakka/retroarch_base/retroarch/system.d/tmp-system.mount
@@ -9,7 +9,7 @@ DefaultDependencies=no
 What=none
 Where=/tmp/system
 Type=overlay
-Options=lowerdir=/usr/share/retroarch-system,upperdir=/storage/system,workdir=/storage/.tmp/system-workdir
+Options=lowerdir=/usr/share/retroarch/system,upperdir=/storage/system,workdir=/storage/.tmp/system-workdir
 
 [Install]
 WantedBy=retroarch.target

--- a/packages/lakka/retroarch_base/retroarch_assets/conf.d/05-retroarch-fonts.conf
+++ b/packages/lakka/retroarch_base/retroarch_assets/conf.d/05-retroarch-fonts.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
-  <dir>/usr/share/retroarch-assets</dir>
+  <dir>/usr/share/retroarch/assets</dir>
 </fontconfig>

--- a/packages/lakka/retroarch_base/retroarch_overlays/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_overlays/package.mk
@@ -8,5 +8,5 @@ PKG_DEPENDS_TARGET="gcc:host"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
-  make -C ${PKG_BUILD} install INSTALLDIR="${INSTALL}/usr/share/retroarch-overlays"
+  make -C ${PKG_BUILD} install INSTALLDIR="${INSTALL}/usr/share/retroarch/overlays"
 }

--- a/projects/Ayn/devices/Odin/packages/retroarch/system.d/tmp-overlays.mount
+++ b/projects/Ayn/devices/Odin/packages/retroarch/system.d/tmp-overlays.mount
@@ -6,7 +6,7 @@ After=systemd-tmpfiles-setup.service
 DefaultDependencies=no
 
 [Mount]
-What=/storage/overlays:/usr/share/retroarch-overlays
+What=/storage/overlays:/usr/share/retroarch/overlays
 Where=/tmp/overlays
 Type=mergerfs
 Options=defaults,allow_other,use_ino

--- a/projects/Ayn/devices/Odin/packages/retroarch/system.d/tmp-system.mount
+++ b/projects/Ayn/devices/Odin/packages/retroarch/system.d/tmp-system.mount
@@ -6,7 +6,7 @@ After=systemd-tmpfiles-setup.service
 DefaultDependencies=no
 
 [Mount]
-What=/storage/system:/usr/share/retroarch-system
+What=/storage/system:/usr/share/retroarch/system
 Where=/tmp/system
 Type=mergerfs
 Options=defaults,allow_other,use_ino

--- a/projects/L4T/devices/Switch/packages/retroarch/system.d/tmp-overlays.mount
+++ b/projects/L4T/devices/Switch/packages/retroarch/system.d/tmp-overlays.mount
@@ -6,7 +6,7 @@ After=systemd-tmpfiles-setup.service
 DefaultDependencies=no
 
 [Mount]
-What=/storage/overlays:/usr/share/retroarch-overlays
+What=/storage/overlays:/usr/share/retroarch/overlays
 Where=/tmp/overlays
 Type=mergerfs
 Options=defaults,allow_other,use_ino

--- a/projects/L4T/devices/Switch/packages/retroarch/system.d/tmp-system.mount
+++ b/projects/L4T/devices/Switch/packages/retroarch/system.d/tmp-system.mount
@@ -6,7 +6,7 @@ After=systemd-tmpfiles-setup.service
 DefaultDependencies=no
 
 [Mount]
-What=/storage/system:/usr/share/retroarch-system
+What=/storage/system:/usr/share/retroarch/system
 Where=/tmp/system
 Type=mergerfs
 Options=defaults,allow_other,use_ino


### PR DESCRIPTION
I'm not sure how this came about but we had inconsistencies.

I decided to move everything to `retroarch/*` instead of `retroarch-*` as I feel it's neater, but would happily change back.

The main point is I think this is all consistent now and assets will be mounted correctly