### PR TITLE
brcmfmac_sdio-firmware-rpi: update to 26ff205

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware-rpi/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="brcmfmac_sdio-firmware-rpi"
-PKG_VERSION="a25c7c3d04db0363409dfd17f265bab66f0eae5a"
-PKG_SHA256="1caa1be79a3050f02f7c4950caa8007220fcc486ebc181a54ae6e4b07af34795"
+PKG_VERSION="26ff205b45dc109b498a70aaf182804ad9dbfea5"
+PKG_SHA256="2f0917b104739455dd488dd8f5af2ee4430801a7ac8fe8d9866e74bfbb185356"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/LibreELEC/LibreELEC.tv"
 PKG_URL="https://github.com/LibreELEC/${PKG_NAME}/archive/${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
## This PullRequest will fix RPi Zero 2W wifi(BCM43430/2) problem.
This PullRequest is for issue #1911 .

Using the following LibreELEC.tv commit.(d88685e6038d669edc0f0d6c2a207c75e881ef69)
https://github.com/LibreELEC/LibreELEC.tv/commit/d88685e6038d669edc0f0d6c2a207c75e881ef69
### brcmfmac_sdio-firmware-rpi: update to 26ff205
Sync with RPiOS 1.2-9+rpt2 bluez / 1:20230210-5+rpt2 brcmfmac versions
- Add Bluetooth coexistence settings on 43436/43436s
- Updated SYN43436S firmware for Zero 2 W
- 43455/43456 Fix BLE advertising on new phones
- Add more model-specific symlinks

##


## Local test result:
- Build test : Passed on Pi02GPi.arm (Confirmed by ShigeakiAsai)

- WIFI test : **Fixed** and Working on RPi Zero 2W wifi(BCM43430/2) (Confirmed by [jdalmanza](https://github.com/jdalmanza))
[BCM43430_2-log-2024-01-01-13.42.57.zip](https://github.com/libretro/Lakka-LibreELEC/files/13804806/BCM43430_2-log-2024-01-01-13.42.57.zip)
02_System.log(294): [    9.389190] brcmfmac: F1 signature read @0x18000000=0x1542a9a6
02_System.log(295): [    9.394414] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43430b0-sdio for chip BCM43430/2
02_System.log(296): [    9.395290] usbcore: registered new interface driver brcmfmac
02_System.log(302): [    9.714319] brcmfmac: brcmf_c_preinit_dcmds: Firmware: BCM43430/2 wl0: Mar 31 2022 17:24:51 version 9.88.4.77 (g58bc5cc) FWID 01-3b307371
02_System.log(307): [   10.609172] brcmfmac: brcmf_cfg80211_set_power_mgmt: power save disabled

- WIFI test : Working on RPi Zero 2W wifi(BCM43430/1)  (Confirmed by ShigeakiAsai)
[BCM43430_1-log-2024-01-01-04.57.20.zip](https://github.com/libretro/Lakka-LibreELEC/files/13802797/BCM43430_1-log-2024-01-01-04.57.20.zip)
02_System.log(294): [    9.693078] brcmfmac: F1 signature read @0x18000000=0x1541a9a6
02_System.log(295): [    9.698422] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43430-sdio for chip BCM43430/1
02_System.log(296): [    9.700528] usbcore: registered new interface driver brcmfmac
02_System.log(302): [   10.094994] brcmfmac: brcmf_c_preinit_dcmds: Firmware: BCM43430/1 wl0: Jun 14 2023 07:27:45 version 7.45.96.s1 (gf031a129) FWID 01-70bd2af7 es7
02_System.log(308): [   10.711946] brcmfmac: brcmf_cfg80211_set_power_mgmt: power save disabled

## Noe:
Fixed confirmation was tested by jdalmanza.
Thank you jdalmanza help.


Thanks,
Asai, Shigeaki