### PR TITLE
gpicase_safeshutdown: Fix GPiCase/GPiCase2W safeshutdown doesn't working

### DIFF
--- a/packages/lakka/lakka_tools/gpicase_safeshutdown/system.d/gpicase-safeshutdown.service
+++ b/packages/lakka/lakka_tools/gpicase_safeshutdown/system.d/gpicase-safeshutdown.service
@@ -2,6 +2,7 @@
 Description=GPICase safe shutdown
 
 [Service]
+WorkingDirectory=/storage/.cache
 ExecStart=/usr/bin/safeshutdown_gpi.py
 TimeoutStopSec=5
 Restart=always


### PR DESCRIPTION
### This PR fas related with issue #2018 .

### [Reason]
Current GPiCase/GPiCase2W gpicase_safeshutdown uses gpiozero library.
It has a following problem:
https://github.com/gpiozero/gpiozero/discussions/1153

So, gpicase-safeshutdown.service needs "WorkingDirectory=".

### modified : 1 file
- packages/lakka/lakka_tools/gpicase_safeshutdown/system.d/gpicase-safeshutdown.service
  Add "WorkingDirectory=/storage/.cache" in [Service] section.
<BR>

[Confirmatrion]
I confirmed safeshutdown is working correctly on the following devices.
- RPiZero-GPiCase.arm
- RPiZero2-GPiCase.arm
- RPiZero2-GPiCase2W.aarch64
<BR>

### [Note]
Current GPiCase2 gpicase_safeshutdown uses lg-gpio library.
So, this problem is not happened.
<BR>

Thanks.
ASAI, Shigeaki