### PR TITLE
cec_mini_kb : cec-mini-kb.service is started 1 time only when retroarch.service is activated

### DIFF
--- a/packages/lakka/lakka_tools/cec_mini_kb/package.mk
+++ b/packages/lakka/lakka_tools/cec_mini_kb/package.mk
@@ -2,7 +2,7 @@
 # 2021 Giovanni Cascione
 
 PKG_NAME="cec_mini_kb"
-PKG_VERSION="be4289751bd80470c33847073a790b83356696db"
+PKG_VERSION="fea75efa52e73b1fc70750e308b153cfba84696f"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/spleen1981/cec-mini-kb"
 PKG_URL="${PKG_SITE}/archive/${PKG_VERSION}.tar.gz"

--- a/packages/lakka/lakka_tools/cec_mini_kb/system.d/cec-mini-kb.service
+++ b/packages/lakka/lakka_tools/cec_mini_kb/system.d/cec-mini-kb.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=cec-mini-kb
-DefaultDependencies=no
+After=retroarch.service
+Requires=retroarch.service
 
 [Service]
 ExecStart=/usr/bin/cec-mini-kb --poweroff "shutdown -P now"
-Restart=always
-RestartSec=2
+Restart=no
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=retroarch.service

--- a/packages/lakka/lakka_tools/cec_mini_kb/system.d/cec-mini-kb.service
+++ b/packages/lakka/lakka_tools/cec_mini_kb/system.d/cec-mini-kb.service
@@ -5,7 +5,10 @@ Requires=retroarch.service
 
 [Service]
 ExecStart=/usr/bin/cec-mini-kb --poweroff "shutdown -P now"
-Restart=no
+Restart=always
+RestartSec=2
+StartLimitInterval=20s
+StartLimitBurst=3
 
 [Install]
 WantedBy=retroarch.service

--- a/packages/lakka/lakka_tools/cec_mini_kb/system.d/cec-mini-kb.service
+++ b/packages/lakka/lakka_tools/cec_mini_kb/system.d/cec-mini-kb.service
@@ -5,10 +5,7 @@ Requires=retroarch.service
 
 [Service]
 ExecStart=/usr/bin/cec-mini-kb --poweroff "shutdown -P now"
-Restart=always
-RestartSec=2
-StartLimitInterval=20s
-StartLimitBurst=3
+Restart=no
 
 [Install]
 WantedBy=retroarch.service

--- a/packages/lakka/retroarch_base/retroarch/patches/retroarch-999-notify-initialize-complete-to-systemd.patch
+++ b/packages/lakka/retroarch_base/retroarch/patches/retroarch-999-notify-initialize-complete-to-systemd.patch
@@ -1,0 +1,34 @@
+diff --git a/Makefile.common b/Makefile.common
+index 2a715f4786..cd2f49518b 100644
+--- a/Makefile.common
++++ b/Makefile.common
+@@ -788,6 +788,7 @@ endif
+ ifeq ($(HAVE_LAKKA), 1)
+    OBJ += network/drivers_wifi/connmanctl.o
+    OBJ += misc/cpufreq/cpufreq.o
++   LIBS += -lsystemd
+ endif
+ 
+ ifeq ($(HAVE_WIFI), 1)
+diff --git a/retroarch.c b/retroarch.c
+index 8137c2e358..3c766dd6cb 100644
+--- a/retroarch.c
++++ b/retroarch.c
+@@ -215,6 +215,7 @@
+ 
+ #ifdef HAVE_LAKKA
+ #include "lakka.h"
++#include <systemd/sd-daemon.h>
+ #endif
+ 
+ #define _PSUPP(var, name, desc) printf("  %s:\n\t\t%s: %s\n", name, desc, var ? "yes" : "no")
+@@ -5933,6 +5934,9 @@ int rarch_main(int argc, char *argv[], void *data)
+ #if HAVE_CLOUDSYNC
+    task_push_cloud_sync();
+ #endif
++#ifdef HAVE_LAKKA
++   sd_notify(0, "READY=1");
++#endif
+ #if !defined(HAVE_MAIN) || defined(HAVE_QT)
+    for (;;)
+    {

--- a/packages/lakka/retroarch_base/retroarch/system.d/retroarch.service
+++ b/packages/lakka/retroarch_base/retroarch/system.d/retroarch.service
@@ -16,6 +16,7 @@ TimeoutStopSec=10
 Restart=always
 RestartSec=2
 StartLimitInterval=0
+Type=notify
 
 [Install]
 WantedBy=retroarch.target


### PR DESCRIPTION
## This pull request concerns with issue #1981 
Current (Lakka-v5.x) cec-mini-kb.service is always restarted even if it is failed.
If CEC unsupported HDMI display is connected, the framerate hiccups is happened by each cec-mini-kb.service restarts.
It needs to control the cec-mini-kb.service starting.

### Idea for fix
At first, please refer systemd.service manual.
https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html
Give "cec-mini-kb.service" to depend "retroarch.service".
When the systemd detects "retroarch.service" was normally started, it starts "cec-mini-kb.service".
The "cec-mini-kb.service" is started 1 time only.

### Changing detail
- retroarch.service
Change service type to "notify".
- retroarch
Notifies "Ready" to systemd via sd_notify() when initialize is done.
- cec-mini-kb package
Update package revision.
- cec-mini-kb.service
(a) Give "After=retroarch.service" and "Requires=retroarch.service" dependencies in [Unit] section.
(b) Change to "WantedBy=retroarch.service" from "WantedBy=multi-user.target" in [Install] section.
(c) Remove "RestartSec=2" and creplace "Restart=no" from "Restart=always" in [Service] section.
By (a) and (b), the systemd starts "cec-mini-kb.service" after "retroarch.service" is activated.
By (c), the systemd only start s "cec-mini-kb.service" 1 time.

### Limitation:
- When HDMI display is not recognized or not connected in Lakka booting,
"cec-mini-kb.service" is failed after reconnect HDMI display.

### Request:
I placed "sd_notify()" into rarch_main() on retroarch.
Please let me know more good place.

Thanks
ASAI, Shigeaki