### PR TITLE
xpi_gamecon: fix build error and warning on raspberry pi linux v6.12.40

### DIFF
--- a/projects/RPi/devices/RPi4-PiBoyDmg/packages/xpi_gamecon/sources/xpi_gamecon.c
+++ b/projects/RPi/devices/RPi4-PiBoyDmg/packages/xpi_gamecon/sources/xpi_gamecon.c
@@ -1,6 +1,6 @@
 #include <linux/delay.h>
 #include <linux/input.h>
-#include <linux/of_device.h>
+#include <linux/of.h>
 #include <linux/module.h>
 #include <linux/slab.h>
 
@@ -120,7 +120,7 @@ struct kobj_attribute per = __ATTR(percent, 0660, percent_show, percent_store);
 struct kobj_attribute stat = __ATTR(status, 0660, stat_show, stat_store);
 struct kobj_attribute vol = __ATTR(volume, 0660, vol_show, vol_store);
 
-void gpio_func(int pin, int state)
+static void gpio_func(int pin, int state)
 {
 	volatile unsigned *tgpio = gpio;
 	tgpio += (pin/10);
@@ -128,7 +128,7 @@ void gpio_func(int pin, int state)
 	else{*tgpio |= (0x1<<(pin%10)*3);}
 }
 
-uint16_t check_crc16(uint8_t data[])
+static uint16_t check_crc16(uint8_t data[])
 {
 	int len = GC_LENGTH-2;
 	uint16_t crc=0;
@@ -147,7 +147,7 @@ uint16_t check_crc16(uint8_t data[])
 }
 
 uint16_t crc=0;
-void calc_crc16(uint8_t *data, uint8_t len)
+static void calc_crc16(uint8_t *data, uint8_t len)
 {
 	int i,j;
 
@@ -412,7 +412,7 @@ static u32 __init gc_bcm_peri_base_probe(void) {
 	return base_address == 1 ? 0x02000000 : base_address;
 }
 
-void osd(void)
+static void osd(void)
 {
 	char *envp[] = {
 	    "SHELL=/bin/bash",


### PR DESCRIPTION
## This pull requests is fix RPi4-PiBoyDmg aarch64 buildfail on Lakka v6.1.
The upstream LibreELEC 12.2 bumps raspberry pi linux to 6.12.40.
Lakka v6.1 merges LibreELEC 12.2.

The xpi_gamecon package is contained in RPi4-PiBoyDmg only. 
And , the xpi_gamecon package has build fail on Lakka v6.1. (also devel branch)
This build fail related with linux version up.

The xpi_gamecon source file includes "<linux/of_device.h>" header file, and it uses 'of_find_node_by_path()' function and 'of_property_read_u32_index()' function that there ara  defined in "<linux/of.h>" header file.
At old linux "<linux/of_device.h>" header file inlucleds "<linux/of.h>" header file, but it does not include now.
https://github.com/torvalds/linux/commit/ef175b29a242fea98f467f008237484b03c94834

Therefore, it changes include header file from "<linux/of_device.h>" to "<linux/of.h>" in source file.
And add 'static' prototype before 4 functions in source file for fix warning. 

The devel branch used old linux version as workaround.
https://github.com/libretro/Lakka-LibreELEC/issues/2040
This pull requests is effective for devel branch too.

### [Confirmation]
- RPi4-PiBoyDmg.aarch64 
Build is passed.
The linux and retroach is able to start on PiBoyDmg.
It is able to use PiBoyDmg controller in retroarch.

Thanks
ASAI, Shigeaki