### PR TITLE
Fix PR #1904 (Change bcm2835-bootloader package for distroconfig.txt updates)

### DIFF
--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -45,3 +45,4 @@ makeinstall_target() {
       echo "force_turbo=0" >> ${INSTALL}/usr/share/bootloader/config.txt
     fi
 }
+


### PR DESCRIPTION
## Pull requests
Fix PullRequest #1904. 
Change bcm2835-bootloader package for distroconfig.txt updates

### Description
I found PullRequest #1904 mistake in 22 Dec Nightly build.
Each(GPICase/Pi02GPi) "distroconfig.txt" hadn't changed.

### Reason
If it only change "distroconfig.txt", build system does not reconized changing bcm2835-bootloader package.
Therefore, it was not updated image's "distroconfig.txt".
It was needed to change also packages/tools/bcm2835-bootloader/package.mk.

### Changed file : 1 file
packages/tools/bcm2835-bootloader/package.mk
- Only add '\\n' to file end. 
This is for bulid system recognize changing bcm2835-bootloader package.

Sorry for my late confirm.
ASAI, Shigeaki