### PR TITLE
Holani libretro core

### DIFF
--- a/packages/lakka/libretro_cores/holani/package.mk
+++ b/packages/lakka/libretro_cores/holani/package.mk
@@ -1,0 +1,17 @@
+PKG_NAME="holani"
+PKG_VERSION="0.9.6"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://github.com/LLeny/holani-retro"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain cargo:host"
+PKG_LONGDESC="A cycle-stepped Atari Lynx emulator"
+PKG_TOOLCHAIN="manual"
+
+make_target() {
+	cargo build --release --target ${TARGET_NAME}
+}
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+    cp -v ${PKG_BUILD}/.${TARGET_NAME}/target/${TARGET_NAME}/release/libholani.so ${INSTALL}/usr/lib/libretro/holani_libretro.so
+}

--- a/packages/lakka/libretro_cores/package.mk
+++ b/packages/lakka/libretro_cores/package.mk
@@ -72,6 +72,7 @@ LIBRETRO_CORES="\
                 hatari \
                 higan_sfc \
                 higan_sfc_balanced \
+                holani \
                 jaxe \
                 jumpnbump \
                 kronos \


### PR DESCRIPTION
adds lakka/libretro_cores/holani: Atari Lynx libretro core. https://docs.libretro.com/library/holani/
Requires rust >= 1.82