### PR TITLE
Disable CEC_FRAMEWORK_SUPPORT on GPICase and Pi02GPi

### DIFF
--- a/projects/RPi/devices/GPICase/options
+++ b/projects/RPi/devices/GPICase/options
@@ -14,6 +14,7 @@
     EXFAT="no"
     NTFS3G="no"
     HFSTOOLS="no"
+    CEC_FRAMEWORK_SUPPORT="no"
 
     OPENGLES="bcm2835-driver"
     GRAPHICS_DRIVERS=""

--- a/projects/RPi/devices/Pi02GPi/options
+++ b/projects/RPi/devices/Pi02GPi/options
@@ -17,6 +17,7 @@
     SFTP_SERVER="yes"
     PPTP_SUPPORT="no"
     OPENVPN_SUPPORT="no"
+    CEC_FRAMEWORK_SUPPORT="no"
 
     OPENGLES="bcm2835-driver"
     GRAPHICS_DRIVERS=""


### PR DESCRIPTION
# Pull requests
Disable CEC_FRAMEWORK_SUPPORT on GPICase and Pi02GPi
This pull request is for #1915 

## Description
- GPICase and Pi02GPi devices have no HDMI interface, and HDMI is disabled on both devices.
- Also "cec_mini_kb" is enabled on on both devices.

The "cec_mini_kb" service depends to HDMI.
If HDMI is disabled, cec_mini_kb service is failed and restarted by each 2 sec.
So these cec_mini_kb service logs are recorded in dmesg and journalctl.

## Modify information
When the device is GPICase.arm and Pi02GPi.arm, It disables CEC_FRAMEWORK_SUPPORT as 'no'.
It changes 2 files.
- projects/RPi/devices/GPICase/options
- projects/RPi/devices/Pi02GPi/options

## Confirmation
- "cec_mini_kb service is DISABLED on GPICase.arm ([After-cec-GPICase_arm.txt](https://github.com/libretro/Lakka-LibreELEC/files/13783930/After-cec-GPICase_arm.txt))
Fixed confirmation.
- "cec_mini_kb service is DISABLED on Pi02GPi.arm ([After-cec-Pi02GPi_arm.txt](https://github.com/libretro/Lakka-LibreELEC/files/13783945/After-cec-Pi02GPi_arm.txt))
Fixed confirmation.
- "cec_mini_kb service is ENABLED on RPi4.aarch64 ([After-cec-RPi4_aarch64.txt](https://github.com/libretro/Lakka-LibreELEC/files/13783957/After-cec-RPi4_aarch64.txt))
No-affect confirmation.

Thanks
Asai, SHigeaki