### PR TITLE
openssl: Resurrect lost i386 build param

### DIFF
--- a/packages/security/openssl/package.mk
+++ b/packages/security/openssl/package.mk
@@ -69,6 +69,9 @@ pre_configure_target() {
     aarch64)
       OPENSSL_TARGET=linux-aarch64
       ;;
+    i386)
+      OPENSSL_TARGET=linux-generic32
+      ;;
   esac
 }
 


### PR DESCRIPTION
Lakka-v6.x generic i386 openssl package has build failure.
Attached file is openssl package build log.
[Lakka-v6.x_Generic_i386_openssl_buildfail.log](https://github.com/user-attachments/files/22860736/Lakka-v6.x_Generic_i386_openssl_buildfail.log)

This failure is caused by commit 3f0077a625b80e597fbdf91f49c33d5caaad4229.
upstream LibreELEC drops i386 support but Lakka still supports i386.

So resurrect lost i386 build parameter in openssl package.

### [Confirmation]
- Generic.i386 
Build is passed.

### [Note]
This problem is only happened in Lakka-v6.x.

Thanks
ASAI, Shigeaki