### PR TITLE
RPi4-PiBoyDmg: Fix xpi_gamecon build failure problem #2040.

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -29,12 +29,6 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/after-6.14"
     ;;
-  raspberrypi-6.6.y)
-    PKG_VERSION="6d16e47ca139ba64c5daedf06e72f2774adbdc48" # 6.6.74
-    PKG_SHA256="2625c01652ed76de6a69062c286bda0c256b0106bf29352766e8232c1690033f"
-    PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
-    PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
-    ;;
   raspberrypi-5.10.y)
     PKG_VERSION="8e1110a580887f4b82303b9354c25d7e2ff5860e" # 5.10.110
     PKG_SHA256="e3244061e44426eafe97541633b87a71b8be1828d1bc48a18ec4c83fddb2f4c5"
@@ -232,7 +226,7 @@ pre_make_target() {
   fi
 
   # enable Dualsense on default and raspberrypi kernels for Lakka
-  if [ "${DISTRO}" = "Lakka" ] && [ "${LINUX}" = "default" -o "${LINUX:0:11}" = "raspberrypi" ]; then
+  if [ "${DISTRO}" = "Lakka" ] && [ "${LINUX}" = "default" -o "${LINUX}" = "raspberrypi" ]; then
     ${PKG_BUILD}/scripts/config \
                                 --enable CONFIG_HID_PLAYSTATION \
                                 --enable CONFIG_PLAYSTATION_FF

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -226,7 +226,7 @@ pre_make_target() {
   fi
 
   # enable Dualsense on default and raspberrypi kernels for Lakka
-  if [ "${DISTRO}" = "Lakka" ] && [ "${LINUX}" = "default" -o "${LINUX}" = "raspberrypi" ]; then
+  if [ "${DISTRO}" = "Lakka" ] && [ "${LINUX}" = "default" -o "${LINUX:0:11}" = "raspberrypi" ]; then
     ${PKG_BUILD}/scripts/config \
                                 --enable CONFIG_HID_PLAYSTATION \
                                 --enable CONFIG_PLAYSTATION_FF

--- a/projects/RPi/devices/RPi4-PiBoyDmg/options
+++ b/projects/RPi/devices/RPi4-PiBoyDmg/options
@@ -35,9 +35,6 @@
   # Kernel target
     KERNEL_TARGET="Image"
 
-  # override default linux, not compatible with xpi_gamecon driver/module
-    LINUX="raspberrypi-6.6.y"
-
   # enable vulkan for Lakka
     if [ "${DISTRO}" = "Lakka" ]; then
       VULKAN="vulkan-loader"

--- a/projects/RPi/devices/RPi4-PiBoyDmg/packages/xpi_gamecon/sources/xpi_gamecon.c
+++ b/projects/RPi/devices/RPi4-PiBoyDmg/packages/xpi_gamecon/sources/xpi_gamecon.c
@@ -1,6 +1,6 @@
 #include <linux/delay.h>
 #include <linux/input.h>
-#include <linux/of_device.h>
+#include <linux/of.h>
 #include <linux/module.h>
 #include <linux/slab.h>
 
@@ -120,7 +120,7 @@ struct kobj_attribute per = __ATTR(percent, 0660, percent_show, percent_store);
 struct kobj_attribute stat = __ATTR(status, 0660, stat_show, stat_store);
 struct kobj_attribute vol = __ATTR(volume, 0660, vol_show, vol_store);
 
-void gpio_func(int pin, int state)
+static void gpio_func(int pin, int state)
 {
 	volatile unsigned *tgpio = gpio;
 	tgpio += (pin/10);
@@ -128,7 +128,7 @@ void gpio_func(int pin, int state)
 	else{*tgpio |= (0x1<<(pin%10)*3);}
 }
 
-uint16_t check_crc16(uint8_t data[])
+static uint16_t check_crc16(uint8_t data[])
 {
 	int len = GC_LENGTH-2;
 	uint16_t crc=0;
@@ -147,7 +147,7 @@ uint16_t check_crc16(uint8_t data[])
 }
 
 uint16_t crc=0;
-void calc_crc16(uint8_t *data, uint8_t len)
+static void calc_crc16(uint8_t *data, uint8_t len)
 {
 	int i,j;
 
@@ -412,7 +412,7 @@ static u32 __init gc_bcm_peri_base_probe(void) {
 	return base_address == 1 ? 0x02000000 : base_address;
 }
 
-void osd(void)
+static void osd(void)
 {
 	char *envp[] = {
 	    "SHELL=/bin/bash",


### PR DESCRIPTION
## This pull requests is fix "[xpi_gamecon: does not compile on devel branch](https://github.com/libretro/Lakka-LibreELEC/issues/2040)". (#2040)
The devel branch bumps raspberry pi linux to 6.12.15.
But there was build fail on RPi4-PiBoyDmg xpi_gamecon package. (#2040)
This pull request fixs above problem.
And same fix is merged in Lakka-v6.1 already (#2108).

### [Cause]
Please refer issue #2040 comments and pull requests #2108.

### [Commit] : this pull requests has 3commits
- Revert "linux: add older raspberrypi kernel for PiBoyDmg (37fc0cb6cb84b68cb17ebded47b011580f552d03)
Revert RPi4-PiBoyDmg workaround. RPi4-PiBoyDmg uses raspberry pi linux 6.12.15 too.
- linux: it resurrects "enable Dualsense" for raspberry pi composite (8e6673f9f06de32d463adde58346e84a72074180)
It resurrects changing for raspberry pi composite
- xpi_gamecon: fix build error and warning on raspberry pi linux v6.12.15 (69c7050f362dd82a11ca230eb6653dfc614d7383)
Fix build fail and resolve build warning

### [Confirmation]
- RPi4-PiBoyDmg.aarch64 
Build is passed.
The linux and retroach is able to start on PiBoyDmg.
It is able to use PiBoyDmg controller in retroarch.

Thanks
ASAI, Shigeaki