### PR TITLE
retroflag_picase_safeshutdown: Add support RETROFLAG Pi CASE safe shutdown function for Lakka-v6.x

### DIFF
--- a/packages/lakka/lakka_tools/retroflag_picase_safeshutdown/package.mk
+++ b/packages/lakka/lakka_tools/retroflag_picase_safeshutdown/package.mk
@@ -1,0 +1,17 @@
+PKG_NAME="retroflag_picase_safeshutdown"
+PKG_VERSION="1.0"
+PKG_ARCH="aarch64"
+PKG_DEPENDS_TARGET="Python3 lg-gpio"
+PKG_SECTION="system"
+PKG_LONGDESC="RETROFLAG Pi CASE series safe shutdown script."
+PKG_TOOLCHAIN="manual"
+
+makeinstall_target() {
+  # service
+  mkdir -p "${INSTALL}/usr/lib/systemd/system"
+    cp -av "${PKG_DIR}/system.d/retroflag_picase_safeshutdown.service" "${INSTALL}/usr/lib/systemd/system"
+
+  # script
+  mkdir -p "${INSTALL}/usr/bin"
+    cp -av "${PKG_DIR}/scripts/retroflag_picase_safeshutdown.py" "${INSTALL}/usr/bin"
+}

--- a/packages/lakka/lakka_tools/retroflag_picase_safeshutdown/scripts/retroflag_picase_safeshutdown.py
+++ b/packages/lakka/lakka_tools/retroflag_picase_safeshutdown/scripts/retroflag_picase_safeshutdown.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+#
+# The safe shutdown script for RETROFLAG Pi CASE series for Lakka-v6 (lg-gpio version)
+# https://abyz.me.uk/lg/
+# https://abyz.me.uk/lg/py_lgpio.html
+#
+
+
+import os
+os.environ["LG_WD"] = "/tmp"
+import lgpio as sbc
+import time
+import signal
+
+
+handle=-1
+powerPin = 3 #pin 5
+ledPin = 14 #TXD
+resetPin = 2 #pin 13
+powerenPin = 4 #pin 5
+LED_status = 0 #LED ON=1 OFF=0
+
+
+def init():
+
+	global handle
+	global LED_status
+
+	# Open GPIO handle.
+	handle = sbc.gpiochip_open(0)
+
+	# Activate PowerEn Pin for enable PowerSwitch.
+	sbc.gpio_claim_output(handle, powerenPin, level=1)
+
+	# Enable Power LED.
+	LED_status = 1
+	sbc.gpio_claim_output(handle, ledPin, level=LED_status)
+
+	# Add poweroff() callback.
+	sbc.gpio_claim_alert(handle, powerPin, sbc.FALLING_EDGE, lFlags=sbc.SET_PULL_UP)
+	sbc.callback(handle, powerPin, sbc.FALLING_EDGE, poweroff)
+
+        # Add reset() callback.
+	sbc.gpio_claim_alert(handle, resetPin, sbc.FALLING_EDGE, lFlags=sbc.SET_PULL_UP)
+	sbc.callback(handle, resetPin, sbc.FALLING_EDGE, reset)
+
+
+def poweroff(chip, gpio, level, timestamp):
+
+	# Start LED blink.
+	signal.setitimer(signal.ITIMER_REAL, 0.2, 0.2)
+
+	# Stop retroarch.service.
+	os.system("systemctl stop retroarch")
+
+	# Wait 1 sec.
+	time.sleep(1)
+
+	# Shutdown system.
+	os.system("systemctl poweroff")
+
+
+def reset(chip, gpio, level, timestamp):
+
+	# Start LED blink.
+	signal.setitimer(signal.ITIMER_REAL, 0.2, 0.2)
+
+	# Stop retroarch.service.
+	os.system("systemctl stop retroarch")
+
+	# Wait 1 sec.
+	time.sleep(1)
+
+	# Shutdown system.
+	os.system("systemctl reboot")
+
+
+def ledBlink(arg1, arg2):
+
+	global LED_status
+
+	if LED_status == 1:
+		# LED ON -> OFF
+		LED_status = 0
+	else:
+		# LED OFF -> ON
+		LED_status = 1
+
+	sbc.gpio_write(handle, ledPin, LED_status)
+
+
+def main():
+
+	# Initialize
+	init()
+
+	# Register signal handler for LED blink
+	signal.signal(signal.SIGALRM, ledBlink)
+
+	# Loop & sleep
+	while True:
+		time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/packages/lakka/lakka_tools/retroflag_picase_safeshutdown/system.d/retroflag_picase_safeshutdown.service
+++ b/packages/lakka/lakka_tools/retroflag_picase_safeshutdown/system.d/retroflag_picase_safeshutdown.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=RETROFLAG Pi CASE series - safe shutdown service
+
+[Service]
+ExecStart=/usr/bin/retroflag_picase_safeshutdown.py
+TimeoutStopSec=5
+Restart=always
+RestartSec=5
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/lakka/package.mk
+++ b/packages/lakka/package.mk
@@ -34,6 +34,10 @@ if [ "${PROJECT}" = "RPi" ]; then
   if [ "${DEVICE}" = "RPiZero-GPiCase" -o "${DEVICE}" = "RPiZero2-GPiCase" -o "${DEVICE}" = "RPi4-GPiCase2" -o "${DEVICE}" = "RPiZero2-GPiCase2W" ]; then
     PKG_DEPENDS_TARGET+=" gpicase_safeshutdown"
   fi
+  
+  if [ "${DEVICE}" = "RPi3" -o "${DEVICE}" = "RPi4" -o "${DEVICE}" = "RPi5" ]; then
+    PKG_DEPENDS_TARGET+=" retroflag_picase_safeshutdown"
+  fi
 fi
 
 if [ "${DEVICE}" != "Switch" -a "${DEVICE}" != "RPiZero-GPiCase" -a "${DEVICE}" != "RPiZero2-GPiCase" -a "${DEVICE}" != "RPiZero2-GPiCase2W" ]; then


### PR DESCRIPTION
## Add support RETROFLAG Pi CASE safe shutdown function for Lakka-v6.x
This is for safe shutdown service and script for RETROFLAG Pi CASE Lakka-v6.x.

This function is disabled in default.
If you want to enable this function, please execute the following commands via SSH console.
> systemctl enable retroflag_picase_safeshutdown.service
> systemctl start retroflag_picase_safeshutdown.service
<BR>


### Change 1 file, Add 3 files
-   packages/lakka/package.mk
  Change; This package is added when RPi3, RPi4 and RPi5.
-   packages/lakka/lakka_tools/retroflag_picase_safeshutdown/package.mk
  Add; Package information file for this function.
-   packages/lakka/lakka_tools/retroflag_picase_safeshutdown/system.d/retroflag_picase_safeshutdown.service
  Add; Systemd service file for this function.
-   packages/lakka/lakka_tools/retroflag_picase_safeshutdown/scripts/retroflag_picase_safeshutdown.py
  Add; Python script file for this function.
<BR>

### Confirmatrion
- RPi3 + MEGA Pi CASE : OK
  * build is passed : OK
  * The service and script files are exist : OK
  * Able to enable this function : OK
  * The reset function : OK
  * The power off function : OK

- RPi4 + NESPi 4 CASE : OK
  * build is passed : OK
  * The service and script files are exist : OK
  * Able to enable this function : OK
  * The reset function : OK
  * The power off function : OK

- RPi5 + 64Pi CASE : OK
  * build is passed : OK
  * The service and script files are exist : OK
  * Able to enable this function : OK
  * The reset function : OK
  * The power off function : OK
<BR>

Thanks
ASAI, Shigeaki