### PR TITLE
Amlogic: update linux bananapi-m2pro/m5 device tree patch for Lakka v5

### DIFF
--- a/projects/Amlogic/devices/AMLGX/patches/linux/amlogic-0121-WIP-arm64-dts-amlogic-sm1-bananapi-lower-SD-card-speed-for-stability.patch
+++ b/projects/Amlogic/devices/AMLGX/patches/linux/amlogic-0121-WIP-arm64-dts-amlogic-sm1-bananapi-lower-SD-card-speed-for-stability.patch
@@ -1,0 +1,62 @@
+From: Christian Hewitt <christianshewitt@gmail.com>
+To: Neil Armstrong <neil.armstrong@linaro.org>,
+	Kevin Hilman <khilman@baylibre.com>,
+	Jerome Brunet <jbrunet@baylibre.com>,
+	Martin Blumenstingl <martin.blumenstingl@googlemail.com>,
+	Rob Herring <robh@kernel.org>,
+	Krzysztof Kozlowski <krzk+dt@kernel.org>,
+	Conor Dooley <conor+dt@kernel.org>,
+	devicetree@vger.kernel.org, linux-arm-kernel@lists.infradead.org,
+	linux-amlogic@lists.infradead.org, linux-kernel@vger.kernel.org
+Subject: [PATCH] arm64: dts: amlogic: sm1-bananapi: lower SD card speed for stability
+Date: Mon,  5 May 2025 14:37:00 +0000	[thread overview]
+Message-ID: <20250505143700.4029484-1-christianshewitt@gmail.com> (raw)
+
+Users report being able to boot (u-boot) from SD card but kernel
+init then fails to mount partitions on the card containing boot
+media resulting in first-boot failure. System logs show only the
+probe of the mmc devices: the SD card is seen, but no partitions
+are found so init fails to mount them and boot stalls.
+
+Reducing the speed of the SD card from 50MHz to 35MHz results in
+complete probing of the card and successful boot.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+The same workaround of dropping to 35MHz is also done with the
+ac2xx dtsi; which has a comment about CRC errors being seen at
+50MHz. It's probable this is the same although I forget now how
+that diagnosis was done (or who did it, Martin perhaps?). I've
+removed the FIXUP comment and added one about boot failures
+being seen at 50Mhz but if you prefer to repeat the CRC comment
+from ac2xx feel free to fixup when applying or I can send a v2
+with that change. Links to original issue reports with user test
+results [0] [1] are below:
+
+[0] https://github.com/LibreELEC/LibreELEC.tv/issues/10027
+[1] https://github.com/libretro/Lakka-LibreELEC/issues/2059
+
+ arch/arm64/boot/dts/amlogic/meson-sm1-bananapi.dtsi | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi.dtsi b/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi.dtsi
+index 40db95f64636..03b4b414cd5f 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi.dtsi
+@@ -384,11 +384,10 @@ &sd_emmc_b {
+ 
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
+-	max-frequency = <50000000>;
++	/* Boot failures are observed at 50MHz */
++	max-frequency = <35000000>;
+ 	disable-wp;
+ 
+-	/* TOFIX: SD card is barely usable in SDR modes */
+-
+ 	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
+ 	vmmc-supply = <&tflash_vdd>;
+ 	vqmmc-supply = <&vddio_c>;
+-- 
+2.34.1
+


### PR DESCRIPTION
## This pull request fixs issue #2059 for Lakka-v5.x
This is PR#2072 backport. 

This fix is provided by [chewitt](https://github.com/chewitt).
https://patchwork.kernel.org/project/linux-amlogic/patch/20250505143700.4029484-1-christianshewitt@gmail.com/

It can build finished nomally on my local build environment.
And local build image can boot on my Banana Pi M5.
<BR>

Thanks
ASAI, Shigeaki

