### PR TITLE
binutils: bump version to 2.44 for fix RPi vulkan retroarch service failed

### DIFF
--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="binutils"
-PKG_VERSION="2.43"
-PKG_SHA256="b53606f443ac8f01d1d5fc9c39497f2af322d99e14cea5c0b4b124d630379365"
+PKG_VERSION="2.43.1"
+PKG_SHA256="13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/binutils/"
 PKG_URL="https://ftp.gnu.org/gnu/binutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="binutils"
-PKG_VERSION="2.41"
-PKG_SHA256="ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450"
+PKG_VERSION="2.42"
+PKG_SHA256="f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/binutils/"
 PKG_URL="https://ftp.gnu.org/gnu/binutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="binutils"
-PKG_VERSION="2.42"
-PKG_SHA256="f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800"
+PKG_VERSION="2.43"
+PKG_SHA256="b53606f443ac8f01d1d5fc9c39497f2af322d99e14cea5c0b4b124d630379365"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/binutils/"
 PKG_URL="https://ftp.gnu.org/gnu/binutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"

--- a/packages/devel/binutils/package.mk
+++ b/packages/devel/binutils/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="binutils"
-PKG_VERSION="2.43.1"
-PKG_SHA256="13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd"
+PKG_VERSION="2.44"
+PKG_SHA256="67be9198476cc37436e2801de649f4ad80bf0d02430d86aff63c6b59b6e23987"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.gnu.org/software/binutils/"
-PKG_URL="https://ftp.gnu.org/gnu/binutils/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_URL="https://ftp.gnu.org/gnu/binutils/${PKG_NAME}-with-gold-${PKG_VERSION}.tar.xz"
 PKG_DEPENDS_HOST="ccache:host bison:host flex:host linux:host"
 PKG_DEPENDS_TARGET="toolchain zlib binutils:host"
 PKG_LONGDESC="A GNU collection of binary utilities."

--- a/packages/devel/binutils/patches/binutils-01-warn-for-uses-of-system-directories-when-link.patch
+++ b/packages/devel/binutils/patches/binutils-01-warn-for-uses-of-system-directories-when-link.patch
@@ -14,7 +14,7 @@ Subject: [PATCH 09/13] warn for uses of system directories when cross linking
 +++ b/ld/ldfile.c
 @@ -103,6 +103,17 @@ ldfile_add_library_path (const char *nam
    if (!cmdline && config.only_cmd_line_lib_dirs)
-     return;
+     return NULL;
  
 +  /* skip those directories when linking */
 +  if ((!strncmp (name, "/lib", 4)) ||
@@ -24,7 +24,7 @@ Subject: [PATCH 09/13] warn for uses of system directories when cross linking
 +  {
 +    einfo (_("%P: warning: library search path \"%s\" is unsafe for "
 +             "cross-compilation, ignore it\n"), name);
-+    return;
++    return NULL;
 +  }
 +
    new_dirs = (search_dirs_type *) xmalloc (sizeof (search_dirs_type));

--- a/packages/devel/binutils/patches/binutils-01-warn-for-uses-of-system-directories-when-link.patch
+++ b/packages/devel/binutils/patches/binutils-01-warn-for-uses-of-system-directories-when-link.patch
@@ -12,9 +12,9 @@ Subject: [PATCH 09/13] warn for uses of system directories when cross linking
 
 --- a/ld/ldfile.c
 +++ b/ld/ldfile.c
-@@ -103,6 +103,17 @@ ldfile_add_library_path (const char *nam
+@@ -314,6 +314,17 @@ ldfile_add_library_path (const char *nam
    if (!cmdline && config.only_cmd_line_lib_dirs)
-     return NULL;
+     return;
  
 +  /* skip those directories when linking */
 +  if ((!strncmp (name, "/lib", 4)) ||
@@ -24,7 +24,7 @@ Subject: [PATCH 09/13] warn for uses of system directories when cross linking
 +  {
 +    einfo (_("%P: warning: library search path \"%s\" is unsafe for "
 +             "cross-compilation, ignore it\n"), name);
-+    return NULL;
++    return;
 +  }
 +
    new_dirs = (search_dirs_type *) xmalloc (sizeof (search_dirs_type));


### PR DESCRIPTION
## This pull requests fixes RPi4/5 vulkan retroarch service failed.
Current Lakka-v6.1 uses mesa 25.1.9 version and binutils 2.41 version.

If this mesa version's vulkan build uses ld.gold 2.41 that it contained in binutils 2.41, there is problem.
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29986#note_2516917
This is known in mesa project, they recommend to update to ld.gold/binutils 2.44 or to use the other linker.

It updates binutils to 2.44.

### [commits]
There are 4 commits for this update
each commits ware used in upstream LibreELEC master branch

### [confirmation]
- Generic.x86_64 build is passed
- Switch.aarch64 build is passed
- RPi5.aarch64 build is passed and fixed vulkan retroarch can't start service issue.
- RPi4.aarch64 build is passed and fixed vulkan retroarch can't start service issue.
- Odin.aarch64 build is passed

Thanks
ASAI, Shigeaki