### PR TITLE
libretro_cores: Add lr-dice for machines without a CPU.

### DIFF
--- a/packages/lakka/libretro_cores/dice/package.mk
+++ b/packages/lakka/libretro_cores/dice/package.mk
@@ -1,0 +1,13 @@
+PKG_NAME="dice"
+PKG_VERSION="0b49c6956b6507a44c4798a1de2106f06c00cf92"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://github.com/mittonk/dice-libretro"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="DICE is a Discrete Integrated Circuit Emulator for games without any type of CPU."
+PKG_TOOLCHAIN="make"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+    cp -v dice_libretro.so ${INSTALL}/usr/lib/libretro/
+}

--- a/packages/lakka/libretro_cores/package.mk
+++ b/packages/lakka/libretro_cores/package.mk
@@ -41,6 +41,7 @@ LIBRETRO_CORES="\
                 daphne \
                 desmume \
                 desmume_2015 \
+                dice \
                 dinothawr \
                 dirksimple \
                 dolphin \
@@ -250,6 +251,7 @@ elif [ "${PROJECT}" = "RPi" ]; then
                               bsnes_mercury \
                               desmume \
                               desmume_2015 \
+                              dice \
                               dolphin \
                               dosbox \
                               dosbox_core \


### PR DESCRIPTION
libretro_cores: Add lr-dice for machines without a CPU.

Tested locally on a Pi1B+ (with that architecture temporarily enabled).
Already in 5.x, this is aiming for devel & 6.x.