### PR TITLE
Fix Cheats directory path

### DIFF
--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -190,7 +190,7 @@ makeinstall_target() {
   echo 'rgui_show_start_screen = "false"' >> ${INSTALL}/etc/retroarch.cfg
   echo 'assets_directory = "/tmp/assets"' >> ${INSTALL}/etc/retroarch.cfg
   echo 'overlay_directory = "/tmp/overlays"' >> ${INSTALL}/etc/retroarch.cfg
-  echo 'cheat_database_path = "/tmp/database/chts"' >> ${INSTALL}/etc/retroarch.cfg
+  echo 'cheat_database_path = "/tmp/database/cht"' >> ${INSTALL}/etc/retroarch.cfg
   echo 'cursor_directory = "/tmp/database/cursors"' >> ${INSTALL}/etc/retroarch.cfg
   echo 'log_dir = "/storage/logfiles"' >> ${INSTALL}/etc/retroarch.cfg
   echo 'recording_output_directory = "/storage/recordings"' >> ${INSTALL}/etc/retroarch.cfg


### PR DESCRIPTION
This changes the default cheats directory to match that from libretro-database. Fixes https://github.com/libretro/Lakka-LibreELEC/issues/2066


Do you know whwat the other cht directory is?