### PR TITLE
Rust 1.83

### DIFF
--- a/packages/rust/cargo-snapshot/package.mk
+++ b/packages/rust/cargo-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="d0c54d824e64b7313a974409541ca3a157b3ed7299865786bd0c440b0e073091"
+    PKG_SHA256="5b96aba48790acfacea60a6643a4f30d7edc13e9189ad36b41bbacdad13d49e1"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="427eff597f3801987959a97a1ee5d5df57c56875a7adada41b45e72b46edfb4d"
+    PKG_SHA256="6e72f235d4ebce15eb2eaeaecaa9b29b21df7df64bd71ace55d2c85b7bdf0453"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="30ec0ad9fca443ec12c544f9ce448dacdde411a45b9042961938b650e918ccfb"
+    PKG_SHA256="de834a4062d9cd200f8e0cdca894c0b98afe26f1396d80765df828880a39b98c"
     PKG_URL="https://static.rust-lang.org/dist/cargo-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust-std-snapshot/package.mk
+++ b/packages/rust/rust-std-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="c0c579d9321da855109a2b6c7d7c9e01549db37e8490f058cfdc0012bef394cd"
+    PKG_SHA256="8804f673809c5c3db11ba354b5cf9724aed68884771fa32af4b3472127a76028"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="3b9a6af550679c82cf205b665962de86d067e9ccfc392c754217519dbf2bce52"
+    PKG_SHA256="1d71e107b7cd96ad90e45fa402475c96ea9420290740be90168205137f3163ab"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="e41150b52d923a3bbe166c4ecc5719f56576274b0d034d764768aee279ae2063"
+    PKG_SHA256="c88fe6cb22f9d2721f26430b6bdd291e562da759e8629e2b4c7eb2c7cad705f2"
     PKG_URL="https://static.rust-lang.org/dist/rust-std-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac

--- a/packages/rust/rust/package.mk
+++ b/packages/rust/rust/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2017-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="rust"
-PKG_VERSION="1.82.0"
-PKG_SHA256="7c53f4509eda184e174efa6ba7d5eeb586585686ce8edefc781a2b11a7cf512a"
+PKG_VERSION="1.83.0"
+PKG_SHA256="722d773bd4eab2d828d7dd35b59f0b017ddf9a97ee2b46c1b7f7fac5c8841c6e"
 PKG_LICENSE="MIT"
 PKG_SITE="https://www.rust-lang.org"
 PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-src.tar.gz"
@@ -50,6 +50,9 @@ rpath = true
 channel = "stable"
 codegen-tests = false
 optimize = true
+
+[llvm]
+download-ci-llvm = false
 
 [build]
 submodules = false

--- a/packages/rust/rust/targets/aarch64-libreelec-linux-gnu.json
+++ b/packages/rust/rust/targets/aarch64-libreelec-linux-gnu.json
@@ -1,7 +1,7 @@
 {
   "arch": "aarch64",
   "crt-static-respected": true,
-  "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
+  "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
   "dynamic-linking": true,
   "env": "gnu",
   "executables": true,

--- a/packages/rust/rust/targets/x86_64-libreelec-linux-gnu.json
+++ b/packages/rust/rust/targets/x86_64-libreelec-linux-gnu.json
@@ -2,7 +2,7 @@
   "arch": "x86_64",
   "cpu": "x86-64",
   "crt-static-respected": true,
-  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
   "dynamic-linking": true,
   "env": "gnu",
   "executables": true,

--- a/packages/rust/rustc-snapshot/package.mk
+++ b/packages/rust/rustc-snapshot/package.mk
@@ -10,15 +10,15 @@ PKG_TOOLCHAIN="manual"
 
 case "${MACHINE_HARDWARE_NAME}" in
   "aarch64")
-    PKG_SHA256="a299b5053d2771c24e3d5787caa0317ea729618700acacf2eeb95e345a92529c"
+    PKG_SHA256="aa5d075f9903682e5171f359948717d32911bed8c39e0395042e625652062ea9"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
   "arm")
-    PKG_SHA256="f398547fd5ad0e2f5904ace4eddaf74c615d0a75221b36ed2667fbb9a6324714"
+    PKG_SHA256="a0f74aab6e9a4d911a261f5bbe24f41066d41e80aa7a68abc754f3bc776037e1"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnueabihf.tar.xz"
     ;;
   "x86_64")
-    PKG_SHA256="9fadfcf71bc6a0ddfd026b9624163faf1c5689dd4a1f7cc1f857167ade4aa6eb"
+    PKG_SHA256="6ec40e0405c8cbed3b786a97d374c144b012fc831b7c22b535f8ecb524f495ad"
     PKG_URL="https://static.rust-lang.org/dist/rustc-${PKG_VERSION}-${MACHINE_HARDWARE_NAME}-unknown-linux-gnu.tar.xz"
     ;;
 esac


### PR DESCRIPTION
rust: update to 1.83 (wrong 1.82 shas)
Requires llvm >= 18