### PR TITLE
Fix link time error in libretro-kronos: -lGL is missing when compiling with OpenGL support

### DIFF
--- a/packages/lakka/libretro_cores/kronos/package.mk
+++ b/packages/lakka/libretro_cores/kronos/package.mk
@@ -12,6 +12,7 @@ PKG_MAKE_OPTS_TARGET="-C yabause/src/libretro HAVE_CDROM=1"
 
 if [ "${OPENGL_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGL}"
+  PKG_MAKE_OPTS_TARGET+=" HAVE_OPENGL=1"
 fi
 
 if [ "${OPENGLES_SUPPORT}" = "yes" ]; then


### PR DESCRIPTION
Fix linker error when compiling kronos with opengl support (-lGL was missing)

HAVE_OPENGL was not set to 1 in package.mk, so the linker flag was never appended to the build command.
I encountered this error while building Lakka 5 for X11-enabled devices with this command:

DISTRO=Lakka PROJECT=Generic ARCH=x86_64 DEVICE=x11 make image

