### PR TITLE
linux: fix odin linux buildfail on Lakka v6.1

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -48,12 +48,12 @@ case "${LINUX}" in
     PKG_SHA256=${L4T_COMBINED_KERNEL_SHA256}
     ;;
   ayn-odin)
-   PKG_SHA256="9aa25bf492928bc7a4542e87d28919c9ac36d27c"
-   PKG_VERSION="${PKG_SHA256}"
-   PKG_URL="https://gitlab.com/sdm845-mainline/linux.git"
-   PKG_PATCH_DIRS="ayn-odin"
-   PKG_GIT_CLONE_BRANCH="sdm845-5.19.16"
-   ;;
+    PKG_SHA256="9aa25bf492928bc7a4542e87d28919c9ac36d27c"
+    PKG_VERSION="${PKG_SHA256}"
+    PKG_URL="https://gitlab.com/sdm845-mainline/linux.git"
+    PKG_PATCH_DIRS="ayn-odin"
+    PKG_GIT_CLONE_BRANCH="sdm845-5.19.16"
+    ;;
   *)
     PKG_VERSION="6.16"
     PKG_SHA256="1a4be2fe6b5246aa4ac8987a8a4af34c42a8dd7d08b46ab48516bcc1befbcd83"
@@ -410,27 +410,51 @@ make_target() {
             ;;
         esac
 
-      WERROR=0 \
-      NO_LIBPERL=1 \
-      NO_LIBPYTHON=1 \
-      NO_SLANG=1 \
-      NO_GTK2=1 \
-      NO_LIBNUMA=1 \
-      NO_LIBAUDIT=1 \
-      NO_LIBTRACEEVENT=1 \
-      NO_LZMA=1 \
-      NO_SDT=1 \
-      NO_LIBDEBUGINFOD=1 \
-      NO_JVMTI=1 \
-      NO_LIBLLVM=1 \
-      NO_LIBPFM4=1 \
-      NO_LIBBABELTRACE=1 \
-      NO_CAPSTONE=1 \
-      NO_LIBPFM4=1 \
-      BUILD_BPF_SKEL=0 \
-      CROSS_COMPILE="${TARGET_PREFIX}" \
-      JOBS="${CONCURRENCY_MAKE_LEVEL}" \
-        make ${PERF_BUILD_ARGS}
+      if [ "${LINUX}" = "ayn-odin" ]; then
+        # Removed "BUILD_BPF_SKEL=0" from make parameters.
+        WERROR=0 \
+        NO_LIBPERL=1 \
+        NO_LIBPYTHON=1 \
+        NO_SLANG=1 \
+        NO_GTK2=1 \
+        NO_LIBNUMA=1 \
+        NO_LIBAUDIT=1 \
+        NO_LIBTRACEEVENT=1 \
+        NO_LZMA=1 \
+        NO_SDT=1 \
+        NO_LIBDEBUGINFOD=1 \
+        NO_JVMTI=1 \
+        NO_LIBLLVM=1 \
+        NO_LIBPFM4=1 \
+        NO_LIBBABELTRACE=1 \
+        NO_CAPSTONE=1 \
+        NO_LIBPFM4=1 \
+        CROSS_COMPILE="${TARGET_PREFIX}" \
+        JOBS="${CONCURRENCY_MAKE_LEVEL}" \
+          make ${PERF_BUILD_ARGS}
+      else
+        WERROR=0 \
+        NO_LIBPERL=1 \
+        NO_LIBPYTHON=1 \
+        NO_SLANG=1 \
+        NO_GTK2=1 \
+        NO_LIBNUMA=1 \
+        NO_LIBAUDIT=1 \
+        NO_LIBTRACEEVENT=1 \
+        NO_LZMA=1 \
+        NO_SDT=1 \
+        NO_LIBDEBUGINFOD=1 \
+        NO_JVMTI=1 \
+        NO_LIBLLVM=1 \
+        NO_LIBPFM4=1 \
+        NO_LIBBABELTRACE=1 \
+        NO_CAPSTONE=1 \
+        NO_LIBPFM4=1 \
+        BUILD_BPF_SKEL=0 \
+        CROSS_COMPILE="${TARGET_PREFIX}" \
+        JOBS="${CONCURRENCY_MAKE_LEVEL}" \
+          make ${PERF_BUILD_ARGS}
+      fi
       mkdir -p ${INSTALL}/usr/bin
         cp perf ${INSTALL}/usr/bin
     )


### PR DESCRIPTION
## This pull requests is fix odin linux buildfail on Lakka v6.1.
The upstream LibreELEC 12.2 updates linux build parameters.
https://github.com/LibreELEC/LibreELEC.tv/commit/d87f906a557cdd9a3a4ff64c772b02aea1ac6481

Of the added parameters, "BUILD_BPF_SKEL=0" causes the build linux to fail in Lakka v6.1 odin build.

The odin linux uses old version.
I think it has no compatible between the old linux and "BUILD_BPF_SKEL=0" build parameter.

Therefore, it removes "BUILD_BPF_SKEL=0" build parameter if odin linux build.

### [Confirmation]
- odin.aarch64
Build is passed.(build check only - I have no odin device sorry)
- Generic.x86_64
Build is passed.(build check only)

### [Note]
- If odin linux is updated, please remove this modification and use common linux build parameters.
- I modified 'ayn-odin)' indentation too.

Thanks
ASAI, Shigeaki