### PR TITLE
ppsspp: turn off vulkan explicitly if needed

### DIFF
--- a/packages/lakka/libretro_cores/ppsspp/package.mk
+++ b/packages/lakka/libretro_cores/ppsspp/package.mk
@@ -34,6 +34,8 @@ if [ "${VULKAN_SUPPORT}" = "yes" ]; then
   else
     PKG_CMAKE_OPTS_TARGET+=" -DUSE_VULKAN_DISPLAY_KHR=ON -DUSING_X11_VULKAN=OFF"
   fi
+else
+  PKG_CMAKE_OPTS_TARGET+=" -DVULKAN=OFF"
 fi
 
 if [ "${OPENGL_SUPPORT}" = "no" -a "${OPENGLES_SUPPORT}" = "yes" ]; then


### PR DESCRIPTION
Turn off vulkan explicitly if needed for ppsspp package, otherwise it will default to `ON`.