### PR TITLE
Fix default No audio for GPICases (GPICase.arm/Pi02GPi.arm/RPi4-GPICase2.aarch64).

### DIFF
--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -270,7 +270,7 @@ makeinstall_target() {
   if [ "${PROJECT}" = "RPi" ] && [ "${DEVICE}" = "GPICase" -o "${DEVICE}" = "Pi02GPi" ]; then
     sed -i -e 's|^input_menu_toggle_gamepad_combo =.*|input_menu_toggle_gamepad_combo = "4"|' ${INSTALL}/etc/retroarch.cfg
     sed -i -e 's|^menu_driver =.*|menu_driver = "rgui"|' ${INSTALL}/etc/retroarch.cfg
-    echo 'audio_device = "default:CARD=ALSA"' >> ${INSTALL}/etc/retroarch.cfg
+    echo 'audio_device = "default:CARD=Headphones"' >> ${INSTALL}/etc/retroarch.cfg
     echo 'menu_timedate_enable = "false"' >> ${INSTALL}/etc/retroarch.cfg
     echo 'menu_enable_widgets = "false"' >> ${INSTALL}/etc/retroarch.cfg
     echo 'aspect_ratio_index = "21"' >> ${INSTALL}/etc/retroarch.cfg
@@ -285,6 +285,9 @@ makeinstall_target() {
     if [ "${DEVICE}" = "Pi02GPi" ]; then
       echo 'input_player1_analog_dpad_mode = "3"' >> $INSTALL/etc/retroarch.cfg
     fi
+  fi
+  if [ "${PROJECT}" = "RPi" ] && [ "${DEVICE}" = "RPi4-GPICase2" ]; then
+    echo 'audio_device = "default:CARD=Device"' >> ${INSTALL}/etc/retroarch.cfg
   fi
 
   # PiBoy DMG / RetroDreamer

--- a/projects/RPi/devices/GPICase/config/distroconfig.txt
+++ b/projects/RPi/devices/GPICase/config/distroconfig.txt
@@ -22,10 +22,11 @@ dpi_group=2
 dpi_mode=87
 dpi_output_format=0x6016
 dpi_timings=240 1 38 10 20 320 1 20 4 4 0 0 0 60 0 6400000 1
-dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2
+#dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2
 disable_pvt=1
 disable_audio_dither=1
-dtoverlay=pwm-audio-pi-zero-gpi
+#dtoverlay=pwm-audio-pi-zero-gpi
+dtoverlay=audremap,pins_18_19,swap_lr
 
 disable_overscan=1
 

--- a/projects/RPi/devices/Pi02GPi/config/distroconfig.txt
+++ b/projects/RPi/devices/Pi02GPi/config/distroconfig.txt
@@ -22,10 +22,11 @@ dpi_group=2
 dpi_mode=87
 dpi_output_format=0x6016
 dpi_timings=240 1 38 10 20 320 1 20 4 4 0 0 0 60 0 6400000 1
-dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2
+#dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2
 disable_pvt=1
 disable_audio_dither=1
-dtoverlay=pwm-audio-pi-zero-gpi
+#dtoverlay=pwm-audio-pi-zero-gpi
+dtoverlay=audremap,pins_18_19,swap_lr
 
 disable_splash=1
 disable_overscan=1

--- a/projects/RPi/devices/Pi02GPi/config/distroconfig_vc4.txt
+++ b/projects/RPi/devices/Pi02GPi/config/distroconfig_vc4.txt
@@ -17,6 +17,7 @@ hdmi_drive=1
 dtparam=audio=off
 disable_fw_kms_setup=1
 framebuffer_priority=1
+dtoverlay=audremap,pins_18_19,swap_lr
 
 #enable_dpi_lcd=1
 #display_default_lcd=1


### PR DESCRIPTION
# Pull requests

### This PR fix "default No audio for GPICases (GPICase.arm/Pi02GPi.arm/RPi4-GPICase2.aarch64)".

On GPICases, there are "default no audio" in Lakka-5,x GPICases latest build.
I think it was mainly caused by Linux or ALSA changing/updating.
Detail is below.

- ### GPICase.arm and Pi02GPi.arm
There are 2 reasons.
1.  audio_device = "default:CARD=ALSA" in /etc/retroarch.cfg does not work.
There is no "default:CARD=ALSA" in aplay -l and aplay -L, only exist "Headphones"
**Therefore "audio_device =" setting changes from "default:CARD=ALSA" to "default:CARD=Headphones" in /etc/retroarch.cfg.**
>Lakka (community): devel-20231209203148-e66c240 (Pi02GPi.arm)
Lakka:~ # aplay -l
**** List of PLAYBACK Hardware Devices ****
card 0: Headphones [bcm2835 Headphones], device 0: bcm2835 Headphones [bcm2835 Headphones]
  Subdevices: 8/8
  Subdevice #0: subdevice #0
  Subdevice #1: subdevice #1
  Subdevice #2: subdevice #2
  Subdevice #3: subdevice #3
  Subdevice #4: subdevice #4
  Subdevice #5: subdevice #5
  Subdevice #6: subdevice #6
  Subdevice #7: subdevice #7
Lakka:~ # aplay -L
null
    Discard all samples (playback) or generate zero samples (capture)
default:CARD=Headphones
    bcm2835 Headphones, bcm2835 Headphones
    Default Audio Device
sysdefault:CARD=Headphones
    bcm2835 Headphones, bcm2835 Headphones
    Default Audio Device
Lakka:~ #
    
2.  "dtoverlay" in distroconfig.txt is changed.
By official RetroFlag GPi Case 2W patch, these following 3 changes (2 disabled and 1 added) are included.
https://github.com/RetroFlag/GPICASE2W-display-patch
- #dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2
- #dtoverlay=pwm-audio-pi-zero-gpi
- dtoverlay=audremap,pins_18_19,swap_lr
**Therefore above 3 "dtoverlay" changes in distroconfig.txt**

<BR>
<BR>

- ### RPi4-GPICase2.aarch64
There is 1 reason.
1.  "audio_device" is not set in /etc/retroarch.cfg and Retroarch uses "Default" as audio device.
But it does not get sound.
If user select audio device via menu settings "default:CARD=Device" or "iec958:CARD=Device,DEV=0", it gets sound.
**Therefore add audio_device = "default:CARD=Device" to /etc/retroarch.cfg.**
>Lakka:~ # aplay -l
**** List of PLAYBACK Hardware Devices ****
card 0: b1 [bcm2835 HDMI 1], device 0: bcm2835 HDMI 1 [bcm2835 HDMI 1]
  Subdevices: 8/8
  Subdevice #0: subdevice #0
  Subdevice #1: subdevice #1
  Subdevice #2: subdevice #2
  Subdevice #3: subdevice #3
  Subdevice #4: subdevice #4
  Subdevice #5: subdevice #5
  Subdevice #6: subdevice #6
  Subdevice #7: subdevice #7
card 0: b1 [bcm2835 HDMI 1], device 1: bcm2835 HDMI 1 [bcm2835 HDMI 1]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 1: Device [USB Audio Device], device 0: USB Audio [USB Audio]
  Subdevices: 0/1
  Subdevice #0: subdevice #0
Lakka:~ # aplay -L
null
    Discard all samples (playback) or generate zero samples (capture)
default:CARD=b1
    bcm2835 HDMI 1, bcm2835 HDMI 1
    Default Audio Device
sysdefault:CARD=b1
    bcm2835 HDMI 1, bcm2835 HDMI 1
    Default Audio Device
default:CARD=Device
    USB Audio Device, USB Audio
    Default Audio Device
sysdefault:CARD=Device
    USB Audio Device, USB Audio
    Default Audio Device
front:CARD=Device,DEV=0
    USB Audio Device, USB Audio
    Front output / input
surround21:CARD=Device,DEV=0
    USB Audio Device, USB Audio
    2.1 Surround output to Front and Subwoofer speakers
surround40:CARD=Device,DEV=0
    USB Audio Device, USB Audio
    4.0 Surround output to Front and Rear speakers
surround41:CARD=Device,DEV=0
    USB Audio Device, USB Audio
    4.1 Surround output to Front, Rear and Subwoofer speakers
surround50:CARD=Device,DEV=0
    USB Audio Device, USB Audio
    5.0 Surround output to Front, Center and Rear speakers
surround51:CARD=Device,DEV=0
    USB Audio Device, USB Audio
    5.1 Surround output to Front, Center, Rear and Subwoofer speakers
surround71:CARD=Device,DEV=0
    USB Audio Device, USB Audio
    7.1 Surround output to Front, Center, Side, Rear and Woofer speakers
iec958:CARD=Device,DEV=0
    USB Audio Device, USB Audio
    IEC958 (S/PDIF) Digital Audio Output
Lakka:~ #

<BR>
<BR>

Thanks and Sorry my storange English.
ASAI, Shigeaki