### PR TITLE
mupen64plus-next: Add Raspberry Pi 5 options

### DIFF
--- a/packages/lakka/libretro_cores/mupen64plus_next/package.mk
+++ b/packages/lakka/libretro_cores/mupen64plus_next/package.mk
@@ -35,10 +35,6 @@ pre_make_target() {
                 -I${SYSROOT_PREFIX}/usr/include/interface/vmcs_host/linux"
   fi
 
-  if [ "${DEVICE}" = "RPi5" ]; then
-    CFLAGS+=" -DPAGESIZE=16384 -mcpu=cortex-a76 -mtune=cortex-a76"
-  fi
-
   case ${DEVICE:-$PROJECT} in
     RPi)
       PKG_MAKE_OPTS_TARGET+=" platform=rpi-mesa"
@@ -59,7 +55,7 @@ pre_make_target() {
       PKG_MAKE_OPTS_TARGET+=" platform=rpi4_64-mesa FORCE_GLES3=1"
       ;;
     RPi5)
-      PKG_MAKE_OPTS_TARGET+=" platform=rpi-mesa FORCE_GLES3=1"
+      PKG_MAKE_OPTS_TARGET+=" platform=rpi-mesa FORCE_GLES3=1 CPUFLAGS+=-DPAGESIZE=16384 CPUFLAGS+=-mcpu=${TARGET_CPU}"
       ;;
     Exynos)
       PKG_MAKE_OPTS_TARGET+=" platform=odroid BOARD=ODROID-XU"

--- a/packages/lakka/libretro_cores/mupen64plus_next/package.mk
+++ b/packages/lakka/libretro_cores/mupen64plus_next/package.mk
@@ -55,7 +55,7 @@ pre_make_target() {
       PKG_MAKE_OPTS_TARGET+=" platform=rpi4_64-mesa FORCE_GLES3=1"
       ;;
     RPi5)
-      PKG_MAKE_OPTS_TARGET+=" platform=rpi-mesa FORCE_GLES3=1 CPUFLAGS+=-DPAGESIZE=16384 CPUFLAGS+=-mcpu=${TARGET_CPU}"
+      PKG_MAKE_OPTS_TARGET+=" platform=rpi-mesa FORCE_GLES3=1 CPUFLAGS="
       ;;
     Exynos)
       PKG_MAKE_OPTS_TARGET+=" platform=odroid BOARD=ODROID-XU"

--- a/packages/lakka/libretro_cores/mupen64plus_next/package.mk
+++ b/packages/lakka/libretro_cores/mupen64plus_next/package.mk
@@ -25,7 +25,7 @@ fi
 
 pre_make_target() {
   if [ "${OPENGLES}" = "libmali" ]; then
-    CLAGS+=" -DGL_USE_DLSYM"
+    CFLAGS+=" -DGL_USE_DLSYM"
     CXXFLAGS+=" -DGL_USE_DLSYM"
     LDFLAGS+=" -ldl"
   elif [ "${OPENGLES}" = "bcm2835-driver" ]; then
@@ -33,6 +33,10 @@ pre_make_target() {
               -I${SYSROOT_PREFIX}/usr/include/interface/vmcs_host/linux"
     CXXFLAGS+=" -I${SYSROOT_PREFIX}/usr/include/interface/vcos/pthreads \
                 -I${SYSROOT_PREFIX}/usr/include/interface/vmcs_host/linux"
+  fi
+
+  if [ "${DEVICE}" = "RPi5" ]; then
+    CFLAGS+=" -DPAGESIZE=16384 -mcpu=cortex-a76 -mtune=cortex-a76"
   fi
 
   case ${DEVICE:-$PROJECT} in
@@ -53,6 +57,9 @@ pre_make_target() {
       ;;
     RPi4*)
       PKG_MAKE_OPTS_TARGET+=" platform=rpi4_64-mesa FORCE_GLES3=1"
+      ;;
+    RPi5)
+      PKG_MAKE_OPTS_TARGET+=" platform=rpi-mesa FORCE_GLES3=1"
       ;;
     Exynos)
       PKG_MAKE_OPTS_TARGET+=" platform=odroid BOARD=ODROID-XU"


### PR DESCRIPTION
Currently on the `RPi5` platform the available N64 emulation cores are crashing upon startup. This is due to a page size mismatch with the new Raspberry Pi 5 kernel, as outlined in issue #1982 

Since the upstream Makefile has no specific options for RPi5, I added the page size option and appropriate CPU optimizations to the compiler flags. Also, I added a case for compiling the `RPi5` platform as it was missing.

This fix still requires testing on a Raspberry Pi 5 device before merging.