### PR TITLE
scummvm: update package [Lakka v4.x]

### DIFF
--- a/packages/lakka/libretro_cores/scummvm/package.mk
+++ b/packages/lakka/libretro_cores/scummvm/package.mk
@@ -1,14 +1,21 @@
-
 PKG_NAME="scummvm"
-PKG_VERSION="a0554745e87361643f1ca3aa820a5073214de935"
+PKG_VERSION="b3959adb5fdea4428bed2489437a7b021df1009d"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/scummvm"
 PKG_URL="${PKG_SITE}.git"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="toolchain curl fluidsynth flac libvorbis zlib faad2 freetype"
 PKG_SHORTDESC="The ScummVM adventure game engine ported to libretro."
 PKG_LONGDESC="ScummVM is a program which allows you to run certain classic graphical point-and-click adventure games, provided you already have their data files."
 PKG_TOOLCHAIN="make"
 PKG_LR_UPDATE_TAG="yes"
+
+PKG_MAKE_OPTS_TARGET="USE_CLOUD=1 \
+                      USE_SYSTEM_fluidsynt=1 \
+                      USE_SYSTEM_FLAC=1 \
+                      USE_SYSTEM_vorbis=1 \
+                      USE_SYSTEM_z=1 \
+                      USE_SYSTEM_faad=1 \
+                      USE_SYSTEM_freetype=1"
 
 pre_make_target() {
   if [ "${DEVICE}" = "OdroidGoAdvance" ]; then
@@ -19,17 +26,17 @@ pre_make_target() {
 }
 
 make_target() {
-  make all ${PKG_MAKE_OPTS_TARGET}
+  make all -C ${PKG_BUILD}/backends/platform/libretro ${PKG_MAKE_OPTS_TARGET}
 }
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
-  cp -v ${PKG_BUILD}/scummvm_libretro.so ${INSTALL}/usr/lib/libretro/
-  cp -v ${PKG_BUILD}/scummvm_libretro.info ${INSTALL}/usr/lib/libretro/
+  cp -v ${PKG_BUILD}/backends/platform/libretro/scummvm_libretro.so ${INSTALL}/usr/lib/libretro/
+  cp -v ${PKG_BUILD}/backends/platform/libretro/scummvm_libretro.info ${INSTALL}/usr/lib/libretro/
 
   # unpack files to retroarch-system folder and create basic ini file
   mkdir -p ${INSTALL}/usr/share/retroarch/system
-  unzip ${PKG_BUILD}/scummvm.zip -d ${INSTALL}/usr/share/retroarch/system
+  unzip ${PKG_BUILD}/backends/platform/libretro/scummvm.zip -d ${INSTALL}/usr/share/retroarch/system
 
   cat << EOF > ${INSTALL}/usr/share/retroarch/system/scummvm.ini
 [scummvm]


### PR DESCRIPTION
- update to ScummVM v2.7.0
- add system shared libs
- add cloud save feature. By default the entire retroarch saves folder will be syncronized, which may be a plus considering that this feature is currently not available in retroarch.