### PR TITLE
retroarch: fix the cheats directory mounting

### DIFF
--- a/packages/lakka/retroarch_base/retroarch/system.d/tmp-cheats.mount
+++ b/packages/lakka/retroarch_base/retroarch/system.d/tmp-cheats.mount
@@ -6,11 +6,10 @@ After=systemd-tmpfiles-setup.service
 DefaultDependencies=no
 
 [Mount]
-What=/storage/cheats:/usr/share/libretro-database/cht
+What=none
 Where=/tmp/cheats
-Type=mergerfs
-Options=defaults,allow_other,use_ino
-
+Type=overlay
+Options=lowerdir=/usr/share/libretro-database/cht,upperdir=/storage/cheats,workdir=/storage/.tmp/cheats-workdir
 
 [Install]
 WantedBy=retroarch.target

--- a/packages/lakka/retroarch_base/retroarch/tmpfiles.d/retroarch-userdirs.conf
+++ b/packages/lakka/retroarch_base/retroarch/tmpfiles.d/retroarch-userdirs.conf
@@ -1,4 +1,5 @@
 d    /storage/assets                0777 root root - -
+d    /storage/cheats                0777 root root - -
 d    /storage/cores                 0777 root root - -
 d    /storage/database              0777 root root - -
 d    /storage/joypads               0777 root root - -
@@ -18,6 +19,7 @@ d    /storage/thumbnails            0777 root root - -
 
 d    /storage/.tmp                  0777 root root - -
 d    /storage/.tmp/assets-workdir   0777 root root - -
+d    /storage/.tmp/cheats-workdir   0777 root root - -
 d    /storage/.tmp/cores-workdir    0777 root root - -
 d    /storage/.tmp/database-workdir 0777 root root - -
 d    /storage/.tmp/joypads-workdir  0777 root root - -

--- a/projects/L4T/devices/Switch/packages/retroarch/system.d/tmp-cheats.mnt
+++ b/projects/L4T/devices/Switch/packages/retroarch/system.d/tmp-cheats.mnt
@@ -6,7 +6,7 @@ After=systemd-tmpfiles-setup.service
 DefaultDependencies=no
 
 [Mount]
-What=/storage/cheats:/usr/share/libretro-cheats
+What=/storage/cheats:/usr/share/libretro-database/cht
 Where=/tmp/cheats
 Type=mergerfs
 Options=defaults,allow_other,use_ino


### PR DESCRIPTION
This updates the cheats directory to be referencing the installed directory from libretro-database.
