### PR TITLE
add ScummVM mainline core package

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -289,6 +289,7 @@
                   sameboy \
                   sameduck \
                   scummvm \
+                  scummvm_mainline \
                   snes9x \
                   snes9x2002 \
                   snes9x2005 \

--- a/packages/lakka/libretro_cores/scummvm_mainline/package.mk
+++ b/packages/lakka/libretro_cores/scummvm_mainline/package.mk
@@ -1,0 +1,36 @@
+
+PKG_NAME="scummvm_mainline"
+PKG_VERSION="98c2b107daebbf3fef8dadf3f32b74b2608e0a4e"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://github.com/spleen1981/scummvm-mainline-libretro"
+PKG_URL="$PKG_SITE.git"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_SHORTDESC="Script Creation Utility for Maniac Mansion Virtual Machine"
+PKG_LONGDESC="ScummVM is a program which allows you to run certain classic graphical point-and-click adventure games, provided you already have their data files."
+PKG_TOOLCHAIN="make"
+
+pre_make_target() {
+  CXXFLAGS+=" -DHAVE_POSIX_MEMALIGN=1"
+  CFLAGS+=" -fPIC"
+  if [ "${DEVICE}" = "OdroidGoAdvance" ]; then
+    PKG_MAKE_OPTS_TARGET+=" platform=oga_a35_neon_hardfloat"
+  fi
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+  cp -v ${PKG_BUILD}/scummvm_mainline_libretro.so ${INSTALL}/usr/lib/libretro/
+  cp -v ${PKG_BUILD}/scummvm_mainline_libretro.info ${INSTALL}/usr/lib/libretro/
+
+  # unpack files to retroarch-system folder and create basic ini file
+  mkdir -p ${INSTALL}/usr/share/retroarch-system
+  unzip ${PKG_BUILD}/scummvm.zip -d ${INSTALL}/usr/share/retroarch-system
+
+  cat << EOF > ${INSTALL}/usr/share/retroarch-system/scummvm.ini
+[scummvm]
+extrapath=/tmp/system/scummvm/extra
+browser_lastpath=/tmp/system/scummvm/extra
+themepath=/tmp/system/scummvm/theme
+guitheme=scummmodern
+EOF
+}


### PR DESCRIPTION
Adds ScummVM mainline libretro core to Lakka, built directly from untouched mainline ScummVM source.

As current official ScummVM libretro core is based on a very old fork of ScummVM, this core aims to be always in sync with ScummVM mainline repository, with a maintenance effort from low to none.

ScummVM main repo is included as a submodule. To sync the libretro core it should be sufficient to update the submodule and build

- No patch is applied to the submodule
- Submodule updates will be generally committed following ScummVM official releases (though it can be updated to any commit upstream, considering that adjustment to core Makefile and sources in src may be required to build)
- Datafiles and themes bundle (scummvm.zip) and core.info files are built automatically based on current submodule source

This core is supposed to be eventually moved to Libretro official repositories (pls let me know how in case) and superseed current outdated scummvm-libretro core.