### PR TITLE
bcm2835-bootloader: fix PKG_URL for Lakka

### DIFF
--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -3,16 +3,19 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="2b3cef2f4e9987ab4ad5e07578c2f6192aa7787d"
-PKG_SHA256="58c1c394d1057d840cbc820e8e86131266bf2289634e8724526e676a094ea911"
+PKG_VERSION="53f4941b7bb2512e07fa7c6baec29cbee4889848"
+PKG_SHA256="4596bbac8aaf622efc0b6db2d25c03430c7c9bcfd014655f064102a07f537b77"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.broadcom.com"
-# PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-PKG_URL="https://github.com/raspberrypi/firmware/archive/refs/tags/${PKG_VERSION}.tar.gz"
+PKG_URL="${DISTRO_SRC}/${PKG_NAME}-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_TARGET="toolchain linux bcmstat"
 PKG_LONGDESC="bcm2835-bootloader: Tool to create a bootable kernel for RaspberryPi"
 PKG_TOOLCHAIN="manual"
+
+if [ "${DISTRO}" = "Lakka" ]; then
+  PKG_URL="https://github.com/raspberrypi/firmware/archive/${PKG_VERSION}.tar.gz"
+fi
 
 makeinstall_target() {
   # upstream repo stores the firmware file in 'boot' subfolder


### PR DESCRIPTION
We get a 404 with the current one and a 302 from the LE one..

This should make it easier to merge, maybe?