### PR TITLE
lg-gpio : Adjust for Lakka v6.x

### DIFF
--- a/packages/addons/addon-depends/rpi-tools-depends/lg-gpio/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/lg-gpio/package.mk
@@ -27,3 +27,20 @@ make_target() {
   )
 }
 
+makeinstall_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    mkdir -p "${INSTALL}/usr/lib"
+    cp -v ./liblgpio.so* "${INSTALL}/usr/lib"
+    (
+      cd PY_LGPIO
+      python setup.py install --root=${INSTALL} --prefix=/usr
+    )
+  fi
+}
+
+post_makeinstall_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    find ${INSTALL}/usr/lib -name "*.py" -exec rm -rf "{}" ";"
+    rm -rf ${INSTALL}/usr/bin
+  fi
+}


### PR DESCRIPTION
# Adjust lg-gpio package for Lakka v6.x
In Lakka v6.x (and upstream), the RPi.GPIO package is removed and the lg-gpio package is added.
Added lg-gpio package needs to adjust for Lakka.

## modified : 1 file
1. packages/addons/addon-depends/rpi-tools-depends/lg-gpio/package.mk
  Like as the gpiozero package, copy necessary files and delete unnecessary files.

<BR>

Thanks.
ASAI, Shigeaki