### PR TITLE
nvidia : Remove libnvidia-vulkan-producer.so from nvidia package.mk

### DIFF
--- a/packages/graphics/nvidia/package.mk
+++ b/packages/graphics/nvidia/package.mk
@@ -91,10 +91,6 @@ makeinstall_target() {
       cp -P libnvidia-glvkspirv.so.${PKG_VERSION}  ${INSTALL}/usr/lib
       ln -sf libnvidia-glvkspirv.so.${PKG_VERSION} ${INSTALL}/usr/lib/libnvidia-glvkspirv.so
 
-      cp -p libnvidia-vulkan-producer.so.${PKG_VERSION}  ${INSTALL}/usr/lib
-      ln -sf libnvidia-vulkan-producer.so.${PKG_VERSION} ${INSTALL}/usr/lib/libnvidia-vulkan-producer.so.1
-      ln -sf libnvidia-vulkan-producer.so.1              ${INSTALL}/usr/lib/libnvidia-vulkan-producer.so
-
     mkdir -p ${INSTALL}/usr/share/vulkan/implicit_layer.d
       sed "s#libGLX_nvidia.so.0#libEGL_nvidia.so.0#" nvidia_layers.json > ${INSTALL}/usr/share/vulkan/implicit_layer.d/nvidia_layers.json
     mkdir -p ${INSTALL}/usr/share/vulkan/icd.d


### PR DESCRIPTION
### This pull requests fixes nvidia package build fail.
libnvidia-vulkan-producer.so is removed by NVIDIA.
https://www.nvidia.com/Download/driverResults.aspx/214102/en-us/
> Removed libnvidia-vulkan-producer.so from the driver package. This helper library is no longer needed by the Wayland WSI.

So it needs to remove about libnvidia-vulkan-producer.so from package.mk. 



<BR>

## modified : 1 file
1. packages/graphics/nvidia/package.mk
  Remove about libnvidia-vulkan-producer.so file.

<BR>

## Confirmation
- [wayland.x86_64]
  build is passed.

<BR>

Thanks.
ASAI, Shigeaki