### PR TITLE
(withdraw) Lakka-v6.x: Fix mesa buildbreak

### DIFF
--- a/config/graphic
+++ b/config/graphic
@@ -45,7 +45,7 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "etnaviv"; then
-    GALLIUM_DRIVERS+=" etnaviv kmsro"
+    GALLIUM_DRIVERS+=" etnaviv"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"
     VDPAU_SUPPORT="no"
@@ -75,7 +75,7 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "lima"; then
-    GALLIUM_DRIVERS+=" kmsro lima"
+    GALLIUM_DRIVERS+=" lima"
     V4L2_SUPPORT="yes"
   fi
 
@@ -100,7 +100,7 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "panfrost"; then
-    GALLIUM_DRIVERS+=" kmsro panfrost"
+    GALLIUM_DRIVERS+=" panfrost"
     VULKAN_DRIVERS_MESA+=" panfrost"
     V4L2_SUPPORT="yes"
   fi
@@ -133,7 +133,7 @@ get_graphicdrivers() {
   fi
 
   if listcontains "${GRAPHIC_DRIVERS}" "vc4"; then
-    GALLIUM_DRIVERS+=" vc4 v3d kmsro"
+    GALLIUM_DRIVERS+=" vc4 v3d"
     VULKAN_DRIVERS_MESA+=" broadcom"
     V4L2_SUPPORT="yes"
     VAAPI_SUPPORT="no"

--- a/packages/devel/libclc/package.mk
+++ b/packages/devel/libclc/package.mk
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libclc"
+PKG_VERSION="$(get_pkg_version llvm)"
+PKG_LICENSE="Apache-2.0"
+PKG_URL=""
+PKG_DEPENDS_HOST="toolchain:host llvm:host"
+PKG_LONGDESC="Low-Level Virtual Machine (LLVM) is a compiler infrastructure."
+PKG_DEPENDS_UNPACK+=" llvm"
+PKG_PATCH_DIRS+=" $(get_pkg_directory llvm)/patches"
+PKG_TOOLCHAIN="cmake"
+
+unpack() {
+  mkdir -p ${PKG_BUILD}
+  tar --strip-components=1 -xf ${SOURCES}/llvm/llvm-${PKG_VERSION}.tar.xz -C ${PKG_BUILD}
+}
+
+pre_configure() {
+  PKG_CMAKE_SCRIPT="${PKG_BUILD}/libclc/CMakeLists.txt"
+}
+
+pre_configure_host() {
+  LIBCLC_TARGETS_TO_BUILD="spirv64-mesa3d-"
+
+  mkdir -p "${PKG_BUILD}/.${HOST_NAME}"
+  cd ${PKG_BUILD}/.${HOST_NAME}
+  PKG_CMAKE_OPTS_HOST="-DLIBCLC_TARGETS_TO_BUILD=${LIBCLC_TARGETS_TO_BUILD}"
+}

--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -54,7 +54,7 @@ if [ "${DISPLAYSERVER}" = "x11" ]; then
   fi
   if [ "${PROJECT}" = "L4T" ]; then
     PKG_DEPENDS_TARGET+=" libglvnd"
-    PKG_MESON_OPTS_TARGET+=" -Dglvnd=true"
+    PKG_MESON_OPTS_TARGET+=" -Dglvnd=enabled"
   fi
 elif [ "${DISPLAYSERVER}" = "wl" ]; then
   PKG_DEPENDS_TARGET+=" wayland wayland-protocols"
@@ -62,7 +62,7 @@ elif [ "${DISPLAYSERVER}" = "wl" ]; then
                            -Dglx=disabled"
 elif [ "${DISTRO}" = "Lakka" -o "${PROJECT}" = "L4T" ]; then
   PKG_DEPENDS_TARGET+=" libglvnd"
-  PKG_MESON_OPTS_TARGET+=" -Dplatforms="" -Ddri3=enabled -Dglx=disabled -Dglvnd=true"
+  PKG_MESON_OPTS_TARGET+=" -Dplatforms="" -Dglx=disabled -Dglvnd=enabled"
 else
   PKG_MESON_OPTS_TARGET+=" -Dplatforms="" \
                            -Dglx=disabled"
@@ -135,6 +135,7 @@ fi
 makeinstall_host() {
   mkdir -p "${TOOLCHAIN}/bin"
     cp -a src/intel/compiler/intel_clc "${TOOLCHAIN}/bin"
+}
 
 post_makeinstall_target() {
   if [ "${PROJECT}" = "L4T" ]; then

--- a/packages/python/devel/flit/package.mk
+++ b/packages/python/devel/flit/package.mk
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="flit"
+PKG_VERSION="3.9.0"
+PKG_SHA256="72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba"
+PKG_LICENSE="BSD"
+PKG_SITE="https://pypi.org/project/flit-core/"
+PKG_URL="https://files.pythonhosted.org/packages/source/f/flit_core/flit_core-${PKG_VERSION}.tar.gz"
+PKG_SOURCE_DIR="flit_core-${PKG_VERSION}"
+PKG_DEPENDS_HOST="Python3:host"
+PKG_LONGDESC="flit provides a PEP 517 build backend for packages using Flit."
+PKG_TOOLCHAIN="manual"
+
+make_host() {
+  export DONT_BUILD_LEGACY_PYC=1
+  python3 -m flit_core.wheel
+}
+
+makeinstall_host() {
+  exec_thread_safe python3 -m bootstrap_install dist/*.whl --installdir=${TOOLCHAIN}/lib/${PKG_PYTHON_VERSION}/site-packages
+}

--- a/packages/python/devel/pybuild/package.mk
+++ b/packages/python/devel/pybuild/package.mk
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pybuild"
+PKG_VERSION="1.2.1"
+PKG_SHA256="526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d"
+PKG_LICENSE="BSD"
+PKG_SITE="https://pypi.org/project/build/"
+PKG_URL="https://files.pythonhosted.org/packages/source/b/build/build-${PKG_VERSION}.tar.gz"
+PKG_SOURCE_DIR="build-${PKG_VERSION}"
+PKG_DEPENDS_HOST="flit:host pyproject-hooks:host pyinstaller:host pypackaging:host"
+PKG_LONGDESC="A simple, correct Python build frontend."
+PKG_TOOLCHAIN="python-flit"

--- a/packages/python/devel/pybuild/package.mk
+++ b/packages/python/devel/pybuild/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pybuild"
-PKG_VERSION="1.2.1"
-PKG_SHA256="526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d"
+PKG_VERSION="1.2.2"
+PKG_SHA256="119b2fb462adef986483438377a13b2f42064a2a3a4161f24a0cca698a07ac8c"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/build/"
 PKG_URL="https://files.pythonhosted.org/packages/source/b/build/build-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/pycparser/package.mk
+++ b/packages/python/devel/pycparser/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pycparser"
+PKG_VERSION="2.22"
+PKG_SHA256="491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"
+PKG_LICENSE="BSD-3-Clause"
+PKG_SITE="https://pypi.org/project/pycparser/"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="Python3:host setuptools:host"
+PKG_LONGDESC="Complete C99 parser in pure Python"
+PKG_TOOLCHAIN="python"

--- a/packages/python/devel/pyinstaller/package.mk
+++ b/packages/python/devel/pyinstaller/package.mk
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pyinstaller"
+PKG_VERSION="0.7.0"
+PKG_SHA256="a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631"
+PKG_LICENSE="MIT"
+PKG_SITE="https://pypi.org/project/installer/"
+PKG_URL="https://files.pythonhosted.org/packages/source/i/installer/installer-${PKG_VERSION}.tar.gz"
+PKG_SOURCE_DIR="installer-${PKG_VERSION}"
+PKG_DEPENDS_HOST="flit:host"
+PKG_LONGDESC="installer provides basic functionality and abstractions for handling wheels and installing packages from wheels."
+PKG_TOOLCHAIN="python-flit"
+
+makeinstall_host() {
+  # simple bootstrap install, but should be able to call itself if needed
+  unzip -o -d ${TOOLCHAIN}/lib/${PKG_PYTHON_VERSION}/site-packages dist/*.whl
+}

--- a/packages/python/devel/pyinstaller/patches/0001-Add-overwrite-existing-option-that-overwrites-existi.patch
+++ b/packages/python/devel/pyinstaller/patches/0001-Add-overwrite-existing-option-that-overwrites-existi.patch
@@ -1,0 +1,82 @@
+From 4628ef70e1159d3cbab58d395f647c3dff887650 Mon Sep 17 00:00:00 2001
+From: Carl Smedstad <carl.smedstad@protonmail.com>
+Date: Tue, 13 Feb 2024 21:10:22 +0100
+Subject: [PATCH] Add --overwrite-existing option that overwrites existing
+ files
+
+Implement the --overwrite-existing option that, if supplied, will make
+installer overwrite any already existing package files instead of
+failing. With this flag, installer can be used in an idempotent manner,
+i.e. the same command can be executed multiple times with the same
+result:
+
+    python -m installer --overwrite-existing --destdir=tmp dist/*.whl
+    python -m installer --overwrite-existing --destdir=tmp dist/*.whl
+    python -m installer --overwrite-existing --destdir=tmp dist/*.whl
+---
+ src/installer/__main__.py     |  6 ++++++
+ src/installer/destinations.py |  5 ++++-
+ tests/test_destinations.py    | 22 ++++++++++++++++++++++
+ 3 files changed, 32 insertions(+), 1 deletion(-)
+
+diff --git a/src/installer/__main__.py b/src/installer/__main__.py
+index 7ece8d213fe4..b587232912f9 100644
+--- a/src/installer/__main__.py
++++ b/src/installer/__main__.py
+@@ -51,6 +51,11 @@ def _get_main_parser() -> argparse.ArgumentParser:
+         choices=["all", "entries", "none"],
+         help="validate the wheel against certain part of its record (default=none)",
+     )
++    parser.add_argument(
++        "--overwrite-existing",
++        action="store_true",
++        help="silently overwrite existing files",
++    )
+     return parser
+ 
+ 
+@@ -95,6 +100,7 @@ def _main(cli_args: Sequence[str], program: Optional[str] = None) -> None:
+             script_kind=get_launcher_kind(),
+             bytecode_optimization_levels=bytecode_levels,
+             destdir=args.destdir,
++            overwrite_existing=args.overwrite_existing,
+         )
+         installer.install(source, destination, {})
+ 
+diff --git a/src/installer/destinations.py b/src/installer/destinations.py
+index 31a254c387be..982e6adfc218 100644
+--- a/src/installer/destinations.py
++++ b/src/installer/destinations.py
+@@ -111,6 +111,7 @@ class SchemeDictionaryDestination(WheelDestination):
+         hash_algorithm: str = "sha256",
+         bytecode_optimization_levels: Collection[int] = (),
+         destdir: Optional[str] = None,
++        overwrite_existing: bool = False,
+     ) -> None:
+         """Construct a ``SchemeDictionaryDestination`` object.
+ 
+@@ -127,6 +128,7 @@ class SchemeDictionaryDestination(WheelDestination):
+         :param destdir: A staging directory in which to write all files. This
+             is expected to be the filesystem root at runtime, so embedded paths
+             will be written as though this was the root.
++        :param overwrite_existing: silently overwrite existing files.
+         """
+         self.scheme_dict = scheme_dict
+         self.interpreter = interpreter
+@@ -134,6 +136,7 @@ class SchemeDictionaryDestination(WheelDestination):
+         self.hash_algorithm = hash_algorithm
+         self.bytecode_optimization_levels = bytecode_optimization_levels
+         self.destdir = destdir
++        self.overwrite_existing = overwrite_existing
+ 
+     def _path_with_destdir(self, scheme: Scheme, path: str) -> str:
+         file = os.path.join(self.scheme_dict[scheme], path)
+@@ -161,7 +164,7 @@ class SchemeDictionaryDestination(WheelDestination):
+         - Hashes the written content, to determine the entry in the ``RECORD`` file.
+         """
+         target_path = self._path_with_destdir(scheme, path)
+-        if os.path.exists(target_path):
++        if not self.overwrite_existing and os.path.exists(target_path):
+             message = f"File already exists: {target_path}"
+             raise FileExistsError(message)
+ 

--- a/packages/python/devel/pypackaging/package.mk
+++ b/packages/python/devel/pypackaging/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pypackaging"
-PKG_VERSION="24.1"
-PKG_SHA256="026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"
+PKG_VERSION="24.2"
+PKG_SHA256="c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/build/"
 PKG_URL="https://files.pythonhosted.org/packages/source/p/packaging/packaging-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/pypackaging/package.mk
+++ b/packages/python/devel/pypackaging/package.mk
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pypackaging"
+PKG_VERSION="24.1"
+PKG_SHA256="026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"
+PKG_LICENSE="BSD"
+PKG_SITE="https://pypi.org/project/build/"
+PKG_URL="https://files.pythonhosted.org/packages/source/p/packaging/packaging-${PKG_VERSION}.tar.gz"
+PKG_SOURCE_DIR="packaging-${PKG_VERSION}"
+PKG_DEPENDS_HOST="flit:host pyinstaller:host"
+PKG_LONGDESC="Reusable core utilities for various Python Packaging interoperability specifications."
+PKG_TOOLCHAIN="python-flit"

--- a/packages/python/devel/pyproject-hooks/package.mk
+++ b/packages/python/devel/pyproject-hooks/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pyproject-hooks"
-PKG_VERSION="1.0.0"
-PKG_SHA256="f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5"
+PKG_VERSION="1.2.0"
+PKG_SHA256="1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8"
 PKG_LICENSE="BSD"
 PKG_SITE="https://pypi.org/project/pyproject-hooks/"
 PKG_URL="https://files.pythonhosted.org/packages/source/p/pyproject_hooks/pyproject_hooks-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/pyproject-hooks/package.mk
+++ b/packages/python/devel/pyproject-hooks/package.mk
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pyproject-hooks"
+PKG_VERSION="1.0.0"
+PKG_SHA256="f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5"
+PKG_LICENSE="BSD"
+PKG_SITE="https://pypi.org/project/pyproject-hooks/"
+PKG_URL="https://files.pythonhosted.org/packages/source/p/pyproject_hooks/pyproject_hooks-${PKG_VERSION}.tar.gz"
+PKG_SOURCE_DIR="pyproject_hooks-${PKG_VERSION}"
+PKG_DEPENDS_HOST="flit:host pyinstaller:host"
+PKG_LONGDESC="pyproject-hooks provides the basic functionality to help write tooling that generates distribution files from Python projects."
+PKG_TOOLCHAIN="python-flit"

--- a/packages/python/devel/pyyaml/package.mk
+++ b/packages/python/devel/pyyaml/package.mk
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="pyyaml"
+PKG_VERSION="6.0.2"
+PKG_SHA256="d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"
+PKG_LICENSE="MIT"
+PKG_SITE="https://pypi.org/project/PyYAML/"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_HOST="Python3:host setuptools:host"
+PKG_LONGDESC="YAML parser and emitter for Python"
+PKG_TOOLCHAIN="python"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="75.5.0"
-PKG_SHA256="5c4ccb41111392671f02bb5f8436dfc5a9a7185e80500531b133f5775c4163ef"
+PKG_VERSION="75.6.0"
+PKG_SHA256="8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="75.2.0"
-PKG_SHA256="753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec"
+PKG_VERSION="75.3.0"
+PKG_SHA256="fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="75.1.0"
-PKG_SHA256="d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538"
+PKG_VERSION="75.2.0"
+PKG_SHA256="753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="74.1.2"
-PKG_SHA256="95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6"
+PKG_VERSION="75.1.0"
+PKG_SHA256="d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,17 +3,17 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="52.0.0"
-PKG_SHA256="ff0c74d1b905a224d647f99c6135eacbec2620219992186b81aa20012bc7f882"
+PKG_VERSION="73.0.1"
+PKG_SHA256="d59a3e788ab7e012ab2c4baed1b376da6366883ee20d7a5fc426816e3d7b1193"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
-PKG_URL="https://github.com/pypa/setuptools/archive/v${PKG_VERSION}.tar.gz"
+PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="Python3:host"
 PKG_LONGDESC="Replaces Setuptools as the standard method for working with Python module distributions."
 PKG_TOOLCHAIN="manual"
 
 make_host() {
-  python3 bootstrap.py
+  python3 setup.py build
 }
 
 makeinstall_host() {

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -8,14 +8,6 @@ PKG_SHA256="d59a3e788ab7e012ab2c4baed1b376da6366883ee20d7a5fc426816e3d7b1193"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_HOST="Python3:host"
+PKG_DEPENDS_HOST="pybuild:host"
 PKG_LONGDESC="Replaces Setuptools as the standard method for working with Python module distributions."
-PKG_TOOLCHAIN="manual"
-
-make_host() {
-  python3 setup.py build
-}
-
-makeinstall_host() {
-  exec_thread_safe python3 setup.py install --prefix=${TOOLCHAIN}
-}
+PKG_TOOLCHAIN="python"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="74.0.0"
-PKG_SHA256="a85e96b8be2b906f3e3e789adec6a9323abf79758ecfa3065bd740d81158b11e"
+PKG_VERSION="74.1.0"
+PKG_SHA256="bea195a800f510ba3a2bc65645c88b7e016fe36709fefc58a880c4ae8a0138d7"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="73.0.1"
-PKG_SHA256="d59a3e788ab7e012ab2c4baed1b376da6366883ee20d7a5fc426816e3d7b1193"
+PKG_VERSION="74.0.0"
+PKG_SHA256="a85e96b8be2b906f3e3e789adec6a9323abf79758ecfa3065bd740d81158b11e"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="74.1.0"
-PKG_SHA256="bea195a800f510ba3a2bc65645c88b7e016fe36709fefc58a880c4ae8a0138d7"
+PKG_VERSION="74.1.2"
+PKG_SHA256="95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="75.3.0"
-PKG_SHA256="fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686"
+PKG_VERSION="75.4.0"
+PKG_SHA256="1dc484f5cf56fd3fe7216d7b8df820802e7246cfb534a1db2aa64f14fcb9cdcb"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="75.4.0"
-PKG_SHA256="1dc484f5cf56fd3fe7216d7b8df820802e7246cfb534a1db2aa64f14fcb9cdcb"
+PKG_VERSION="75.5.0"
+PKG_SHA256="5c4ccb41111392671f02bb5f8436dfc5a9a7185e80500531b133f5775c4163ef"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NAME}/${PKG_NAME,,}-${PKG_VERSION}.tar.gz"

--- a/scripts/build
+++ b/scripts/build
@@ -111,7 +111,7 @@ if [ -z "${PKG_TOOLCHAIN}" -o "${PKG_TOOLCHAIN}" = "auto" ]; then
   fi
   _auto_toolchain=" (auto-detect)"
 fi
-if ! listcontains "meson cmake cmake-make configure ninja make autotools manual" "${PKG_TOOLCHAIN}"; then
+if ! listcontains "meson cmake cmake-make configure ninja make autotools manual python-flit python" "${PKG_TOOLCHAIN}"; then
   die "$(print_color "CLR_ERROR" "ERROR:") unknown toolchain ${PKG_TOOLCHAIN}"
 fi
 build_msg "CLR_TOOLCHAIN" "TOOLCHAIN" "${PKG_TOOLCHAIN}${_auto_toolchain}"
@@ -403,6 +403,23 @@ else
       echo "Executing (bootstrap): make ${PKG_MAKE_OPTS_BOOTSTRAP}" | tr -s " "
       make ${PKG_MAKE_OPTS_BOOTSTRAP}
       ;;
+
+    # python builds
+    "python-flit:target")
+      die "$(print_color "CLR_ERROR" "ERROR:") toolchain python-flit should not be used for target!"
+      ;;
+    "python-flit:host")
+      echo "Executing (host): python3 -m flit_core.wheel"
+      DONT_BUILD_LEGACY_PYC=1 python3 -m flit_core.wheel
+      ;;
+    "python:target")
+      echo "Executing (target): python3 -m build -n -w -x ${PKG_PYTHON_OPTS_TARGET}" | tr -s " "
+      python_target_env python3 -m build -n -w -x ${PKG_PYTHON_OPTS_TARGET}
+      ;;
+    "python:host")
+      echo "Executing (host): python3 -m build -n -w -x ${PKG_PYTHON_OPTS_HOST}" | tr -s " "
+      DONT_BUILD_LEGACY_PYC=1 python3 -m build -n -w -x ${PKG_PYTHON_OPTS_HOST}
+      ;;
   esac
 fi
 
@@ -461,6 +478,17 @@ else
       ;;
     "configure:bootstrap"|"cmake-make:bootstrap"|"autotools:bootstrap"|"make:bootstrap")
       make install ${PKG_MAKEINSTALL_OPTS_BOOTSTRAP}
+      ;;
+
+    # python builds
+    "python-flit:target")
+      die "$(print_color "CLR_ERROR" "ERROR:") toolchain python-flit should not be used for target!"
+      ;;
+    "python:target")
+      python3 -m installer --overwrite-existing dist/*.whl -d ${INSTALL} -p /usr
+      ;;
+    "python-flit:host" | "python:host")
+      python3 -m installer --overwrite-existing dist/*.whl
       ;;
   esac
 fi


### PR DESCRIPTION
## Fix build failure on Lakka-v6.x
Lakka-v6.x (commit:6a895e4e6a32ca07b4454c924f160a51f7549ada) is not able to finish because build is failed.
This build failure has occurred since commit e66319dea5d86a460ea6070c9512fdf53ac72b20.
<BR>

### [Reason]
There are 2 reasons.
1. Updated mesa's package.mk had no '}' in makeinstall_host().
2. Bumped mesa needs new python packages and modify script files.
<BR>

### modified : 4 files, Added : 9 files
- config/graphic : modified
  It from LibreELEC "mesa: drop unnecessary kmsro option"
  https://github.com/LibreELEC/LibreELEC.tv/commit/7f1b2e1dd0eb9cb3743ce34be5c53537edd1df3d
- packages/devel/libclc/package.mk : added
  It from LibreELEC "libclc: initial package"
  https://github.com/LibreELEC/LibreELEC.tv/commit/8be81eee9bb96aaa5903186e195df1c39358699f
- packages/graphics/mesa/package.mk : modified
  Add '}' in makeinstall_host().
  And, some parameters for L4T modified.
- packages/python/devel/flit/package.mk : added
  It from LibreELEC "flit: initial package"
  https://github.com/LibreELEC/LibreELEC.tv/commit/7169541b3e3ed2feeb99ead60623febba470e96e
- packages/python/devel/pybuild/package.mk : added
  It from LibreELEC "pybuild: initial package" and more 1 commit.
  https://github.com/LibreELEC/LibreELEC.tv/commit/85524a792d1a015c507d50149857601f5dc81cba
  https://github.com/LibreELEC/LibreELEC.tv/commit/d0b2445cdbaa19be635895a2565d6eddabfd8f5e  
- packages/python/devel/pycparser/package.mk : added
  It from LibreELEC "pycparser: initial package" and more 1 commit.
  https://github.com/LibreELEC/LibreELEC.tv/commit/13cbee4617f1943b51b9a2561e49ad32668b345f
  https://github.com/LibreELEC/LibreELEC.tv/commit/86adc79e30ce7f06001478055f599e22d746b36c
- packages/python/devel/pyinstaller/package.mk : added
- packages/python/devel/pyinstaller/patches/0001-Add-overwrite-existing-option-that-overwrites-existi.patch : added
  Above 2 files from LibreELEC "pyinstaller: initial package".
  https://github.com/LibreELEC/LibreELEC.tv/commit/28bc5fe111f8e1020032a6694f90375e9d4e9c93
- packages/python/devel/pypackaging/package.mk : added
  It from LibreELEC "pypackaging: initial package" and more 1 commit.
  https://github.com/LibreELEC/LibreELEC.tv/commit/7d73f34c79a537eca4c63302e21db77a13322b77
  https://github.com/LibreELEC/LibreELEC.tv/commit/333fa97a3484353b6090ee0d1660d8f3af36ccad
- packages/python/devel/pyproject-hooks/package.mk : added
  It from LibreELEC "pyproject-hooks: initial package" and more 1 commit.
  https://github.com/LibreELEC/LibreELEC.tv/commit/289ccd659470f441c24507cc88e7db879f82d9fb
  https://github.com/LibreELEC/LibreELEC.tv/commit/d881eb4cd9495429da0948d9436e152bb19becf6
- packages/python/devel/pyyaml/package.mk : added
  It from LibreELEC "pyyaml: initial package" and more 1 commit.
  https://github.com/LibreELEC/LibreELEC.tv/commit/f8e126383d2dd241dcf5dbb112c8e43791436787
  https://github.com/LibreELEC/LibreELEC.tv/commit/66011e29d8389de44b5df021bf9f3ccef2e4f61d
- packages/python/devel/setuptools/package.mk : modified
  It from LibreELEC "setuptools: update to 73.0.1" and more 10 commit.
  https://github.com/LibreELEC/LibreELEC.tv/commit/678dfa0f7d8122573fd0e0bfadc63ece29d234da
  https://github.com/LibreELEC/LibreELEC.tv/commit/d4fa7dfc365e0f6a872d5622dd3f26c9114c65e1
  https://github.com/LibreELEC/LibreELEC.tv/commit/63572fc4371c460d24efbe7634a7b4158aa3617b
  https://github.com/LibreELEC/LibreELEC.tv/commit/4e1757e74d2f2523a71167e1517464236c2eaba2
  https://github.com/LibreELEC/LibreELEC.tv/commit/b11b1336bdd776f7191a04ce35cc6a4bf7028beb
  https://github.com/LibreELEC/LibreELEC.tv/commit/2901014f0768e3199492be7b1b78222eedeb7d57
  https://github.com/LibreELEC/LibreELEC.tv/commit/6c410d9fe3666819b6c8c2263eb970228374d307
  https://github.com/LibreELEC/LibreELEC.tv/commit/44db9c9eed90a3f1d9473e01dcb659f3cb4ac883
  https://github.com/LibreELEC/LibreELEC.tv/commit/8d6ee1f3f5fd12da60d0e181e6d7f258d0033ffd
  https://github.com/LibreELEC/LibreELEC.tv/commit/f79d7bcfa2fd2c6162ae6ca6bec838bb44a3777f
  https://github.com/LibreELEC/LibreELEC.tv/commit/ccc1ba5722cb6b8d2110c286b30bcbcb89c2bb76
- scripts/build : modified
  It from LibreELEC "scripts: add python toolchain".
  https://github.com/LibreELEC/LibreELEC.tv/commit/e9f9e782016fb0ca1f19ddcadeafc35bf6a438e2
<BR>

### [Confirmatrion]
- RPi5.aarch64 build is passed.
- RPi5.aarch64 image is booted and PERSONA3 PORTABLE - ppsspp core was able to start.
- RPi4.aarch64 build is passed.
- RPi4.aarch64 image is booted and LUMINES - ppsspp core was able to start..
<BR>

### [Note]
- Switch.aarch64 build is still falied. 
  FAILURE: scripts/build switch-u-boot:target during make_target (package.mk)
  I will keep investigation.
- Generic.x86_64 build is still falied. 
  FAILURE: scripts/build libdrm:host during configure_host (default)
  I will keep investigation.
- Other projects and devices build are not confirmed yet.
<BR>

Thanks
ASAI, Shigeaki