### PR TITLE
gdk-pixbuf: Add a GDK PIXBUF_VERSION_2_44 macro to fix -Wundef warnings

### DIFF
--- a/packages/graphics/gdk-pixbuf/patches/Add_a_GDK_PIXBUF_VERSION_2_44_macro_to_fix_-Wundef_warnings.patch
+++ b/packages/graphics/gdk-pixbuf/patches/Add_a_GDK_PIXBUF_VERSION_2_44_macro_to_fix_-Wundef_warnings.patch
@@ -1,0 +1,27 @@
+commit 101805761797283449bc3d02df1efc43c8be3b8a
+Author: correctmost <136447-correctmost@users.noreply.gitlab.gnome.org>
+Date:   Mon Jun 16 01:21:00 2025 -0400
+
+    Add a GDK_PIXBUF_VERSION_2_44 macro to fix -Wundef warnings
+
+diff --git a/gdk-pixbuf/gdk-pixbuf-macros.h b/gdk-pixbuf/gdk-pixbuf-macros.h
+index 335285f5c..f831a308a 100644
+--- a/gdk-pixbuf/gdk-pixbuf-macros.h
++++ b/gdk-pixbuf/gdk-pixbuf-macros.h
+@@ -258,6 +258,16 @@
+  */
+ #define GDK_PIXBUF_VERSION_2_40 (G_ENCODE_VERSION (2, 40))
+ 
++/**
++ * GDK_PIXBUF_VERSION_2_44:
++ *
++ * A macro that evaluates to the 2.44 version of GdkPixbuf,
++ * in a format that can be used by the C pre-processor.
++ *
++ * Since: 2.44
++ */
++#define GDK_PIXBUF_VERSION_2_44 (G_ENCODE_VERSION (2, 44))
++
+ #ifndef __GTK_DOC_IGNORE__
+ #if (GDK_PIXBUF_MINOR % 2)
+ #define GDK_PIXBUF_VERSION_CUR_STABLE (G_ENCODE_VERSION (GDK_PIXBUF_MAJOR, GDK_PIXBUF_MINOR + 1))


### PR DESCRIPTION
## This pull requests is fix wayland x86_64 buildfail on Lakka v6.1.
The upstream LibreELEC 12.2 bumps gdk-pixbuf package to v2.43.2.
But, gdk-pixbuf v2.43.2 had a problem. (gdk-pixbuf know problem and have fix)
And this build failure happenes not only Lakka v6.1 not also LibreELEC 12.2.

So I create the following pull requests on LibreELEC github.
- https://github.com/LibreELEC/LibreELEC.tv/pull/10399
[le12.2] gdk-pixbuf: add upstream patch file for v2.43.2 release

It is not merged into LibreELEC yet.
https://github.com/LibreELEC/LibreELEC.tv/pull/10399#issuecomment-3216896517

In any case, I'll make this pull requests for Lakka. 

### [Confirmation]
- wayland.x86_64
Build is passed.
The linux and retroach is able to start on N100 PC.

### [Note]
- If upstreamLE bumps gdk-pixbuf package, please remove this patch file.

Thanks
ASAI, Shigeaki