### PR TITLE
retroarch_joypad_autoconfig : Catch up upstream file name change and …

### DIFF
--- a/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
@@ -10,14 +10,14 @@ makeinstall_target() {
   make -C ${PKG_BUILD} install INSTALLDIR="${INSTALL}/etc/retroarch-joypad-autoconfig" DOC_DIR="${INSTALL}/etc/doc/."
 
   #Remove non tested joycon configs
-  rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo\ -\ Switch\ Pro\ Controller\ \(old\).cfg
-  rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo\ -\ Switch\ Pro\ Controller.cfg
-  rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo-Switch-Online_NES-Controller_Left.cfg
-  rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo-Switch-Online_NES-Controller_Right.cfg
-  rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo\ Switch\ Left\ Joy-Con.cfg
-  rm "${INSTALL}"/etc/retroarch-joypad-autoconfig/udev/Nintendo\ Switch\ Right\ Joy-Con.cfg
+  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Co., Ltd. Pro Controller (old).cfg"
+  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Co., Ltd. Pro Controller.cfg"
+  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo-Switch-Online_NES-Controller_Left.cfg"
+  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo-Switch-Online_NES-Controller_Right.cfg"
+  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Switch Left Joy-Con.cfg"
+  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Switch Right Joy-Con.cfg"
   #Place Working configs
-  cp -Pr "${PKG_DIR}"/joypad_configs/* "${INSTALL}"/etc/retroarch-joypad-autoconfig/  
+  cp -Prv ${PKG_DIR}/joypad_configs/* ${INSTALL}/etc/retroarch-joypad-autoconfig/
 
 }
 


### PR DESCRIPTION
## retroarch_joypad_autoconfig : Catch up upstream file name change and remove some quotes.

- It catched up 2 file name changing, both are changed by upstream.
[Rename Nintendo - Switch Pro Controller.cfg to Nintendo Co., Ltd. Pro Controller.cfg](https://github.com/libretro/retroarch-joypad-autoconfig/commit/0ca8545bba883b24c53c8cde8c5357c8357ec224)
[Rename Nintendo - Switch Pro Controller (old).cfg to Nintendo Co., Ltd. Pro Controller (old).cfg](https://github.com/libretro/retroarch-joypad-autoconfig/commit/5c4389e6358d7cb4d67d535f6fb2af6d67b793ee)

- It removes some quotes on package.mk.

## modified : 1 file
1. packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
  It modifies about above things.

<BR>

## Confirmation
- Build passed on RPi4-GPICase2.aarch64.

<BR>

Thanks.
ASAI, Shigeaki