### PR TITLE
Set CEC_FRAMEWORK_SUPPORT to "no" when the cec_mini_kb package is removed

### DIFF
--- a/projects/Allwinner/options
+++ b/projects/Allwinner/options
@@ -60,7 +60,7 @@
     fi
 
   # build and install CEC framework support (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
+    CEC_FRAMEWORK_SUPPORT="no"
 
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"

--- a/projects/Amlogic/options
+++ b/projects/Amlogic/options
@@ -77,7 +77,7 @@
     ADDITIONAL_PACKAGES+=" dtc ethmactool emmctool flashrom pciutils tm16xx"
 
   # use the kernel CEC framework for libcec (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
+    CEC_FRAMEWORK_SUPPORT="no"
 
   # debug tty path
     DEBUG_TTY="/dev/ttyAML0"

--- a/projects/L4T/devices/Switch/options
+++ b/projects/L4T/devices/Switch/options
@@ -12,7 +12,7 @@ case ${TARGET_ARCH} in
 esac
 
 # CEC Support
-  CEC_FRAMEWORK_SUPPORT="yes"
+  CEC_FRAMEWORK_SUPPORT="no"
 
 if [ "${DISTRO}" = "Lakka" ]; then
   DISTRO_PATH="lakka"

--- a/projects/NXP/options
+++ b/projects/NXP/options
@@ -72,4 +72,4 @@
     INSTALLER_SUPPORT="no"
 
   # use the kernel CEC framework for libcec (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
+    CEC_FRAMEWORK_SUPPORT="no"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -59,7 +59,7 @@
     KODIPLAYER_DRIVER="mesa"
 
   # use the kernel CEC framework for libcec (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
+    CEC_FRAMEWORK_SUPPORT="no"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,

--- a/projects/Rockchip/options
+++ b/projects/Rockchip/options
@@ -65,7 +65,7 @@
     ADDITIONAL_PACKAGES+=" dtc"
 
   # build and install CEC framework support (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
+    CEC_FRAMEWORK_SUPPORT="no"
 
   # build with installer (yes / no)
     INSTALLER_SUPPORT="no"

--- a/projects/Samsung/options
+++ b/projects/Samsung/options
@@ -77,7 +77,7 @@
     DRIVER_ADDONS_SUPPORT="no"
 
   # use the kernel CEC framework for libcec (yes / no)
-    CEC_FRAMEWORK_SUPPORT="yes"
+    CEC_FRAMEWORK_SUPPORT="no"
 
   # debug tty path
     DEBUG_TTY="/dev/ttySAC2"


### PR DESCRIPTION
When the cec_mini_kb package is removed, build doesn't start on CEC_FRAMEWORK_SUPPORT="yes" project/device.
This pull requests is able to start build.

projects/Allwinner/options(63):     CEC_FRAMEWORK_SUPPORT="yes" -> "no"
projects/Amlogic/options(80):     CEC_FRAMEWORK_SUPPORT="yes" -> "no"
projects/L4T/devices/Switch/options(15):   CEC_FRAMEWORK_SUPPORT="yes" -> "no"
projects/NXP/options(75):     CEC_FRAMEWORK_SUPPORT="yes" -> "no"
projects/Rockchip/options(68):     CEC_FRAMEWORK_SUPPORT="yes" -> "no"
projects/RPi/options(62):     CEC_FRAMEWORK_SUPPORT="yes" -> "no"
projects/Samsung/options(80):     CEC_FRAMEWORK_SUPPORT="yes" -> "no"

projects=L4T,devices=Switch CEC_FRAMEWORK_SUPPORT is disabled in packages/lakka/package.mk
https://github.com/libretro/Lakka-LibreELEC/blob/a28487a1aa74898221e6ec77377a0393700be5c0/packages/lakka/package.mk#L47
but this also changes to "no" just in case.

