### PR TITLE
Fix RPi4-GPICase2 button mapping flip

### DIFF
--- a/projects/RPi/devices/RPi4-GPICase2/patches/retroarch_joypad_autoconfig/retroarch_joypad_autoconfig-01-fix-ABXY-buttons.patch
+++ b/projects/RPi/devices/RPi4-GPICase2/patches/retroarch_joypad_autoconfig/retroarch_joypad_autoconfig-01-fix-ABXY-buttons.patch
@@ -1,0 +1,25 @@
+diff --git a/udev/Microsoft X-Box 360 pad.cfg b/udev/Microsoft X-Box 360 pad.cfg
+index aec5472..26eb188 100644
+--- a/udev/Microsoft X-Box 360 pad.cfg	
++++ b/udev/Microsoft X-Box 360 pad.cfg	
+@@ -4,16 +4,16 @@ input_driver = "udev"
+ input_vendor_id = "1118"
+ input_product_id = "654"
+ 
+-input_b_btn = "0"
+-input_y_btn = "2"
++input_b_btn = "1"
++input_y_btn = "3"
+ input_select_btn = "6"
+ input_start_btn = "7"
+ input_up_btn = "h0up"
+ input_down_btn = "h0down"
+ input_left_btn = "h0left"
+ input_right_btn = "h0right"
+-input_a_btn = "1"
+-input_x_btn = "3"
++input_a_btn = "0"
++input_x_btn = "2"
+ input_l_btn = "4"
+ input_r_btn = "5"
+ input_l2_axis = "+2"


### PR DESCRIPTION
## This PR is to fix RPi4-GPICase2 button mapping flip.

RPi4-GPICase2 also needs "retroarch_joypad_autoconfig-01-fix-ABXY-buttons.patch" patch file same as GPICase and Pi02GPi.

- Add file : 1 file.
projects/RPi/devices/RPi4-GPICase2/patches/retroarch_joypad_autoconfig/retroarch_joypad_autoconfig-01-fix-ABXY-buttons.patch

<BR>
<BR>

Thanks
ASAI, shigeaki