### PR TITLE
citra: bump version to 8e634af because "dynarmic" submodule url is changed

### DIFF
--- a/packages/lakka/libretro_cores/citra/package.mk
+++ b/packages/lakka/libretro_cores/citra/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="citra"
-PKG_VERSION="a31aff7e1a3a66f525b9ea61633d2c5e5b0c8b31"
+PKG_VERSION="8e634afee9e870620b40efedaef77478cd1f3c99"
 PKG_ARCH="x86_64 aarch64"
 PKG_LICENSE="GPLv2+"
 PKG_SITE="https://github.com/libretro/citra"


### PR DESCRIPTION
The citra core building is failed with the following fail message when Lakka build starts on the new environment.

> fatal: clone of 'https://github.com/PabloMK7/dynarmic.git' into submodule path '/home/yasai/Lakka-LibreELEC/sources/citra/citra-a31aff7e1a3a66f525b9ea61633d2c5e5b0c8b31/externals/dynarmic' failed

Reason:
"https://github.com/PabloMK7/dynarmic.git" repository is removed maybe.

Fix:
This problem is fixed the latest citra core version.
So, bump citra core version.

Confirmation:
Build is passed with this bump on RPi4.aarch64 and Generic.x86_64.

Note:
I will create another PR for devel branch version later.

Thanks,
ASAI, Shigeaki