### PR TITLE
swanstation: update cmake options

### DIFF
--- a/packages/lakka/libretro_cores/swanstation/package.mk
+++ b/packages/lakka/libretro_cores/swanstation/package.mk
@@ -20,10 +20,7 @@ if [ "${VULKAN_SUPPORT}" = "yes" ]; then
   PKG_DEPENDS_TARGET+=" ${VULKAN}"
 fi
 
-PKG_CMAKE_OPTS_TARGET="-DBUILD_NOGUI_FRONTEND=OFF \
-                       -DBUILD_QT_FRONTEND=OFF \
-                       -DBUILD_LIBRETRO_CORE=ON \
-                       -DENABLE_DISCORD_PRESENCE=OFF"
+PKG_CMAKE_OPTS_TARGET="-DCMAKE_BUILD_TYPE=Release"
 
 if [ "${PROJECT}" = "Amlogic" ]; then
   PKG_CMAKE_OPTS_TARGET+=" -DUSE_FBDEV=ON"


### PR DESCRIPTION
Remove unused cmake variables and add `CMAKE_BUILD_TYPE=Release`  variable.