### PR TITLE
Switch: U-Boot: bump version to 2024-NX02

### DIFF
--- a/projects/L4T/devices/Switch/packages/switch-u-boot/package.mk
+++ b/projects/L4T/devices/Switch/packages/switch-u-boot/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="switch-u-boot"
-PKG_VERSION="69c0501a638f535424a4d045355f45c028110f82"
+PKG_VERSION="2606ef5dfa14faedca16f2dcdea59719c7c963f7"
 PKG_GIT_CLONE_BRANCH="linux-hekatf"
 PKG_DEPENDS_HOST="toolchain Python3:host gcc:host swig:host"
 PKG_DEPENDS_TARGET="toolchain Python3 gcc:target swig:host"


### PR DESCRIPTION
This is the branch I am putting fixes/workarounds for the next merge. I will change this when I am ready to merge.
Please do not merge this until I have removed the labels/dont merge stuff. I am getting tired of half finished PR's getting merged, because they are mine.
This PR is going to target these things:
1. Update u-boot. (experimental exfat booting support). (Finished)
2. Not started: Update Kernel
3. Finished/Not included because I am waiting on kernel release: Update bootloader packages for new kernel changes
4. Update Kernel Config to add support for iptables..... (Finished)
5. More LibreELEC stuff, that I need to clean up and merge.

Note:
If I can find the time to look into a solution for https://github.com/libretro/Lakka-LibreELEC/issues/1922 as this isnt an issue with cifs, but an issue with not being able to symlink files on fat32/exfat which stops you from being able to enable services from storage dir.