### PR TITLE
Lakka-v5.x : Pi02GPi.arm : It revives several cores for Pi02GPi.

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -329,7 +329,7 @@
 
 # disable some cores
   if [ "${PROJECT}" = "RPi" ]; then
-    if [ "${DEVICE}" = "RPi" -o "${DEVICE}" = "GPICase" -o "${DEVICE}" = "Pi02GPi" ]; then
+    if [ "${DEVICE}" = "RPi" -o "${DEVICE}" = "GPICase" ]; then
       EXCLUDE_LIBRETRO_CORES+="\
                                beetle_bsnes \
                                beetle_psx \
@@ -378,6 +378,8 @@
                                yabause \
                                yabasanshiro \
                               "
+    elif [ "${DEVICE}" = "Pi02GPi" ]; then
+      EXCLUDE_LIBRETRO_CORES+=" kronos openlara play ppsspp vircon32 yabasanshiro"
     elif [ "${DEVICE}" = "RPi2" ]; then
       EXCLUDE_LIBRETRO_CORES+=" play"
     elif [ "${DEVICE}" = "RPi3" ]; then


### PR DESCRIPTION
## It revives several cores for Pi02GPi.
Several cores are disabled on Pi02GPi.arm.
This pull request revives these cores.

## modified : 1 file
1. distributions/Lakka/options
It separates GPICase and Pi02GPi about EXCLUDE_LIBRETRO_CORES settings.
And, Pi02GPi excludes following 6 cores.
kronos, openlara, play, ppsspp, vircon32, yabasanshiro
These 6 cores are depend or relate on 'mesa' I think, but  Pi02GPi uses 'bcm2835-driver'.

<BR>

## Confirmation
- Build passed on Pi02GPi.arm and GPICase.arm.
- Confirm enabled cores and disable cores on Pi02GPi.arm GPiCASE2W
  \- Please refer to attached [pdf file](https://github.com/libretro/Lakka-LibreELEC/files/14897240/TestResult.pdf).

<BR>

Thanks.
ASAI, Shigeaki