### PR TITLE
vitaquake2: Add libretro core

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -311,6 +311,7 @@
                   vecx \
                   vice \
                   virtualjaguar \
+                  vitaquake2 \
                   vitaquake3 \
                   wasm4 \
                   xmil \

--- a/packages/lakka/libretro_cores/vitaquake2/package.mk
+++ b/packages/lakka/libretro_cores/vitaquake2/package.mk
@@ -1,0 +1,21 @@
+PKG_NAME="vitaquake2"
+PKG_VERSION="a74ca613ef71ed910a3cf49e71aa3c5f0294d9bf"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/libretro/vitaquake2"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Quake II Game Engine"
+PKG_TOOLCHAIN="make"
+
+if [ "${OPENGL_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+fi
+
+if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+fi
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+    cp -v vitaquake2_libretro.so ${INSTALL}/usr/lib/libretro/
+}


### PR DESCRIPTION
We already have Quake and Quake III Arena, why not Quake II? :)

Used vitaquake3 package file as a reference.