### PR TITLE
Fix no audio on GPICase/Pi02GPi when upgrade from v4.3

### DIFF
--- a/packages/lakka/lakka_tools/gpicase_change_audio_device/package.mk
+++ b/packages/lakka/lakka_tools/gpicase_change_audio_device/package.mk
@@ -1,0 +1,19 @@
+PKG_NAME="gpicase_change_audio_device"
+PKG_VERSION="1.0"
+PKG_LICENSE="GPL"
+PKG_SITE="https://www.lakka.tv"
+PKG_DEPENDS_TARGET="systemd"
+PKG_LONGDESC="Shell script to wget the latest update"
+PKG_TOOLCHAIN="manual"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/bin
+    cp -v ${PKG_DIR}/scripts/* ${INSTALL}/usr/bin
+}
+
+post_install() {
+  if [ "${DEVICE}" = "GPICase" -o "${DEVICE}" = "Pi02GPi" ]; then
+    enable_service gpicase-change-audio_device.service
+  fi
+}
+

--- a/packages/lakka/lakka_tools/gpicase_change_audio_device/scripts/gpicase-change-audio_device.py
+++ b/packages/lakka/lakka_tools/gpicase_change_audio_device/scripts/gpicase-change-audio_device.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+
+retroarch_cfg_file = '/storage/.config/retroarch/retroarch.cfg'
+before_audio_device = 'audio_device = "default:CARD=ALSA"'
+after_audio_device = 'audio_device = "default:CARD=Headphones"'
+
+if os.path.isfile( retroarch_cfg_file ):
+  with open( retroarch_cfg_file ) as f:
+    data_lines = f.read()
+
+  data_lines = data_lines.replace( before_audio_device , after_audio_device )
+
+  with open( retroarch_cfg_file, mode="w" ) as f:
+    f.write( data_lines )
+
+# Disable (mask) service
+#subprocess.run("systemctl disable gpicase-change-audio_device.service", shell=True)
+subprocess.run("systemctl mask gpicase-change-audio_device.service", shell=True)
+
+# Delete service link -> It is not able to deleted because '/' is readonly filesystem.
+#if(os.path.isfile('/usr/lib/systemd/system/multi-user.target.wants/gpicase-change-audio_device.service')):
+#  os.remove('/usr/lib/systemd/system/multi-user.target.wants/gpicase-change-audio_device.service')
+
+sys.exit(0)

--- a/packages/lakka/lakka_tools/gpicase_change_audio_device/system.d/gpicase-change-audio_device.service
+++ b/packages/lakka/lakka_tools/gpicase_change_audio_device/system.d/gpicase-change-audio_device.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Change audio_device parameter in /.config/retroarch/retroarch.cfg
+Before=retroarch-autostart.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/gpicase-change-audio_device.py
+Restart=no
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/lakka/package.mk
+++ b/packages/lakka/package.mk
@@ -29,6 +29,9 @@ if [ "${PROJECT}" = "RPi" ]; then
   
   if [ "${DEVICE}" = "GPICase" -o "${DEVICE}" = "Pi02GPi" -o "${DEVICE}" = "RPi4-GPICase2" ]; then
     PKG_DEPENDS_TARGET+=" gpicase_safeshutdown"
+    if [ "${DEVICE}" = "GPICase" -o "${DEVICE}" = "Pi02GPi" ]; then
+      PKG_DEPENDS_TARGET+=" gpicase_change_audio_device"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Fix no audio on GPICase/Pi02GPi when upgrade from v4.3
This PR is related to #1904.
When 1st time boot after upgrading, it changes 'audio_device' setting in retroarch.cfg via one time service.

### Background
When it upgrades v5.0 from v4.3, GPICase/Pi02GPi still keep audio_device = ALSA by /storage/.config/retroarch/retroarch.cfg.
It needs to change audio_device setting in /storage/.config/retroarch/retroarch.cfg when upgrading.

<BR>

## modified : 1 files , added : 3 file
1. packages/lakka/package.mk
  When device is GPICase or Pi02GPi, it adds 'gpicase_change_audio_device' package.

1. packages/lakka/lakka_tools/gpicase_change_audio_device/package.mk
  It installs following service and related python script.
  And, enable service.

1. packages/lakka/lakka_tools/gpicase_change_audio_device/system.d/gpicase-change-audio_device.service
  It is unit file for this service.
  \- This service starts before retroarch-autostart.service
  \- This service type is 'oneshot'
  \- This service is not Restart
  \- This service is not Remain After Exit

1. packages/lakka/lakka_tools/gpicase_change_audio_device/scripts/gpicase-change-audio_device.py
  It is main script for this service.
  \- If it includes 'audio_device = "default:CARD=ALSA"' in /storage/.config/retroarch/retroarch.cfg, replace to 'audio_device = "default:CARD=Headphones"'
  \- It mask this service

<BR>

## Confirmation
- [GPICase] - Upgrade from 4.3
  It can play audio after upgrading.
- [Pi02GPi] - Upgrade from 4.3
  It can play audio after upgrading.
- [RPi4]
  There are no files in system.
- [RPi4-GPICase2]
  There are no files in system.

<BR>

My English is so wrong.
Please let me know if you have question.
Thanks.
ASAI, Shigeaki