### PR TITLE
virtualxt: temporarily disable on ARCH=arm because build failure is occurred. (for Lakka-v6.x branch)

### DIFF
--- a/packages/lakka/libretro_cores/virtualxt/package.mk
+++ b/packages/lakka/libretro_cores/virtualxt/package.mk
@@ -1,6 +1,10 @@
 PKG_NAME="virtualxt"
 PKG_VERSION="50519a28e43ca558526f81f68793506c5094c9af"
 PKG_LICENSE="zlib"
+# temporarily disable on arm because build failure is occurred.
+# https://github.com/virtualxt/virtualxt/issues/97
+# please enable (remove "!arm" in PKG_ARCH ) when build failure is fixed.
+PKG_ARCH="any !arm"
 PKG_SITE="https://github.com/virtualxt/virtualxt"
 PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain"


### PR DESCRIPTION
### The virtualxt core building is failed with the following failure message when ARCH=arm building.

[virtualxt -Failed,ARCH=arm,LakkaBuild.log](https://github.com/user-attachments/files/21484767/virtualxt.-Failed.ARCH.arm.LakkaBuild.log)
> odin build src/frontend   -collection:vxt=src -collection:modules=src/modules -collection:bios=bios -collection:boot=boot -out:virtualxt_libretro.o -build-mode:object -define:VXT_STARTUP_RUNTIME=true -target:linux_arm32 -o:speed -reloc-mode:pic
> /usr/include/c++/14.3.0/optional:475: constexpr _Tp& std::_Optional_base_impl<_Tp, _Dp>::_M_get() [with _Tp = llvm::Align; _Dp = std::_Optional_base<llvm::Align, true, true>]: Assertion 'this->_M_is_engaged()' failed.
> make[2]: *** [Makefile:57: object] Aborted (core dumped)

<BR>

### Reason:
I don't know what the reason but it seems like the build environment (not core) issue.
I have created an issue on virtualxt github and asked for an investigation.
https://github.com/virtualxt/virtualxt/issues/97
<BR>

### Temporarily fix:
Temporarily disable the virtualxt core on ARCH=arm building only.
When build failure is solved, Please enable virtualxt core again.
<BR>

### Confirmation:
- RPi.arm
\- Build is passed with this commit.
\- virtualxt_libretro.so file is not contained in RPi.arm image.
- RPi4.aarch64
\- Build is passed with this commit.
\- virtualxt_libretro.so file is contained in RPi4.aarch64 image.
<BR>

### Note:
<del>I will create another PR for devel branch version later.</del>
I'm sorry, the virtualxt core was not merged yet in devel branch.
<BR>
<BR>

Thanks,
ASAI, Shigeaki