### PR TITLE
packages: add gamemode

### DIFF
--- a/packages/devel/inih/package.mk
+++ b/packages/devel/inih/package.mk
@@ -1,0 +1,8 @@
+PKG_NAME="inih"
+PKG_VERSION="54"
+PKG_SHA256="b5566af5203f8a49fda27f1b864c0c157987678ffbd183280e16124012869869"
+PKG_LICENSE="BSD"
+PKG_SITE="https://github.com/benhoyt/inih"
+PKG_URL="https://github.com/benhoyt/inih/archive/refs/tags/r${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Simple .INI file parser in C, good for embedded systems"

--- a/packages/tools/gamemode/package.mk
+++ b/packages/tools/gamemode/package.mk
@@ -1,0 +1,9 @@
+PKG_NAME="gamemode"
+PKG_VERSION="1.7"
+PKG_SHA256="c1860f76f1d4c0d6e3965e52de21c824f24791049946da728da50f0c63748389"
+PKG_LICENSE="BSD"
+PKG_SITE="https://github.com/FeralInteractive/gamemode"
+PKG_URL="https://github.com/FeralInteractive/gamemode/releases/download/${PKG_VERSION}/gamemode-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS_TARGET="toolchain systemd dbus inih"
+PKG_LONGDESC="GameMode is a daemon/lib combo for Linux that allows games to request a set of optimisations be temporarily applied to the host OS and/or a game process."
+

--- a/packages/tools/gamemode/patches/pidfd.patch
+++ b/packages/tools/gamemode/patches/pidfd.patch
@@ -1,0 +1,13 @@
+diff --git a/common/common-pidfds.c b/common/common-pidfds.c
+index 3fcff0d75..6f86ccd98 100644
+--- a/common/common-pidfds.c
++++ b/common/common-pidfds.c
+@@ -58,6 +58,8 @@
+ {
+ 	return (int)syscall(__NR_pidfd_open, pid, flags);
+ }
++#else
++#include <sys/pidfd.h>
+ #endif
+ 
+ /* pidfd functions */


### PR DESCRIPTION
Add gamemode package, but it's not on lakka PKG_DEPENDS_TARGET because of DBUS error.

> Dec 06 10:07:27 Lakka systemd[1]: retroarch.service: Scheduled restart job, restart counter is at 41.
> Dec 06 10:07:27 Lakka systemd[1]: Stopped retroarch.service.
> Dec 06 10:07:27 Lakka systemd[1]: Starting retroarch.service...
> Dec 06 10:07:27 Lakka systemd[1]: Started retroarch.service.
> Dec 06 10:07:27 Lakka retroarch[770]: GameMode ERROR: Could not connect to bus: Using X11 for dbus-daemon autolaunch was disabled at compile time, set your DBUS_SESSION_BUS_ADDRESS instead
> Dec 06 10:07:27 Lakka retroarch[770]: dbus[770]: arguments to dbus_connection_unref() were incorrect, assertion "connection != NULL" failed in file /home/nekoprog/Lakka-LibreELEC/build.Lakka-RPi2.arm/build/dbus-1.14.0/dbus/dbus-connection.c line 2820.
> Dec 06 10:07:27 Lakka retroarch[770]: This is normally a bug in some application using the D-Bus library.
> Dec 06 10:07:27 Lakka retroarch[770]:   D-Bus not built with -rdynamic so unable to print a backtrace
> Dec 06 10:07:27 Lakka systemd[1]: retroarch.service: Main process exited, code=killed, status=6/ABRT
> Dec 06 10:07:27 Lakka systemd[1]: retroarch.service: Failed with result 'signal'.

Hoping someone might be able to solve the error.