### PR TITLE
Update dosbox svn to allow embedded sdl download

### DIFF
--- a/packages/lakka/libretro_cores/dosbox_svn/package.mk
+++ b/packages/lakka/libretro_cores/dosbox_svn/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="dosbox_svn"
-PKG_VERSION="c23be7769518d753378307996de35e204d188c63"
+PKG_VERSION="53ca2f6303a652d129321cfc521f000cd7ec5531"
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/dosbox-svn"
 PKG_URL="${PKG_SITE}.git"


### PR DESCRIPTION
Otherwise the image build fails when trying to download the git submodule.