### PR TITLE
Added VirtualXT core into devel branch

### DIFF
--- a/packages/lakka/libretro_cores/package.mk
+++ b/packages/lakka/libretro_cores/package.mk
@@ -156,6 +156,7 @@ LIBRETRO_CORES="\
                 vice \
                 vircon32 \
                 virtualjaguar \
+                virtualxt \
                 vitaquake2 \
                 vitaquake3 \
                 wasm4 \

--- a/packages/lakka/libretro_cores/virtualxt/package.mk
+++ b/packages/lakka/libretro_cores/virtualxt/package.mk
@@ -1,6 +1,10 @@
 PKG_NAME="virtualxt"
 PKG_VERSION="50519a28e43ca558526f81f68793506c5094c9af"
 PKG_LICENSE="zlib"
+# temporarily disable on arm because build failure is occurred.
+# https://github.com/virtualxt/virtualxt/issues/97
+# please enable (remove "!arm" in PKG_ARCH ) when build failure is fixed.
+PKG_ARCH="any !arm"
 PKG_SITE="https://github.com/virtualxt/virtualxt"
 PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain"

--- a/packages/lakka/libretro_cores/virtualxt/package.mk
+++ b/packages/lakka/libretro_cores/virtualxt/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="virtualxt"
-PKG_VERSION="4fd0a7a9774e673b3ee4a39126c67accee9c56ad"
+PKG_VERSION="50519a28e43ca558526f81f68793506c5094c9af"
 PKG_LICENSE="zlib"
 PKG_SITE="https://github.com/virtualxt/virtualxt"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/libretro_cores/virtualxt/package.mk
+++ b/packages/lakka/libretro_cores/virtualxt/package.mk
@@ -1,0 +1,15 @@
+PKG_NAME="virtualxt"
+PKG_VERSION="4fd0a7a9774e673b3ee4a39126c67accee9c56ad"
+PKG_LICENSE="zlib"
+PKG_SITE="https://github.com/virtualxt/virtualxt"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Lightweight Turbo PC/XT emulator."
+PKG_TOOLCHAIN="make"
+
+PKG_MAKE_OPTS_TARGET="-C tools/package/libretro"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+    cp -v tools/package/libretro/virtualxt_libretro.so ${INSTALL}/usr/lib/libretro/
+}


### PR DESCRIPTION
## Add VirtualXT core into devel branch, VirtualXT core was already merged into Lakka-v6.x

This pull request contains the following 3 commits, these commits are merged into Lakka-v6.x branch.
I use git cherry-pick command.
\- [Added VirtualXT core (\#2074)](https://github.com/libretro/Lakka-LibreELEC/pull/2074)  37f44ac095643593b78053895827fcc09805aab3
\- [VirtualXT: Updated core (\#2079)](https://github.com/libretro/Lakka-LibreELEC/pull/2079) 1106adced534c3c2216891a0cc11cf0849095f0d
\- [virtualxt: temporarily disable on arm because build failure is occurred. (\#2090)](https://github.com/libretro/Lakka-LibreELEC/pull/2090) 0cefc397d871346a23a8bd7bad1877d7f848e66c
<BR>

### Confirmation:
- RPi.arm
\- Build is passed with these commits.
\- virtualxt_libretro.so file is not contained in RPi.arm image.
- RPi4.aarch64
\- Build is passed with these commits.
\- virtualxt_libretro.so file is contained in RPi4.aarch64 image.
<BR>

Thanks,
ASAI, Shigeaki