### PR TITLE
Lakka-v6.x: GPiCase/CPiCase2W: Fix headphone audio LR swap

### DIFF
--- a/projects/RPi/devices/RPiZero-GPiCase/config/distroconfig.gpi2w.txt
+++ b/projects/RPi/devices/RPiZero-GPiCase/config/distroconfig.gpi2w.txt
@@ -26,7 +26,7 @@ dpi_output_format=0x0016
 # dpi_timings=240 1 38 10 20 320 1 20 4 4 0 0 0 60 0 6400000 1
 hdmi_timings=640 0 20 1 20 480 0 1 1 2 0 0 0 60 0 19200000 1  #59hz
 # dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2
-dtoverlay=audremap,pins_18_19,swap_lr
+dtoverlay=audremap,pins_18_19
 avoid_safe_mode=1
 
 disable_pvt=1

--- a/projects/RPi/devices/RPiZero-GPiCase/config/distroconfig.txt
+++ b/projects/RPi/devices/RPiZero-GPiCase/config/distroconfig.txt
@@ -26,7 +26,7 @@ dpi_timings=240 1 38 10 20 320 1 20 4 4 0 0 0 60 0 6400000 1
 disable_pvt=1
 disable_audio_dither=1
 #dtoverlay=pwm-audio-pi-zero-gpi
-dtoverlay=audremap,pins_18_19,swap_lr
+dtoverlay=audremap,pins_18_19
 
 disable_overscan=1
 

--- a/projects/RPi/devices/RPiZero2-GPiCase/config/distroconfig.gpi2w.txt
+++ b/projects/RPi/devices/RPiZero2-GPiCase/config/distroconfig.gpi2w.txt
@@ -26,7 +26,7 @@ dpi_output_format=0x0016
 # dpi_timings=240 1 38 10 20 320 1 20 4 4 0 0 0 60 0 6400000 1
 hdmi_timings=640 0 20 1 20 480 0 1 1 2 0 0 0 60 0 19200000 1  #59hz
 # dtoverlay=pwm-2chan,pin=18,func=2,pin2=19,func2=2
-dtoverlay=audremap,pins_18_19,swap_lr
+dtoverlay=audremap,pins_18_19
 avoid_safe_mode=1
 
 disable_pvt=1

--- a/projects/RPi/devices/RPiZero2-GPiCase/config/distroconfig.txt
+++ b/projects/RPi/devices/RPiZero2-GPiCase/config/distroconfig.txt
@@ -26,7 +26,7 @@ dpi_timings=240 1 38 10 20 320 1 20 4 4 0 0 0 60 0 6400000 1
 disable_pvt=1
 disable_audio_dither=1
 #dtoverlay=pwm-audio-pi-zero-gpi
-dtoverlay=audremap,pins_18_19,swap_lr
+dtoverlay=audremap,pins_18_19
 
 disable_splash=1
 disable_overscan=1

--- a/projects/RPi/devices/RPiZero2-GPiCase/config/distroconfig_vc4.txt
+++ b/projects/RPi/devices/RPiZero2-GPiCase/config/distroconfig_vc4.txt
@@ -17,7 +17,7 @@ hdmi_drive=1
 dtparam=audio=off
 disable_fw_kms_setup=1
 framebuffer_priority=1
-dtoverlay=audremap,pins_18_19,swap_lr
+dtoverlay=audremap,pins_18_19
 
 #enable_dpi_lcd=1
 #display_default_lcd=1

--- a/projects/RPi/devices/RPiZero2-GPiCase2W/config/distroconfig.txt
+++ b/projects/RPi/devices/RPiZero2-GPiCase2W/config/distroconfig.txt
@@ -22,7 +22,7 @@ disable_fw_kms_setup=1
 disable_pvt=1
 disable_overscan=1
 
-dtoverlay=audremap,pins_18_19,swap_lr
+dtoverlay=audremap,pins_18_19
 disable_audio_dither=1
 audio_pwm_mode=2
 


### PR DESCRIPTION
GPiCase/CPiCase2W use GPIO headphone audio.
Current distroconfig.txt is set "dtoverlay=audremap,pins_18_19,swap_lr".

But, real headphone audio was not correct Left/Right.

So remove ",swap_lr".

I tested this PR modification on the following.
Test method : speaker-test -c 2
- RPiZero-GPiCase.arm
- RPiZero2-GPiCase.arm
- RPiZero2-GPiCase2W.aarch64


Thanks,
ASAI, Shigeaki