### PR TITLE
Lakka-v5.x RPi5: Enable Beetle Saturn core on RPi5

### DIFF
--- a/packages/lakka/libretro_cores/beetle_saturn/package.mk
+++ b/packages/lakka/libretro_cores/beetle_saturn/package.mk
@@ -1,6 +1,9 @@
 PKG_NAME="beetle_saturn"
 PKG_VERSION="cd395e9e3ee407608450ebc565e871b24e7ffed6"
 PKG_ARCH="x86_64"
+if [ "${PROJECT}" = "RPi" ] && [ "${DEVICE}" = "RPi5" ]; then
+  PKG_ARCH+=" aarch64"
+fi
 PKG_LICENSE="GPLv2"
 PKG_SITE="https://github.com/libretro/beetle-saturn-libretro"
 PKG_URL="${PKG_SITE}.git"


### PR DESCRIPTION
# Pull requests

```
beetle_saturn: Enable Beetle Saturn core on RPi5
```

## modified : 1 file
- packages/lakka/libretro_cores/beetle_saturn/package.mk
  - Add "aarch64" to "PKG_ARCH" when "${PROJECT}" is "RPi" and "${DEVICE}" is "RPi5"

## Demo movie
https://youtu.be/FK3CzX2bX5M
00:00 Lakka x5.x Raspberry Pi 5 system infromation
00:40 "Beetle Saturn" core information
01:00 "Daytona USA (Japan)" playing
02:35 "Fantasy Zone (Japan)" playing
04:05 "Sega Rally Championship (Japan)" playing
06:20 "Virtua Fighter (Japan)" playing

Thanks.
ASAI, Shigeaki