### PR TITLE
VirtualXT: Updated core

### DIFF
--- a/packages/lakka/libretro_cores/virtualxt/package.mk
+++ b/packages/lakka/libretro_cores/virtualxt/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="virtualxt"
-PKG_VERSION="4fd0a7a9774e673b3ee4a39126c67accee9c56ad"
+PKG_VERSION="50519a28e43ca558526f81f68793506c5094c9af"
 PKG_LICENSE="zlib"
 PKG_SITE="https://github.com/virtualxt/virtualxt"
 PKG_URL="${PKG_SITE}.git"


### PR DESCRIPTION
Updated VirtualXT from 2.0-pre to 2.1-pre.
This fixes a lot of bugs including the rebuild issue: https://github.com/virtualxt/virtualxt/issues/96