### PR TITLE
panda3ds: It supports on RPi4

### DIFF
--- a/packages/lakka/libretro_cores/package.mk
+++ b/packages/lakka/libretro_cores/package.mk
@@ -268,6 +268,7 @@ elif [ "${PROJECT}" = "RPi" ]; then
                               mupen64plus_next \
                               openlara \
                               opera \
+                              panda3ds \
                               parallel_n64 \
                               play \
                               ppsspp \
@@ -287,12 +288,14 @@ elif [ "${PROJECT}" = "RPi" ]; then
                               yabause"
 
   elif [ "${DEVICE}" = "RPi2" ]; then
-    EXCLUDE_LIBRETRO_CORES+=" play"
+    EXCLUDE_LIBRETRO_CORES+=" panda3ds \
+                              play"
 
   elif [ "${DEVICE}" = "RPiZero2-GPiCase" ]; then
     EXCLUDE_LIBRETRO_CORES+=" boom3 \
                               flycast \
                               openlara \
+                              panda3ds \
                               play \
                               ppsspp \
                               vircon32 \
@@ -300,10 +303,9 @@ elif [ "${PROJECT}" = "RPi" ]; then
                               swanstation \
                               yabasanshiro"
 
-  fi
-
-  if [ "${DEVICE}" != "RPi5" ]; then
+  elif [ "${DEVICE}" = "RPi3" -o "${DEVICE}" = "RPiZero2-GPiCase2W" ]; then
     EXCLUDE_LIBRETRO_CORES+=" panda3ds"
+
   fi
 
 elif [ "${PROJECT}" = "Samsung" ]; then

--- a/packages/lakka/libretro_cores/panda3ds/package.mk
+++ b/packages/lakka/libretro_cores/panda3ds/package.mk
@@ -20,6 +20,10 @@ PKG_CMAKE_OPTS_TARGET="-DBUILD_LIBRETRO_CORE=ON \
                        -DENABLE_LTO=ON \
                        -DENABLE_USER_BUILD=ON"
 
+if [ "${ARCH}" = "aarch64" ]; then
+  PKG_CMAKE_OPTS_TARGET+=" -DCRYPTOPP_OPT_DISABLE_ASM=ON"
+fi
+
 if [ "${OPENGL_SUPPORT}" = yes ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGL}"
   PKG_CMAKE_OPTS_TARGET+=" -DENABLE_OPENGL=ON"


### PR DESCRIPTION
## panda3ds: It supports on RPi4
According to the panda3ds repo, [Try to cross-compile Libretro core for arm64](https://github.com/wheremyfoodat/Panda3DS/pull/717)
When building panda3ds core for arm64, "-DCRYPTOPP_OPT_DISABLE_ASM=ON" compilation switch is needed. 

So we need to add this compilation switch for Lakka panda3ds too.

RPi3 build was passed with this compilation switch, but Panda3DS core was NOT able to start.
Therefore it is excluded Panda3DS core on RPi3 and RPiZero2-GPiCase2W.
<BR>

### Change: 2 files
-   packages/lakka/libretro_cores/package.mk
  Exclude Panda3DS core when DEVICE=RPi, RPiZero-GPiCase, RPi2, RPiZero2-GPiCase, 
  RPi3 and RPiZero2-GPiCase2W. 
-   packages/lakka/libretro_cores/panda3ds/package.mk
  Add "-DCRYPTOPP_OPT_DISABLE_ASM=ON" compilation switch when "${ARCH}" = "aarch64".
<BR>

### [Confirmatrion]
- RPi : OK
  * build is passed : OK
  * Panda3DS core is NOT contained : OK

- RPi2 : OK
  * build is passed : OK
  * Panda3DS core is NOT contained : OK

- RPiZero2-GPiCase : OK
  * build is passed : OK
  * Panda3DS core is NOT contained : OK

- RPi3 : NG -> OK
  * build is passed : OK
  * Panda3DS core is contained : OK
  * Panda3DS core is able to start on RPi3 Lakka : NG
    -> It removes on RPi3/RPiZero2-GPiCase2W
       - RPi3 : OK
         * build is passed : OK
         * Panda3DS core is NOT contained : OK
       - RPiZero2-GPiCase2W : OK
         * build is passed : OK
         * Panda3DS core is NOT contained : OK

- RPi4 : OK
  * build is passed : OK
  * Panda3DS core is contained : OK
  * Panda3DS core is able to start on RPi4 Lakka : OK

- RPi5 : OK
  * build is passed : OK
  * Panda3DS core is contained : OK
  * Panda3DS core is able to start on RPi5 Lakka : OK

- Generic - Generic - x86_64 : OK
  * build is passed : OK
  * build without "-DCRYPTOPP_OPT_DISABLE_ASM=ON" : OK
  * Panda3DS core is contained : OK


<BR>

Thanks
ASAI, Shigeaki