### PR TITLE
fake-08: Add fake-08 to Libretro cores

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -221,6 +221,7 @@
                   dosbox_svn \
                   emux_sms\
                   ecwolf \
+                  fake_08 \
                   fbalpha2012 \
                   fbneo \
                   fceumm \

--- a/packages/lakka/libretro_cores/fake_08/package.mk
+++ b/packages/lakka/libretro_cores/fake_08/package.mk
@@ -1,0 +1,15 @@
+PKG_NAME="fake_08"
+PKG_VERSION="74fc93696a439eb7d697af44216784b0f5995039"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/jtothebell/fake-08"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="A Pico-8 player/emulator for console homebrew"
+PKG_TOOLCHAIN="make"
+
+PKG_MAKE_OPTS_TARGET="-C platform/libretro"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+  cp -v platform/libretro/fake08_libretro.so ${INSTALL}/usr/lib/libretro/
+}


### PR DESCRIPTION
Add [fake-08](https://github.com/jtothebell/fake-08) to Libretro cores tested and working fine on `x86_64` and `arm`.