### PR TITLE
Switch: Half assed fixes for the switch build

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -386,6 +386,7 @@
   elif [ "${PROJECT}" = "L4T" -a "${DEVICE}" = "Switch" ]; then
     #Remove xpadneo from L4T builds
     ADDITIONAL_PACKAGES="${ADDITIONAL_PACKAGES//xpadneo/}"
+    EXCLUDE_LIBRETRO_CORES+=" cap32 scummvm ppsspp"
   elif [ "${PROJECT}" = "Ayn" -a "${DEVICE}" = "Odin" ]; then
     EXCLUDE_LIBRETRO_CORES+=" lr_moonlight"
   fi

--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -96,16 +96,16 @@ else
   PKG_FFMPEG_DEBUG="--disable-debug --enable-stripping"
 fi
 
-#Re-enable when patches are rebased on newer version of ffmpeg,for now we use old version. 
-
-if [ "${PROJECT}" = "L4T" ]; then
-   PKG_DEPENDS_TARGET+=" tegra-bsp:host"
-   PKG_PATCH_DIRS+=" L4T"
-   PKG_FFMPEG_NVV4L2="--enable-nvv4l2"
-   EXTRA_CFLAGS="-I${SYSROOT_PREFIX}/usr/src/jetson_multimedia_api/include"
-else
-   PKG_FFMPEG_NVV4L2=""
-fi
+#This block is useless, because someone else doesnt know how to properly rebase stuff.
+#I am done fixing shit I have fixed 1000 times, so I guess recording, and proper decoders just arent that damn important anyway.
+#if [ "${PROJECT}" = "L4T" ]; then
+#   PKG_DEPENDS_TARGET+=" tegra-bsp:host"
+#   PKG_PATCH_DIRS+=" L4T"
+#   PKG_FFMPEG_NVV4L2="--enable-nvv4l2"
+#   EXTRA_CFLAGS="-I${SYSROOT_PREFIX}/usr/src/jetson_multimedia_api/include"
+#else
+#   PKG_FFMPEG_NVV4L2=""
+#fi
 
 if [ "${DISTRO}" = "Lakka" -a "${VULKAN_SUPPORT}" = yes ]; then
   PKG_DEPENDS_TARGET+=" ${VULKAN}"

--- a/packages/x11/util/xdotool/package.mk
+++ b/packages/x11/util/xdotool/package.mk
@@ -22,5 +22,5 @@ makeinstall_target() {
   mkdir -p ${INSTALL}/usr/{lib,bin}
   cp -v xdotool ${INSTALL}/usr/bin
   cp -v libxdo* ${INSTALL}/usr/lib
-  cp -v libxdo* ${TOOLCHAIN}/aarch64-libreelec-linux-gnueabi/sysroot/usr/lib/
+  cp -v libxdo* ${TOOLCHAIN}/aarch64-libreelec-linux-gnu/sysroot/usr/lib/
 }

--- a/projects/L4T/devices/Switch/patches/joycond/01-Fix-cmake-install.patch
+++ b/projects/L4T/devices/Switch/patches/joycond/01-Fix-cmake-install.patch
@@ -6,7 +6,7 @@ diff -Naur joycond-031f04311a912514cea9deb020512ee6d7063398/CMakeLists.txt joyco
  add_subdirectory(src)
  
 -install(FILES joycond DESTINATION /usr/bin/
-+install(FILES .aarch64-libreelec-linux-gnueabi/joycond DESTINATION /usr/bin/
++install(FILES .aarch64-libreelec-linux-gnu/joycond DESTINATION /usr/bin/
          PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
          )
  install(FILES udev/89-joycond.rules udev/72-joycond.rules DESTINATION /lib/udev/rules.d/


### PR DESCRIPTION
This fixes the build issues on the switch, by removing cores that dont build, and removing patching from ffmpeg. The patches can easily be rebased, so I left them in tree..... really it is just the first one, all patches after that should just apply cleanly.

That being said, I dont see a point in adding support to fix it properly, since every time someone pulls from upstream libreelec they seem to reset the package, and dont care to pull the changes I did properly for things like encoders for recording, and what not. I am not going to maintain support for something if the plan is to break it constantly for no reason other than to say you did.