### PR TITLE
build_all.sh: remove Allwinner H616 for devel branch

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -81,7 +81,6 @@ targets="\
 	Allwinner|H3|arm|image \
 	Allwinner|H5|aarch64|image \
 	Allwinner|H6|aarch64|image \
-	Allwinner|H616|aarch64|image \
 	Allwinner|R40|arm|image \
 	Amlogic|AMLGX|aarch64|image \
 	Ayn|Odin|aarch64|image \


### PR DESCRIPTION
It removes "PROJECT=Allwinner DEVICE=H616" from "build_all.sh"
This is for devel branch.

Thanks
ASAI, Shigeaki