### PR TITLE
Lakka-v5.x:Ayn:Odin:Kernel Fix kernel sources download

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -37,10 +37,11 @@ case "${LINUX}" in
     PKG_SHA256=$L4T_COMBINED_KERNEL_SHA256
     ;;
   ayn-odin)
-   PKG_SHA256="c19a1c06f1ff61f5d6971757442acf0736585551"
+   PKG_SHA256="9aa25bf492928bc7a4542e87d28919c9ac36d27c"
    PKG_VERSION="${PKG_SHA256}"
    PKG_URL="https://gitlab.com/sdm845-mainline/linux.git"
    PKG_PATCH_DIRS="default ayn-odin"
+   PKG_GIT_CLONE_BRANCH="sdm845-5.19.16"
    ;;
   *)
     PKG_VERSION="6.1"


### PR DESCRIPTION
This is basically the same changes re-based on a slightly newer version of the same kernel, because upstream deleted the old branch when they released.