### PR TITLE
amlogic: add rtl8821c support to kernel-firmware

### DIFF
--- a/projects/Amlogic/config/kernel-firmware.dat
+++ b/projects/Amlogic/config/kernel-firmware.dat
@@ -6,6 +6,8 @@ qca/rampatch_00230302.bin
 rtlwifi/rtl8192cufw_TMSC.bin
 rtlwifi/rtl8192cufw.bin
 rtlwifi/rtl8192eu_nic.bin
+rtl_bt/rtl8821c_config.bin
+rtl_bt/rtl8821c_fw.bin
 rtl_bt/rtl8822cs_config.bin
 rtl_bt/rtl8822cs_fw.bin
 meson


### PR DESCRIPTION
This should fix #1768