### PR TITLE
libXv: Fix libXv URL and checksum

### DIFF
--- a/packages/x11/lib/libXv/package.mk
+++ b/packages/x11/lib/libXv/package.mk
@@ -4,10 +4,10 @@
 
 PKG_NAME="libXv"
 PKG_VERSION="1.0.11"
-PKG_SHA256="11c7e47bed737c8fa01741d1dba4d39a523ded25dd5f3d47f516a0c62dbc450a"
+PKG_SHA256="c4112532889b210e21cf05f46f0f2f8354ff7e1b58061e12d7a76c95c0d47bb1"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.x.org/"
-PKG_URL="https://github.com/freedesktop/xorg-libXv/archive/refs/tags/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_URL="https://xorg.freedesktop.org/releases/individual/lib/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain util-macros libX11 libXfixes libXext"
 PKG_LONGDESC="LibXv provides an X video extension to the X protocol."
 PKG_BUILD_FLAGS="+pic"


### PR DESCRIPTION
xorg-libXv does not seem to be on Github anymore. This updates the repository.