### PR TITLE
retroarch: RPiZero2-GPiCase2W: Fix typo

### DIFF
--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -293,7 +293,7 @@ makeinstall_target() {
   fi
 
   # RPiZero2 + GPiCase2W (3rd Gen Retroflag GPiCase)
-  if [ "${DEVICE}" = "RPiZero2-GPiCaseW" ]; then
+  if [ "${DEVICE}" = "RPiZero2-GPiCase2W" ]; then
     echo 'audio_device = "default:CARD=Headphones"' >> ${INSTALL}/etc/retroarch.cfg
     echo 'audio_out_rate = "44100"' >> ${INSTALL}/etc/retroarch.cfg
     echo 'xmb_layout = "2"' >> ${INSTALL}/etc/retroarch.cfg


### PR DESCRIPTION
Fix typo for RPiZero2-GPiCase2W retroarch.

[Modify] 1 file
- packages/lakka/retroarch_base/retroarch/package.mk
<BR>

[Confirm]
Test on RPiZero2-GPiCase2W.aarch64
- retroarch is shown
- audio settings is got
<BR>

Thanks
ASAI, Shigeaki