### PR TITLE
Lakka-v6.x: RPi5: parallel_n64: use "cached_interpreter" into "parallel-n64-cpucore" as workaround

### DIFF
--- a/projects/RPi/devices/RPi5/patches/parallel_n64/parallel-n64_prioritize_cached_interpreter_for_RPi5.patch
+++ b/projects/RPi/devices/RPi5/patches/parallel_n64/parallel-n64_prioritize_cached_interpreter_for_RPi5.patch
@@ -1,0 +1,17 @@
+diff --git a/libretro/libretro.c b/libretro/libretro.c
+index 16525703..1ec43b90 100644
+--- a/libretro/libretro.c
++++ b/libretro/libretro.c
+@@ -341,7 +341,11 @@ static void setup_variables(void)
+ #if defined(IOS)
+          "CPU Core; cached_interpreter|pure_interpreter|dynamic_recompiler" },
+ #else
+-         "CPU Core; dynamic_recompiler|cached_interpreter|pure_interpreter" },
++         /* RPi5 fails to launch parallel_n64 core.
++          * Therefore, it uses "cached_interpreter" into "parallel-n64-cpucore" as workaround.
++          * https://github.com/libretro/Lakka-LibreELEC/issues/1982#issuecomment-2154720599 */
++         "CPU Core; cached_interpreter|pure_interpreter|dynamic_recompiler" },
++         // "CPU Core; dynamic_recompiler|cached_interpreter|pure_interpreter" },
+ #endif
+ #else
+          "CPU Core; cached_interpreter|pure_interpreter" },


### PR DESCRIPTION
## This pull requests is workaround for issue #2120 on Lakka-v6.x

### [Confirmation]
- RPi5.aarch64 
Build is passed.
parallel_n64 core is able to start.

Thanks
ASAI, Shigeaki