### PR TITLE
panda3ds: It supports on RPi4 for devel branch

### DIFF
--- a/packages/lakka/libretro_cores/panda3ds/package.mk
+++ b/packages/lakka/libretro_cores/panda3ds/package.mk
@@ -20,6 +20,10 @@ PKG_CMAKE_OPTS_TARGET="-DBUILD_LIBRETRO_CORE=ON \
                        -DENABLE_LTO=ON \
                        -DENABLE_USER_BUILD=ON"
 
+if [ "${ARCH}" = "aarch64" ]; then
+  PKG_CMAKE_OPTS_TARGET+=" -DCRYPTOPP_OPT_DISABLE_ASM=ON"
+fi
+
 if [ "${OPENGL_SUPPORT}" = yes ]; then
   PKG_DEPENDS_TARGET+=" ${OPENGL}"
   PKG_CMAKE_OPTS_TARGET+=" -DENABLE_OPENGL=ON"


### PR DESCRIPTION
## panda3ds: It supports on RPi4 for devel branch
This pull request is for devel branch.
It is same as pull request #2046.

If merge this PR, please ONLY enable panda3ds core on RPi4* and RPi5.
<BR>

### Change: 1 files
-   packages/lakka/libretro_cores/panda3ds/package.mk
  Add "-DCRYPTOPP_OPT_DISABLE_ASM=ON" compilation switch when "${ARCH}" = "aarch64".
<BR>

### [Confirmatrion]
- RPi4 : OK
  * build is passed : OK
  * Panda3DS core is contained : OK
  * Panda3DS core is able to start on RPi4 Lakka : OK

- RPi5 : OK
  * build is passed : OK
  * Panda3DS core is contained : OK
  * Panda3DS core is able to start on RPi5 Lakka : OK
<BR>

Thanks
ASAI, Shigeaki