### PR TITLE
RPi: gamecon_gpio_rpi driver support

### DIFF
--- a/packages/lakka/lakka_tools/gamecon_gpio_rpi/Readme.md
+++ b/packages/lakka/lakka_tools/gamecon_gpio_rpi/Readme.md
@@ -1,0 +1,3 @@
+Instructions here:
+
+https://github.com/h1aji/gamecon_gpio_rpi/

--- a/packages/lakka/lakka_tools/gamecon_gpio_rpi/package.mk
+++ b/packages/lakka/lakka_tools/gamecon_gpio_rpi/package.mk
@@ -14,7 +14,8 @@ pre_make_target() {
 }
 
 make_target() {
-  make KDIR=$(kernel_path)
+  kernel_make KDIR=$(kernel_path) \
+        -C $(kernel_path) M=${PKG_BUILD} modules
 }
 
 makeinstall_target() {

--- a/packages/lakka/lakka_tools/gamecon_gpio_rpi/package.mk
+++ b/packages/lakka/lakka_tools/gamecon_gpio_rpi/package.mk
@@ -1,0 +1,23 @@
+PKG_NAME="gamecon_gpio_rpi"
+PKG_VERSION="26b61caea841dacc1f57587f655288d39f3ffedc"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/h1aji/gamecon_gpio_rpi"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="${LINUX_DEPENDS}"
+PKG_LONGDESC="Gamecon GPIO rpi joystick driver"
+PKG_TOOLCHAIN="manual"
+PKG_IS_KERNEL_PKG="yes"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make KDIR=$(kernel_path)
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+  cp -v ${PKG_BUILD}/*.ko ${INSTALL}/$(get_full_module_dir)/${PKG_NAME}
+}

--- a/packages/lakka/package.mk
+++ b/packages/lakka/package.mk
@@ -24,7 +24,7 @@ fi
 if [ "${PROJECT}" = "RPi" ]; then
   PKG_DEPENDS_TARGET+=" rpi_disable_hdmi_service disable_wifi_powersave RPi.GPIO"
   if [ "${DEVICE}" != "GPICase" -a "${DEVICE}" != "Pi02GPi" -a "${DEVICE}" != "RPiZero2-GPiCASE2W" ] ; then
-    PKG_DEPENDS_TARGET+=" wii-u-gc-adapter wiringPi mk_arcade_joystick_rpi joycond"
+    PKG_DEPENDS_TARGET+=" wii-u-gc-adapter wiringPi mk_arcade_joystick_rpi joycond gamecon_gpio_rpi"
   fi
   
   if [ "${DEVICE}" = "GPICase" -o "${DEVICE}" = "Pi02GPi" -o "${DEVICE}" = "RPi4-GPICase2" -o "${DEVICE}" = "RPiZero2-GPiCASE2W" ]; then


### PR DESCRIPTION
Updated gamecon_gpio_rpi driver to version 1.4 from https://github.com/marqs85/gamecon_gpio_rpi