### PR TITLE
Switch: Fix Clock speed menus on mariko.

### DIFF
--- a/packages/lakka/retroarch_base/retroarch/patches/0001-lakka-switch-Add_Support_for_Mariko_Overclock.patch
+++ b/packages/lakka/retroarch_base/retroarch/patches/0001-lakka-switch-Add_Support_for_Mariko_Overclock.patch
@@ -1,0 +1,226 @@
+From f18ed2c4f41d06f1992574e093e7c347f6f081dc Mon Sep 17 00:00:00 2001
+From: Ronald Brown <rbrown4014@yahoo.com>
+Date: Thu, 12 Jan 2023 20:49:58 -0800
+Subject: [PATCH] Lakka:Switch: Add Support for mariko clocks
+
+---
+ menu/cbs/menu_cbs_ok.c        | 26 +++++++++++++--
+ menu/menu_displaylist.c       | 55 +++++++++++++++++++++++++++---
+ switch_performance_profiles.h | 63 +++++++++++++++++++++++++++++++++++
+ 3 files changed, 136 insertions(+), 8 deletions(-)
+
+diff --git a/menu/cbs/menu_cbs_ok.c b/menu/cbs/menu_cbs_ok.c
+index 0e3d97b821..83875d6afa 100644
+--- a/menu/cbs/menu_cbs_ok.c
++++ b/menu/cbs/menu_cbs_ok.c
+@@ -3857,7 +3857,18 @@ static int action_ok_set_switch_cpu_profile(const char *path,
+ {
+    char command[PATH_MAX_LENGTH] = {0};
+ #ifdef HAVE_LAKKA_SWITCH
+-   char* profile_name            = SWITCH_CPU_PROFILES[entry_idx];
++   char* profile_name;
++   char soc[2];
++   FILE *board = NULL;
++   board = popen("cpu-profile board-info", "r");
++   fgets(soc, 2, board);
++   pclose(board);
++
++   if ( soc[0] == 'E' ) {
++     profile_name=SWITCH_CPU_PROFILES[entry_idx];
++   } else if (soc[0] == 'M' ) {
++     profile_name=SWITCH_CPU_PROFILES_MARIKO[entry_idx];
++   }
+ 
+    snprintf(command, sizeof(command), "cpu-profile set '%s'", profile_name);
+ 
+@@ -3895,8 +3906,17 @@ static int action_ok_set_switch_gpu_profile(const char *path,
+       const char *label, unsigned type, size_t idx, size_t entry_idx)
+ {
+    char command[PATH_MAX_LENGTH];
+-   char            *profile_name  = SWITCH_GPU_PROFILES[entry_idx];
+-
++   char soc[2];
++   FILE *board = NULL;
++   board = popen("gpu-profile board-info", "r");
++   fgets(soc, 2, board);
++   pclose(board);
++   char *profile_name;
++   if (soc[0] == 'M') {
++      profile_name  = SWITCH_GPU_PROFILES_MARIKO[entry_idx];
++   } else if (soc[0] == 'E') {
++      profile_name  = SWITCH_GPU_PROFILES[entry_idx];
++   }
+    command[0]                     = '\0';
+ 
+    snprintf(command, sizeof(command),
+diff --git a/menu/menu_displaylist.c b/menu/menu_displaylist.c
+index e5d9b1acb7..940a60c3c0 100644
+--- a/menu/menu_displaylist.c
++++ b/menu/menu_displaylist.c
+@@ -11704,8 +11704,20 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
+ #ifdef HAVE_LAKKA_SWITCH
+          char current_profile[PATH_MAX_LENGTH];
+          FILE               *profile = NULL;
+-#endif
++         size_t profiles_count = 0;
++         char soc[2];
++         FILE *board = NULL;
++         board = popen("cpu-profile board-info", "r");
++         fgets(soc, 2, board);
++         pclose(board);
++         if ( soc[0] == 'E') {
++           profiles_count = sizeof(SWITCH_CPU_PROFILES)/sizeof(SWITCH_CPU_PROFILES[1]);
++         } else if (soc[0] == 'M') {
++           profiles_count = sizeof(SWITCH_CPU_PROFILES_MARIKO)/sizeof(SWITCH_CPU_PROFILES_MARIKO[1]);
++         }
++#else
+          const size_t profiles_count = sizeof(SWITCH_CPU_PROFILES)/sizeof(SWITCH_CPU_PROFILES[1]);
++#endif
+ 
+          runloop_msg_queue_push("Warning : extended overclocking can damage the Switch", 1, 90, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+ 
+@@ -11737,12 +11749,24 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
+             0,
+             MENU_INFO_MESSAGE, 0, 0, NULL))
+             count++;
+-
+          for (i = 0; i < profiles_count; i++)
+          {
+             char title[PATH_MAX_LENGTH];
++#ifdef HAVE_LAKKA_SWITCH
++            char* profile;
++            char* speed;
++            if (soc[0] == 'E') {
++              profile               = SWITCH_CPU_PROFILES[i];
++              speed                 = SWITCH_CPU_SPEEDS[i];
++            } else if (soc[0] == 'M') {
++              profile               = SWITCH_CPU_PROFILES_MARIKO[i];
++              speed                 = SWITCH_CPU_SPEEDS_MARIKO[i];
++
++           }
++#else
+             char* profile               = SWITCH_CPU_PROFILES[i];
+             char* speed                 = SWITCH_CPU_SPEEDS[i];
++#endif
+             title[0] = '\0';
+ 
+             snprintf(title, sizeof(title), "%s (%s)", profile, speed);
+@@ -11766,8 +11790,20 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
+          unsigned i;
+          char text[PATH_MAX_LENGTH];
+          char current_profile[PATH_MAX_LENGTH];
++         size_t profiles_count = 0;
+          FILE               *profile = NULL;
+-         const size_t profiles_count = sizeof(SWITCH_GPU_PROFILES)/sizeof(SWITCH_GPU_PROFILES[1]);
++
++         char soc[2];
++         FILE *board = NULL;
++         board = popen("gpu-profile board-info", "r");
++         fgets(soc, 2, board);
++         pclose(board);
++
++         if (soc[0] == 'E') {
++           profiles_count = sizeof(SWITCH_GPU_PROFILES)/sizeof(SWITCH_GPU_PROFILES[1]);
++         } else if (soc[0] == 'M') {
++           profiles_count = sizeof(SWITCH_GPU_PROFILES_MARIKO)/sizeof(SWITCH_GPU_PROFILES_MARIKO[1]);
++         }
+ 
+          runloop_msg_queue_push("Warning : extended overclocking can damage the Switch", 1, 90, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+ 
+@@ -11787,8 +11823,17 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
+          for (i = 0; i < profiles_count; i++)
+          {
+             char title[PATH_MAX_LENGTH];
+-            char* profile               = SWITCH_GPU_PROFILES[i];
+-            char* speed                 = SWITCH_GPU_SPEEDS[i];
++            char* profile;
++            char* speed;
++            if (soc[0] == 'E') {
++              profile               = SWITCH_GPU_PROFILES[i];
++              speed                 = SWITCH_GPU_SPEEDS[i];
++            } else if (soc[0] == 'M') {
++              profile               = SWITCH_GPU_PROFILES_MARIKO[i];
++              speed                 = SWITCH_GPU_SPEEDS_MARIKO[i];
++
++           }
++
+ 
+             snprintf(title, sizeof(title), "%s (%s)", profile, speed);
+ 
+diff --git a/switch_performance_profiles.h b/switch_performance_profiles.h
+index 5d07ba6ed5..ab92b0e114 100644
+--- a/switch_performance_profiles.h
++++ b/switch_performance_profiles.h
+@@ -48,6 +48,69 @@ static char *SWITCH_GPU_SPEEDS[] = {
+     "153 Mhz",
+     "76 Mhz"
+ };
++
++static char *SWITCH_GPU_PROFILES_MARIKO[] = {
++    "Docked Stock +3",
++    "Docked Stock +2",
++    "Docked Stock +1",
++    "Docked Stock Mode",
++    "Handheld Boost +3",
++    "Handheld Boost +2",
++    "Handheld Boost +1",
++    "Handheld Boost Mode",
++    "Handheld Stock +1",
++    "Handheld Stock Mode",
++    "Powersaving +2",
++    "Powersaving +1",
++    "Powersaving Mode",
++};
++
++static char *SWITCH_GPU_SPEEDS_MARIKO[] = {
++    "998 Mhz",
++    "921 Mhz",
++    "844 Mhz",
++    "768 Mhz",
++    "691 Mhz",
++    "614 Mhz",
++    "537 Mhz",
++    "460 Mhz",
++    "384 Mhz",
++    "307 Mhz",
++    "230 Mhz",
++    "153 Mhz",
++    "76 Mhz"
++};
++
++static char *SWITCH_CPU_PROFILES_MARIKO[] = {
++    "Max Overdrive +3",
++    "Max Overdrive +2",
++    "Max Overdrive +1",
++    "Maximum Performance",
++    "Boost Performance 4",
++    "Boost Performance 3",
++    "Boost Performance 2",
++    "Boost Performance 1",
++    "Stock Performance",
++    "Powersaving Mode 1",
++    "Powersaving Mode 2",
++    "Powersaving Mode 3"
++};
++
++static char *SWITCH_CPU_SPEEDS_MARIKO[] = {
++    " **UNSTABLE**  2295 MHz",
++    " **UNSTABLE**  2193 MHz",
++    " **UNSTABLE**  2091 MHz",
++    "1963 MHz",
++    "1887 MHz",
++    "1785 MHz",
++    "1581 MHz",
++    "1224 MHz",
++    "1020 MHz",
++    "918 MHz",
++    "816 MHz",
++    "714 MHz"
++};
++
+ #endif
+ 
+ static char *SWITCH_CPU_PROFILES[] = {
+-- 
+2.35.1
+

--- a/projects/L4T/devices/Switch/packages/switch-cpu-profile/package.mk
+++ b/projects/L4T/devices/Switch/packages/switch-cpu-profile/package.mk
@@ -1,12 +1,11 @@
 PKG_NAME="switch-cpu-profile"
-PKG_VERSION="1.1"
+PKG_VERSION="2.0"
 PKG_DEPENDS_TARGET="Python3"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
-    #cp -v ${PKG_DIR}/scripts/cpu-profile ${INSTALL}/usr/bin
-    touch ${INSTALL}/usr/bin/cpu-profile
+    cp -v ${PKG_DIR}/scripts/cpu-profile ${INSTALL}/usr/bin
     chmod +x ${INSTALL}/usr/bin/cpu-profile
 }
 

--- a/projects/L4T/devices/Switch/packages/switch-cpu-profile/scripts/cpu-profile
+++ b/projects/L4T/devices/Switch/packages/switch-cpu-profile/scripts/cpu-profile
@@ -15,9 +15,9 @@ For now the profile is not retained and is set to default speed when rebooting.
 PROFILE_FILE = "/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq"
 OVERCLOCK_FILE = "/sys/kernel/tegra_cpufreq/overclock"
 SAVED_PROFILE_FILE = "/storage/.config/.cpu_profile"
-
+SERIAL_FILE = "/sys/firmware/devicetree/base/serial-number"
 # Profiles list, in KHz - max 2091000
-PROFILES = {
+PROFILES_ERISTA = {
     "Max Overdrive +3":    "2091000",
     "Max Overdrive +2":    "1989000",
     "Max Overdrive +1":    "1887000",
@@ -30,8 +30,41 @@ PROFILES = {
     "Powersaving Mode 3":  "714000",
 }
 
+PROFILES_MARIKO = {
+    "Max Overdrive +3": "2295000",
+    "Max Overdrive +2": "2193000",
+    "Max Overdrive +1": "2091000",
+    "Maximum Performance": "1963500",
+    "Boost Performance 4": "1887000",
+    "Boost Performance 3": "1785000",
+    "Boost Performance 2": "1581000",
+    "Boost Performance 1": "1224000",
+    "Stock Performance": "1020000",
+    "Powersaving Mode 1": "918000",
+    "Powersaving Mode 2": "816000",
+    "Powersaving Mode 3": "714000"
+}
+
 # Default profile
 DEFAULT_PROFILE = "Stock Performance"
+def get_board():
+    try:
+        f=open(SERIAL_FILE, "r")
+    except IOError:
+        return -1
+    board_prefix=str(f.read().strip())
+    board_prefix=board_prefix[:3]
+
+    if board_prefix == "NXM":
+        return 1
+    elif board_prefix == "NXV":
+        return 1
+    elif board_prefix ==  "NXF":
+        return 1
+    elif board_prefix ==  "NXO":
+        return 0
+    else:
+        return -1
 
 def get_saved_profile():
     try:
@@ -43,31 +76,42 @@ def get_saved_profile():
         return DEFAULT_PROFILE
     else:
         return NEW_DEFAULT_PROFILE
-	
+
 def save_profile(profile):
         with open(SAVED_PROFILE_FILE, "w") as f:
             f.write(profile)
             f.flush()
-       
+
 def get_profile():
     with open(PROFILE_FILE, "r") as f:
         pstate = str(f.read().strip())
 
     profile_code = pstate
-
-    for profile in PROFILES:
-        if profile_code == PROFILES[profile]:
-            return profile
-
+    board=get_board() 
+    if board == 1:
+        for profile in PROFILES_MARIKO:
+            if profile_code == PROFILES_MARIKO[profile]:
+                return profile
+    elif board == 0:
+        for profile in PROFILES_ERISTA:
+            if profile_code == PROFILES_ERISTA[profile]:
+                return profile
     raise Exception("Unknown profile code %s" % profile_code)
 
 
 def apply_profile(profile):
-    if profile not in PROFILES:
-        raise Exception("Unknown profile %s" % profile)
-
+    board=get_board()
+    if board == 1:
+        if profile not in PROFILES_MARIKO:
+            raise Exception("Unknown profile %s" % profile)
+    elif board == 0:
+       if profile not in PROFILES_ERISTA:
+            raise Exception("Unknown profile %s" % profile)
     with open(PROFILE_FILE, "w") as f:
-        f.write(PROFILES[profile])
+        if board == 1:
+            f.write(PROFILES_MARIKO[profile])
+        elif board == 0:
+            f.write(PROFILES_ERISTA[profile])
         f.flush()
     print(("Applied profile %s" % profile))
 
@@ -84,13 +128,13 @@ def print_usage():
     Usage :
         cpu-profile init
             Sets the default profile - should be called on boot
-            
+
         cpu-profile list
             Lists all the available profiles and their corresponding frequency
-                
+
         cpu-profile set <profile>
             Sets the current profile to <profile>
-    
+
         cpu-profile get
             Gets the current profile name
     ''')
@@ -98,31 +142,47 @@ def print_usage():
 
 def print_profiles():
     print("Format : <name> - <freq in KHz> [* : enabled] [d : reboot default]")
-
-    max_profile_name_length = max([len(x) for x in list(PROFILES.keys())])
-    
+    board=get_board()
     current_profile = get_profile()
-    
-    for profile in reversed(list(PROFILES.keys())):
-        profile_name = profile
-        profile_freq = PROFILES[profile]
-        is_default = (profile_name == DEFAULT_PROFILE)
-        is_current = (current_profile == profile_name)
-        padding = " " * (max_profile_name_length - len(profile_name))
-        print("%s%s - %s %s %s" % (profile_name, padding, profile_freq, "*" if is_current else " ", "d" if is_default else ""))
 
+    if board == 1:
+        max_profile_name_length = max([len(x) for x in list(PROFILES_MARIKO.keys())])
+        for profile in reversed(list(PROFILES_MARIKO.keys())):
+            profile_name = profile
+            profile_freq = PROFILES_MARIKO[profile]
+            is_default = (profile_name == DEFAULT_PROFILE)
+            is_current = (current_profile == profile_name)
+            padding = " " * (max_profile_name_length - len(profile_name))
+            print("%s%s - %s %s %s" % (profile_name, padding, profile_freq, "*" if is_current else " ", "d" if is_default else ""))
+    elif board == 0:
+        max_profile_name_length = max([len(x) for x in list(PROFILES_ERISTA.keys())])
+        for profile in reversed(list(PROFILES_ERISTA.keys())):
+            profile_name = profile
+            profile_freq = PROFILES_ERISTA[profile]
+            is_default = (profile_name == DEFAULT_PROFILE)
+            is_current = (current_profile == profile_name)
+            padding = " " * (max_profile_name_length - len(profile_name))
+            print("%s%s - %s %s %s" % (profile_name, padding, profile_freq, "*" if is_current else " ", "d" if is_default else ""))
 
 # Main
 if __name__ == "__main__":
     argc = len(sys.argv)
     if argc == 2:
         if sys.argv[1] == "init":
-            apply_profile(get_saved_profile())
             unlock_full_power()
+            apply_profile(get_saved_profile())
         elif sys.argv[1] == "get":
             print(get_profile())
         elif sys.argv[1] == "list":
             print_profiles()
+        elif sys.argv[1] == "board-info":
+            x=get_board()
+            if x == 1:
+                print("M")
+            elif x == 0:
+                print("E")
+            else:
+                print("Not A Switch")
         else:
             print_usage()
     elif argc == 3:

--- a/projects/L4T/devices/Switch/packages/switch-gpu-profile/package.mk
+++ b/projects/L4T/devices/Switch/packages/switch-gpu-profile/package.mk
@@ -1,13 +1,12 @@
 PKG_NAME="switch-gpu-profile"
-PKG_VERSION="1.1"
+PKG_VERSION="2.0"
 PKG_DEPENDS_TARGET="Python3"
 PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/bin
-    #cp -v ${PKG_DIR}/scripts/gpu-profile ${INSTALL}/usr/bin
-    touch ${INSTALL}/usr/bin/cpu-profile
-    chmod +x ${INSTALL}/usr/bin/cpu-profile
+    cp -v ${PKG_DIR}/scripts/gpu-profile ${INSTALL}/usr/bin
+    chmod +x ${INSTALL}/usr/bin/gpu-profile
 
 }
 

--- a/projects/L4T/devices/Switch/packages/switch-gpu-profile/scripts/gpu-profile
+++ b/projects/L4T/devices/Switch/packages/switch-gpu-profile/scripts/gpu-profile
@@ -17,9 +17,10 @@ L4T variant.
 PROFILE_FILE_MAX = "/sys/devices/57000000.gpu/devfreq/57000000.gpu/max_freq"
 PROFILE_FILE_MIN = "/sys/devices/57000000.gpu/devfreq/57000000.gpu/min_freq"
 SAVED_PROFILE_FILE = "/storage/.config/.gpu_profile"
+SERIAL_FILE = "/sys/firmware/devicetree/base/serial-number"
 
 # Profiles list
-PROFILES = {
+PROFILES_ERISTA = {
     "Docked Stock +2":      "921600000",  # 921 Mhz
     "Docked Stock +1":      "844800000",  # 844 Mhz
     "Docked Stock Mode":    "768000000",  # 768 Mhz
@@ -34,8 +35,44 @@ PROFILES = {
     "Powersaving Mode":     "76800000",   # 76 Mhz
 }
 
+PROFILES_MARIKO = {
+    "Docked Stock +3":      "998400000",  #998 Mhz
+    "Docked Stock +2":      "921600000",  # 921 Mhz
+    "Docked Stock +1":      "844800000",  # 844 Mhz
+    "Docked Stock Mode":    "768000000",  # 768 Mhz
+    "Handheld Boost +3":    "691200000",  # 691 Mhz
+    "Handheld Boost +2":    "614400000",  # 614 Mhz
+    "Handheld Boost +1":    "537600000",  # 537 Mhz
+    "Handheld Boost Mode":  "460800000",  # 460 Mhz
+    "Handheld Stock +1":    "384000000",  # 384 Mhz
+    "Handheld Stock Mode":  "307200000",  # 307 Mhz
+    "Powersaving +2":       "230400000",  # 230 Mhz
+    "Powersaving +1":       "153600000",  # 153 Mhz
+    "Powersaving Mode":     "76800000",   # 76 Mhz
+}
+
+
 # Default profile
 DEFAULT_PROFILE = "Handheld Stock Mode"
+
+def get_board():
+    try:
+        f=open(SERIAL_FILE, "r")
+    except IOError:
+        return -1
+    board_prefix=str(f.read().strip())
+    board_prefix=board_prefix[:3]
+
+    if board_prefix == "NXM":
+        return 1
+    elif board_prefix == "NXV":
+        return 1
+    elif board_prefix ==  "NXF":
+        return 1
+    elif board_prefix ==  "NXO":
+        return 0
+    else:
+        return -1
 
 def get_saved_profile():
     try:
@@ -47,31 +84,41 @@ def get_saved_profile():
         return DEFAULT_PROFILE
     else:
         return NEW_DEFAULT_PROFILE
-	
+
 def save_profile(profile):
         with open(SAVED_PROFILE_FILE, "w") as f:
             f.write(profile)
             f.flush()
-    
+
 def get_profile():
     with open(PROFILE_FILE_MAX, "r") as f:
         pstate = str(f.read().strip())
-
-    for profile in PROFILES:
-        if pstate == PROFILES[profile]:
-            return profile
-
+    board=get_board()
+    if board == 1:
+        for profile in PROFILES_MARIKO:
+            if pstate == PROFILES_MARIKO[profile]:
+                return profile
+    elif board == 0:
+        for profile in PROFILES_ERISTA:
+            if pstate == PROFILES_ERISTA[profile]:
+                return profile
     raise Exception("Unknown profile %s" % pstate)
 
 
 
 def apply_profile(profile):
-    if profile not in PROFILES:
-        raise Exception("Unknown profile %s" % profile)
-
+    board=get_board()
     files = []
-    cur_profile = int(PROFILES[get_profile()])
-    new_profile = int(PROFILES[profile])
+    if board == 1:
+        if profile not in PROFILES_MARIKO:
+            raise Exception("Unknown profile %s" % profile)
+        cur_profile = int(PROFILES_MARIKO[get_profile()])
+        new_profile = int(PROFILES_MARIKO[profile])
+    elif board == 0:
+        if profile not in PROFILES_ERISTA:
+            raise Exception("Unknown profile %s" % profile)
+        cur_profile = int(PROFILES_ERISTA[get_profile()])
+        new_profile = int(PROFILES_ERISTA[profile])
 
     if new_profile < cur_profile:
         files = [
@@ -86,7 +133,10 @@ def apply_profile(profile):
 
     for pfile in files:
         with open(pfile, "w") as f:
-            f.write(PROFILES[profile])
+            if board == 1:
+                f.write(PROFILES_MARIKO[profile])
+            elif board == 0:
+                f.write(PROFILES_ERISTA[profile])
             f.flush()
     print(("Applied profile %s" % profile))
 
@@ -114,6 +164,14 @@ if __name__ == "__main__":
             apply_profile(get_saved_profile())
         elif sys.argv[1] == "get":
             print(get_profile())
+        elif sys.argv[1] == "board-info":
+            x=get_board()
+            if x == 1:
+                print("M")
+            elif x == 0:
+                print("E")
+            else:
+                print("Not A Switch")
         else:
             print_usage()
     elif argc == 3:


### PR DESCRIPTION
This adds new retroarch patch that adds board detection for the switch, and makes clock speed menus dynamic based upon board sku.