### PR TITLE
Samba: prevent new files being marked as executable

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -21,6 +21,7 @@
   passdb backend = smbpasswd
   smb encrypt = disabled
   fruit:model = Xserve
+  create mask = 0644
 
   # samba share options
   map to guest = Bad User


### PR DESCRIPTION
This pull request updates the default SMB configuration file to set the permissions for new files to 644, from the original default of 744. I am submitting this because it doesn't make sense for ROM files copied over the network to be marked as executable and it can be confusing to see lots of highlighted files when listing them in the terminal. 644 also matches the current umask for new files created on the system directly. There are no compatibility issues with other OS to worry about either as DOS permissions are stored in extended attributes by modern versions of Samba.

```
Lakka:~ # umask
0022
Lakka:~ # touch test
Lakka:~ # ls -l test
-rw-r--r--    1 root     root             0 Sep 29 23:34 test
```