### PR TITLE
Generic: linux: fix after kernel-firmware update and add nvidia firmware

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -291,7 +291,7 @@ pre_make_target() {
   if [ "${TARGET_ARCH}" = "x86_64" -o "${TARGET_ARCH}" = "i386" ]; then
     # copy some extra firmware to linux tree
     mkdir -p ${PKG_BUILD}/external-firmware
-      cp -a $(get_build_dir kernel-firmware)/.copied-firmware/{amdgpu,amd-ucode,i915,radeon,e100,rtl_nic} ${PKG_BUILD}/external-firmware
+      cp -a $(get_build_dir kernel-firmware)/.copied-firmware/{amdgpu,amd-ucode,i915,nvidia,radeon,e100,rtl_nic} ${PKG_BUILD}/external-firmware
 
     cp -a $(get_build_dir intel-ucode)/intel-ucode ${PKG_BUILD}/external-firmware
 

--- a/projects/Generic/patches/linux/linux-777-Makefile-build-firmware-built-in-arg-list-squeeze.patch
+++ b/projects/Generic/patches/linux/linux-777-Makefile-build-firmware-built-in-arg-list-squeeze.patch
@@ -1,0 +1,13 @@
+Workaround for 'Argument list too long' error.
+
+--- a/scripts/Makefile.build
++++ b/scripts/Makefile.build
+@@ -394,7 +394,7 @@
+ #
+ 
+ quiet_cmd_ar_builtin = AR      $@
+-      cmd_ar_builtin = rm -f $@; $(AR) cDPrST $@ $(real-prereqs)
++      cmd_ar_builtin = rm -f $@; $(if $(findstring drivers/base/firmware_loader/builtin/built-in.a,$@),$(AR) cDPrST $@ $(sort $(foreach f,$(real-prereqs),$(dir $(f))*.o)),$(AR) cDPrST $@ $(real-prereqs))
+ 
+ $(obj)/built-in.a: $(real-obj-y) FORCE
+ 	$(call if_changed,ar_builtin)


### PR DESCRIPTION
- Workaround for 'Argument list too long' error
- Add nvidia firmware