### PR TITLE
Lakka v4.x general

### DIFF
--- a/distributions/Lakka/version
+++ b/distributions/Lakka/version
@@ -2,4 +2,4 @@
   LIBREELEC_VERSION="devel"
 
 # OS_VERSION: OS Version
-  OS_VERSION="4.2"
+  OS_VERSION="4.3"


### PR DESCRIPTION
This PR does 2 general things....

It downgrades ppsspp to version from lakka v4.2, which actually loads/works.

It bumps Lakka version to 4.3