### PR TITLE
flycast: RPi5: Fix to does not start flycast on Lakka-v6 RPi5

### DIFF
--- a/projects/RPi/devices/RPi5/patches/flycast/0002-remove-to-set-PAGE_SIZE-when-building-for-RPi5.patch
+++ b/projects/RPi/devices/RPi5/patches/flycast/0002-remove-to-set-PAGE_SIZE-when-building-for-RPi5.patch
@@ -1,0 +1,15 @@
+diff -uNr a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2024-12-05 13:41:07.436899300 +0900
++++ b/CMakeLists.txt	2024-12-05 13:49:20.465024903 +0900
+@@ -244,11 +244,6 @@
+ 		$<$<BOOL:${WINDOWS_STORE}>:NOCRYPT>
+ 		$<$<OR:$<BOOL:${MINGW}>,$<BOOL:${MSVC}>>:_USE_MATH_DEFINES>)
+ 
+-if(UNIX AND NOT ANDROID AND NOT APPLE)
+-	execute_process(COMMAND getconf PAGESIZE OUTPUT_VARIABLE PAGE_SIZE OUTPUT_STRIP_TRAILING_WHITESPACE)
+-	target_compile_definitions(${PROJECT_NAME} PRIVATE PAGE_SIZE=${PAGE_SIZE})
+-endif()
+-
+ if(NOT "${SENTRY_UPLOAD_URL}" STREQUAL "")
+ 	target_compile_definitions(${PROJECT_NAME} PRIVATE SENTRY_UPLOAD="${SENTRY_UPLOAD_URL}")
+ endif()


### PR DESCRIPTION
## Fix to does not start flycast on Lakka-v6.x RPi5
Lakka-v6.x RPi5 is't able to start flycast core. 
- Lakka-RPi5.aarch64-6.0-devel-20241203150651-04002d5.img.gz
- Lakka-RPi5.aarch64-6.x-20240618-88bdb7e.img.gz
<BR>

### [Reason]
The flycast core side committed the following for RPi5 issue.
https://github.com/flyinghead/flycast/commit/0f6a92caad25ed65d6b558bb965793ae02c39be1
In ‎CMakeLists.txt, line 239
`execute_process(COMMAND getconf PAGESIZE OUTPUT_VARIABLE PAGE_SIZE OUTPUT_STRIP_TRAILING_WHITESPACE)`
It gets HOST's PAGE_SIZE. So PAGE_SIZE is set 4096 and use it for building.
But, RPi5's PAGE_SIZE needs 16KB.
<BR>

### Add : 1 file
- projects/RPi/devices/RPi5/patches/flycast/0002-remove-to-set-PAGE_SIZE-when-building-for-RPi5.patch
  Only for RPi5, Remove get/set PAGE_SIZE of build envrionment.

<BR>

### [Confirmatrion]
- The flycast core with this patch file build is passed.
- Built flycast core is able to start on Lakka-RPi5.aarch64-6.0-devel-20241203150651-04002d5.img.gz
<BR>

Thanks
ASAI, Shigeaki