### PR TITLE
update openssl to 3.5.1 and openssh to 10.0p2

### DIFF
--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -3,15 +3,15 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssh"
-PKG_VERSION="9.9p2"
-PKG_SHA256="91aadb603e08cc285eddf965e1199d02585fa94d994d6cae5b41e1721e215673"
+PKG_VERSION="10.0p2"
+PKG_SHA256="021a2e709a0edf4250b1256bd5a9e500411a90dddabea830ed59cef90eb9d85c"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.openssh.com/"
 PKG_URL="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain openssl zlib"
 PKG_LONGDESC="An open re-implementation of the SSH package."
 PKG_TOOLCHAIN="autotools"
-PKG_BUILD_FLAGS="+lto"
+PKG_BUILD_FLAGS="+lto -cfg-libs"
 
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_header_rpc_types_h=no \
                            --sysconfdir=/etc/ssh \
@@ -55,5 +55,8 @@ post_makeinstall_target() {
 }
 
 post_install() {
+  if [ "${SSH_ENABLED_DEFAULT}" = "yes" ]; then
+    sed -e "\|^Condition.*|d" -i ${INSTALL}/usr/lib/systemd/system/sshd.service
+  fi
   enable_service sshd.service
 }

--- a/packages/network/openssh/patches/openssh-8.9p1-keydir.patch
+++ b/packages/network/openssh/patches/openssh-8.9p1-keydir.patch
@@ -1,7 +1,7 @@
 diff -u a/configure.ac b/configure.ac
 --- a/configure.ac	2018-10-16 20:01:20.000000000 -0400
 +++ b/configure.ac	2018-12-06 04:08:42.718993760 -0500
-@@ -5185,6 +5185,19 @@
+@@ -5355,6 +5355,19 @@
  )
  
  
@@ -21,7 +21,7 @@ diff -u a/configure.ac b/configure.ac
  AC_MSG_CHECKING([if we need to convert IPv4 in IPv6-mapped addresses])
  IPV4_IN6_HACK_MSG="no"
  AC_ARG_WITH(4in6,
-@@ -5565,6 +5578,7 @@
+@@ -5754,6 +5767,7 @@
  H=`eval echo ${PRIVSEP_PATH}` ; H=`eval echo ${H}`
  I=`eval echo ${user_path}` ; I=`eval echo ${I}`
  J=`eval echo ${superuser_path}` ; J=`eval echo ${J}`
@@ -29,7 +29,7 @@ diff -u a/configure.ac b/configure.ac
  
  echo ""
  echo "OpenSSH has been configured with the following options:"
-@@ -5588,6 +5602,9 @@
+@@ -5777,6 +5791,9 @@
  if test ! -z "$superuser_path" ; then
  echo "          sshd superuser user PATH: $J"
  fi
@@ -39,14 +39,13 @@ diff -u a/configure.ac b/configure.ac
  echo "                    Manpage format: $MANTYPE"
  echo "                       PAM support: $PAM_MSG"
  echo "                   OSF SIA support: $SIA_MSG"
-Common subdirectories: a/contrib and b/contrib
 diff -u a/Makefile.in b/Makefile.in
 --- a/Makefile.in	2018-10-16 20:01:20.000000000 -0400
 +++ b/Makefile.in	2018-12-06 04:00:04.301968236 -0500
-@@ -32,8 +32,10 @@
- STRIP_OPT=@STRIP_OPT@
+@@ -33,8 +33,10 @@
  TEST_SHELL=@TEST_SHELL@
  BUILDDIR=@abs_top_builddir@
+ SK_STANDALONE=@SK_STANDALONE@
 +KEYDIR=@KEYDIR@
  
  PATHS= -DSSHDIR=\"$(sysconfdir)\" \
@@ -54,7 +53,7 @@ diff -u a/Makefile.in b/Makefile.in
  	-D_PATH_SSH_PROGRAM=\"$(SSH_PROGRAM)\" \
  	-D_PATH_SSH_ASKPASS_DEFAULT=\"$(ASKPASS_PROGRAM)\" \
  	-D_PATH_SFTP_SERVER=\"$(SFTP_SERVER)\" \
-@@ -168,11 +170,11 @@
+@@ -192,11 +194,11 @@
  	-e 's|/etc/ssh/sshd_config|$(sysconfdir)/sshd_config|g' \
  	-e 's|/usr/libexec|$(libexecdir)|g' \
  	-e 's|/etc/shosts.equiv|$(sysconfdir)/shosts.equiv|g' \
@@ -71,7 +70,6 @@ diff -u a/Makefile.in b/Makefile.in
  	-e 's|/var/run/sshd.pid|$(piddir)/sshd.pid|g' \
  	-e 's|/etc/moduli|$(sysconfdir)/moduli|g' \
  	-e 's|/etc/ssh/moduli|$(sysconfdir)/moduli|g' \
-Common subdirectories: a/openbsd-compat and b/openbsd-compat
 diff -u a/pathnames.h b/pathnames.h
 --- a/pathnames.h	2018-10-16 20:01:20.000000000 -0400
 +++ b/pathnames.h	2018-12-06 04:15:01.286012398 -0500

--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -95,6 +95,7 @@ post_makeinstall_target() {
   # give user the chance to include their own CA
   mkdir -p ${INSTALL}/usr/bin
     cp ${PKG_DIR}/scripts/openssl-config ${INSTALL}/usr/bin
+    chmod +x ${INSTALL}/usr/bin/openssl-config
     ln -sf /run/libreelec/cacert.pem ${INSTALL}/etc/ssl/cacert.pem
     ln -sf /run/libreelec/cacert.pem ${INSTALL}/etc/ssl/cert.pem
 

--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -3,13 +3,13 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="openssl"
-PKG_VERSION="3.2.5"
-PKG_SHA256="b36347d024a0f5bd09fefcd6af7a58bb30946080eb8ce8f7be78562190d09879"
+PKG_VERSION="3.5.1"
+PKG_SHA256="529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f"
 PKG_LICENSE="Apache-2.0"
 PKG_SITE="https://openssl-library.org"
 PKG_URL="https://github.com/openssl/openssl/releases/download/${PKG_NAME}-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_HOST="ccache:host"
-PKG_DEPENDS_TARGET="toolchain"
+PKG_DEPENDS_TARGET="autotools:host gcc:host"
 PKG_LONGDESC="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security"
 PKG_TOOLCHAIN="configure"
 
@@ -50,6 +50,8 @@ configure_host() {
 
 makeinstall_host() {
   make install_sw
+  mkdir -p ${TOOLCHAIN}/etc/ssl
+  cp ${PKG_DIR}/cert/cacert.pem ${TOOLCHAIN}/etc/ssl/cert.pem
 }
 
 pre_configure_target() {
@@ -66,9 +68,6 @@ pre_configure_target() {
       ;;
     aarch64)
       OPENSSL_TARGET=linux-aarch64
-      ;;
-    i386)
-      OPENSSL_TARGET=linux-generic32
       ;;
   esac
 }
@@ -99,7 +98,7 @@ post_makeinstall_target() {
     ln -sf /run/libreelec/cacert.pem ${INSTALL}/etc/ssl/cacert.pem
     ln -sf /run/libreelec/cacert.pem ${INSTALL}/etc/ssl/cert.pem
 
-  # backwards comatibility
+  # backwards compatibility
   mkdir -p ${INSTALL}/etc/pki/tls
     ln -sf /run/libreelec/cacert.pem ${INSTALL}/etc/pki/tls/cacert.pem
   mkdir -p ${INSTALL}/etc/pki/tls/certs


### PR DESCRIPTION
This pull request updates openssl and openssh. The packages are from LibreELEC directly, the only change applied was to make `/usr/bin/openssl-config` executable, which was necessary otherwise the OpenSSL configuration service fails to run.