### PR TITLE
Added VirtualXT core

### DIFF
--- a/packages/lakka/libretro_cores/package.mk
+++ b/packages/lakka/libretro_cores/package.mk
@@ -154,6 +154,7 @@ LIBRETRO_CORES="\
                 vice \
                 vircon32 \
                 virtualjaguar \
+                virtualxt \
                 vitaquake2 \
                 vitaquake3 \
                 wasm4 \

--- a/packages/lakka/libretro_cores/virtualxt/package.mk
+++ b/packages/lakka/libretro_cores/virtualxt/package.mk
@@ -1,0 +1,15 @@
+PKG_NAME="virtualxt"
+PKG_VERSION="4fd0a7a9774e673b3ee4a39126c67accee9c56ad"
+PKG_LICENSE="zlib"
+PKG_SITE="https://github.com/virtualxt/virtualxt"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Lightweight Turbo PC/XT emulator."
+PKG_TOOLCHAIN="make"
+
+PKG_MAKE_OPTS_TARGET="-C tools/package/libretro"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+    cp -v tools/package/libretro/virtualxt_libretro.so ${INSTALL}/usr/lib/libretro/
+}


### PR DESCRIPTION
Added VirtualXT core.

This core as been tested on RPi3/4 and x86_64 but should also run fine on any 32bit system as it has been built and tested in other CIs and projects.