### PR TITLE
Lakka v5.x : Fix vice core build fail (avoid multiple LDFLAGS)

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -309,6 +309,7 @@
                   uzem \
                   vbam \
                   vecx \
+                  vice \
                   virtualjaguar \
                   vitaquake3 \
                   wasm4 \

--- a/packages/lakka/libretro_cores/vice/patches/Avoid-multiple-LDFLAGS.patch
+++ b/packages/lakka/libretro_cores/vice/patches/Avoid-multiple-LDFLAGS.patch
@@ -1,0 +1,18 @@
+diff --git a/Makefile b/Makefile
+index fc2830ef4..95af92680 100644
+--- a/Makefile
++++ b/Makefile
+@@ -46,8 +46,11 @@ endif
+ # Unix
+ ifeq ($(platform), unix)
+    TARGET := $(TARGET_NAME)_libretro.so
+-   LDFLAGS += -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--gc-sections
+-   fpic = -fPIC
++   ifneq ($(findstring --version-script=,$(LDFLAGS)),--version-script=)
++      LDFLAGS += -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--gc-sections
++      fpic = -fPIC
++   endif
++
+ 
+ # Raspberry Pi 4
+ else ifneq (,$(findstring rpi4,$(platform)))


### PR DESCRIPTION
# Pull requests

### In Lakka v5.x, there was vice core build fail, vice core was temporery removed on Sep 11.

I investigated into this.

I don't know the reason, **but same LDFLAGS was set multiple (2 times)**.
LDFLAGS contains "-version-script=".
If LDFLAGS has two "-version-script=" ,  ld.bfd is failded with error message.
Error message is :
`ld.bfd : anonymous version tag cannot be combined with other version tags`

About fix (Patch)
If LDFLAGS is contained "-version-script=" already, Do not set 2nd LDFLAGS.

Thanks and Sorry my storange English.
ASAI, Shigeaki