### PR TITLE
Lakka-v5.x : Fix SafeShutdown RPi4-GPICase2

### DIFF
--- a/packages/lakka/lakka_tools/gpicase_safeshutdown/package.mk
+++ b/packages/lakka/lakka_tools/gpicase_safeshutdown/package.mk
@@ -1,7 +1,13 @@
 PKG_NAME="gpicase_safeshutdown"
 PKG_VERSION="1.0"
-PKG_ARCH="arm"
-PKG_DEPENDS_TARGET="Python3 gpiozero colorzero"
+PKG_ARCH="arm aarch64"
+if [ "${DEVICE}" != "RPi4-GPICase2" ]; then
+  # for GPICase & Pi02GPi
+  PKG_DEPENDS_TARGET="Python3 gpiozero colorzero"
+else
+  # for RPi4-GPICase2
+  PKG_DEPENDS_TARGET="Python3 RPi.GPIO"
+fi
 PKG_SECTION="system"
 PKG_LONGDESC="GPICase safe shutdown script."
 PKG_TOOLCHAIN="manual"
@@ -12,5 +18,15 @@ makeinstall_target() {
 }
 
 post_install() {
-  enable_service gpicase-safeshutdown.service
+  if [ "${DEVICE}" != "RPi4-GPICase2" ]; then
+    # for GPICase & Pi02GPi
+    enable_service gpicase-safeshutdown.service
+    rm -v ${INSTALL}/usr/bin/safeshutdown_gpicase2.py
+    rm -v ${INSTALL}/usr/lib/systemd/system/gpicase2-safeshutdown.service
+  else
+    # for RPi4-GPICase2
+    enable_service gpicase2-safeshutdown.service
+    rm -v ${INSTALL}/usr/bin/safeshutdown_gpi.py
+    rm -v ${INSTALL}/usr/lib/systemd/system/gpicase-safeshutdown.service
+  fi
 }

--- a/packages/lakka/lakka_tools/gpicase_safeshutdown/scripts/safeshutdown_gpicase2.py
+++ b/packages/lakka/lakka_tools/gpicase_safeshutdown/scripts/safeshutdown_gpicase2.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+# This script has been created using the following as a reference:
+# https://github.com/RetroFlag/GPiCase2-Script
+# And, Pull Request #4 "lakka patch & safe shutdown script & audio fix"
+# https://github.com/RetroFlag/GPiCase2-Script/pull/4
+#
+# Currently, lcdrun() and audiofix() are disabled.
+
+import RPi.GPIO as GPIO
+import os
+import time
+from multiprocessing import Process
+
+#initialize pins
+#powerPin = 26 #pin 5
+#ledPin = 14 #TXD
+#resetPin = 2 #pin 13
+#powerenPin = 27 #pin 5
+
+powerPin = 26
+powerenPin = 27
+
+#initialize GPIO settings
+def init():
+	GPIO.setmode(GPIO.BCM)
+	GPIO.setup(powerPin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+	GPIO.setup(powerenPin, GPIO.OUT, initial=GPIO.HIGH)
+	GPIO.output(powerenPin, GPIO.HIGH)
+	GPIO.setwarnings(False)
+
+#waits for user to hold button up to 1 second before issuing poweroff command
+def poweroff():
+	while True:
+		#self.assertEqual(GPIO.input(powerPin), GPIO.LOW)
+		GPIO.wait_for_edge(powerPin, GPIO.FALLING)
+		#start = time.time()
+		#while GPIO.input(powerPin) == GPIO.HIGH:
+		#	time.sleep(0.5)
+		os.system("systemctl stop retroarch")
+		time.sleep(1)
+		os.system("systemctl poweroff")
+
+#def lcdrun():
+#	while True:
+#		os.system("sh /opt/RetroFlag/lcdnext.sh")
+#		time.sleep(1)
+
+#def audiofix():
+#	while True:
+#		time.sleep(0.5)
+#		os.system("systemctl restart retroarch")
+#		break
+
+if __name__ == "__main__":
+	#initialize GPIO settings
+	init()
+	#create a multiprocessing.Process instance for each function to enable parallelism 
+	powerProcess = Process(target = poweroff)
+	powerProcess.start()
+#	lcdrunProcess = Process(target = lcdrun)
+#	lcdrunProcess.start()
+#	audiofixProcess = Process(target = audiofix)
+#	audiofixProcess.start()
+
+	powerProcess.join()
+#	lcdrunProcess.join()
+#	audiofixProcess.join()
+
+	GPIO.cleanup()
+

--- a/packages/lakka/lakka_tools/gpicase_safeshutdown/system.d/gpicase2-safeshutdown.service
+++ b/packages/lakka/lakka_tools/gpicase_safeshutdown/system.d/gpicase2-safeshutdown.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=GPICase safe shutdown
+Description=GPICase2 safe shutdown
 
 [Service]
-ExecStart=/usr/bin/safeshutdown_gpi.py
+ExecStart=/usr/bin/safeshutdown_gpicase2.py
 TimeoutStopSec=5
 Restart=always
 RestartSec=5

--- a/packages/lakka/package.mk
+++ b/packages/lakka/package.mk
@@ -27,7 +27,7 @@ if [ "${PROJECT}" = "RPi" ]; then
     PKG_DEPENDS_TARGET+=" wii-u-gc-adapter wiringPi mk_arcade_joystick_rpi joycond"
   fi
   
-  if [ "${DEVICE}" = "GPICase" -o "${DEVICE}" = "Pi02GPi" -o "${DEVICE}" = "GPICase2" ]; then
+  if [ "${DEVICE}" = "GPICase" -o "${DEVICE}" = "Pi02GPi" -o "${DEVICE}" = "RPi4-GPICase2" ]; then
     PKG_DEPENDS_TARGET+=" gpicase_safeshutdown"
   fi
 fi

--- a/projects/RPi/devices/RPi4-GPICase2/config/distroconfig.txt
+++ b/projects/RPi/devices/RPi4-GPICase2/config/distroconfig.txt
@@ -13,7 +13,7 @@ avoid_warnings=2
 disable_overscan=1
 boot_delay=0
 
-gpio=0-27=a2
+gpio=0-25=a2
 
 hdmi_group:1=2
 hdmi_mode:1=87


### PR DESCRIPTION
# Pull requests

### This PR fix SafeShutdown on RPi4-GPICase2.

On RPi4-GPICase2 latest Lakka-v5.x build, SafeShutdown was NOT worked.

There are 4 reasons.
1. Target device name is incorrect in packages/lakka/package.mk.
2. Target ARCH is not enoughed in packages/lakka/lakka_tools/gpicase_safeshutdown/package.mk.
3. There is GPIO conflicts in /boot/distroconfig.txt.
4. Current SafeShutdown script is not working on GPICase2. (Can't detect power-off)

By the way, I refer and use RetroFlag/GPiCase2-Script github repogitory have PR #4.
https://github.com/RetroFlag/GPiCase2-Script/pull/4

<BR>
<BR>


## modified: 4 files
- packages/lakka/lakka_tools/gpicase_safeshutdown/package.mk
  - Add "aarch64" to "PKG_ARCH" 
  - Replace "PKG_DEPENDS_TARGET" for GPICase2 safeshutdown script
  - Add and copy GPICase2 safeshutdown script
  - Add and enable GPICase2 safeshutdown service
  - Adjust GPICase2 or other GPICase

- packages/lakka/lakka_tools/gpicase_safeshutdown/system.d/gpicase-safeshutdown.service
  - Remove executable attribute for suppress dmesg/journalctl message

- packages/lakka/package.mk
  - Fix from "GPICase2" to "RPi4-GPICase2"

- projects/RPi/devices/RPi4-GPICase2/config/distroconfig.txt
  - Remove GPIO conflicts

## add: 2 files
- packages/lakka/lakka_tools/gpicase_safeshutdown/scripts/safeshutdown_gpicase2.py
  - Add new safeshutdown script from RetroFlag github GPiCase2-Script repogitory PR #4

- packages/lakka/lakka_tools/gpicase_safeshutdown/system.d/gpicase2-safeshutdown.service
  - Add new service (almost gpicase-safeshutdown.service)

<BR>
<BR>

Thanks and Sorry my storange English.
ASAI, Shigeaki