### PR TITLE
Fix issue #1874.

### DIFF
--- a/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
@@ -10,7 +10,7 @@ makeinstall_target() {
   make -C ${PKG_BUILD} install INSTALLDIR="${INSTALL}/etc/retroarch-joypad-autoconfig" DOC_DIR="${INSTALL}/etc/doc/."
 
   #Remove non tested joycon configs
-  rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo\ -\ Switch\ Pro\ Controller\ \(bare\).cfg
+  rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo\ -\ Switch\ Pro\ Controller\ \(old\).cfg
   rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo\ -\ Switch\ Pro\ Controller.cfg
   rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo-Switch-Online_NES-Controller_Left.cfg
   rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo-Switch-Online_NES-Controller_Right.cfg


### PR DESCRIPTION
# Pull requests

This pull request is for issue #1874.

I think this issue concerns to "Update all lakka packages Retroach latest + cores"(https://github.com/libretro/Lakka-LibreELEC/commit/5b413c99f6452db02c889b1018c91660876a41f8)"'s commit.

I was checking commit history in following package.
PKG_NAME="retroarch_joypad_autoconfig"
PKG_SITE="https://github.com/libretro/retroarch-joypad-autoconfig"

Target version is latest commit(5666e46bb89caf4e9af358fdb97a2b384cb62f36).
But, previous commit(ccd5bd3820969e1236f6eb32f90ed2f7d95ca06f) conteins filename changing.
From "bare" to "old".

Therefore, I thnk it needs to change to replaced filename in package.mk
 - packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk


Thanks,
ASAI, Shigeaki
