### PR TITLE
Lakka-v6.1: Bump retroarch version to v1.22.1 and related packages version

### DIFF
--- a/packages/lakka/retroarch_base/core_info/package.mk
+++ b/packages/lakka/retroarch_base/core_info/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="core_info"
-PKG_VERSION="1141733f88c4693a35e1f94cf0e091142e845666"
+PKG_VERSION="938f24313afe37f62ac122bb77980decdf1b1b4f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-core-info"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/glsl_shaders/package.mk
+++ b/packages/lakka/retroarch_base/glsl_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="glsl_shaders"
-PKG_VERSION="909415db527c98a59464c52d531a9c1b71122dfd"
+PKG_VERSION="28643f63dd8d95dec49fb7241d3d35e3d037e14a"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/glsl-shaders"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/glsl_shaders/package.mk
+++ b/packages/lakka/retroarch_base/glsl_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="glsl_shaders"
-PKG_VERSION="28643f63dd8d95dec49fb7241d3d35e3d037e14a"
+PKG_VERSION="468f67b6f6788e2719d1dd28dfb2c9b7c3db3cc7"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/glsl-shaders"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/libretro_database/package.mk
+++ b/packages/lakka/retroarch_base/libretro_database/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="libretro_database"
-PKG_VERSION="97ca969d058f5401ee06fb8e36a9b6ad7ef82bf2"
+PKG_VERSION="fbcc8c1c24d8b20b6aaca95b4da6a2f39ad85f05"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-database"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch"
-PKG_VERSION="baee906ef35b99283f9a1a060a2ce5ac86159b63"
+PKG_VERSION="703321e80784e3fe3ba0dd648e482cd1ee47cdc0"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch"
-PKG_VERSION="703321e80784e3fe3ba0dd648e482cd1ee47cdc0"
+PKG_VERSION="a15217dbaf2c0794f62c64511839d4f72d71cfd9"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_assets/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_assets/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_assets"
-PKG_VERSION="2d24ef2972a709f870cc3f73853158fa2376f37d"
+PKG_VERSION="76cc6cf03507429c5a136cb50d83a14e05430fcd"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/retroarch-assets"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_joypad_autoconfig"
-PKG_VERSION="c730e2b27df33268ab4d195bf6eb15c92abc59c0"
+PKG_VERSION="38cf938bba0adbde375972053068f10d955a9d14"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/retroarch-joypad-autoconfig"
 PKG_URL="${PKG_SITE}.git"
@@ -10,8 +10,8 @@ makeinstall_target() {
   make -C ${PKG_BUILD} install INSTALLDIR="${INSTALL}/etc/retroarch-joypad-autoconfig" DOC_DIR="${INSTALL}/etc/doc/."
 
   #Remove non tested joycon configs
-  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Co., Ltd. Pro Controller (old).cfg"
-  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Co., Ltd. Pro Controller.cfg"
+  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Switch Pro Controller (non-HID) (default-off).cfg"
+  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Switch Pro Controller.cfg"
   rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo-Switch-Online_NES-Controller_Left.cfg"
   rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo-Switch-Online_NES-Controller_Right.cfg"
   rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Switch Left Joy-Con.cfg"

--- a/packages/lakka/retroarch_base/retroarch_overlays/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_overlays/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_overlays"
-PKG_VERSION="de100b2ae7789a2428ab318df3e51c3eea353b44"
+PKG_VERSION="e2568e3ff9abaeddd087e093ac0b3acd4b649f7d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/common-overlays"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/slang_shaders/package.mk
+++ b/packages/lakka/retroarch_base/slang_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="slang_shaders"
-PKG_VERSION="1ed1b59acec51a3156ec70522fb98be3c74f95f4"
+PKG_VERSION="724d3ec5f67f8fd1eb0962bf712fcf812290ae1a"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/slang-shaders"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/slang_shaders/package.mk
+++ b/packages/lakka/retroarch_base/slang_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="slang_shaders"
-PKG_VERSION="724d3ec5f67f8fd1eb0962bf712fcf812290ae1a"
+PKG_VERSION="3d57e977b892eee945f3347be506c37ddc1b11b5"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/slang-shaders"
 PKG_URL="${PKG_SITE}.git"


### PR DESCRIPTION
## Bump retroarch version to v1.22.1 and related packages version.
This pull requests has 8 packages update.
- core_info: bump version to 938f24313afe37f62ac122bb77980decdf1b1b4f
- glsl_shaders: bump version to 468f67b6f6788e2719d1dd28dfb2c9b7c3db3cc7
- libretro_database: bump version to fbcc8c1c24d8b20b6aaca95b4da6a2f39ad85f05
- retroarch: bump version to v1.22.1 (a15217dbaf2c0794f62c64511839d4f72d71cfd9)
- retroarch_assets: bump version to 76cc6cf03507429c5a136cb50d83a14e05430fcd
- retroarch_joypad_autoconfig: bump version to 38cf938bba0adbde375972053068f10d955a9d14 and catch-up 2 filename changing commit.
  https://github.com/libretro/retroarch-joypad-autoconfig/commit/9223b86d80a491cffedb79804b62d759bd7d3f82
  https://github.com/libretro/retroarch-joypad-autoconfig/commit/df07fe376048040b2b5a43d63cb2fa5608aa2e74
- retroarch_overlays: bump version to e2568e3ff9abaeddd087e093ac0b3acd4b649f7d
- slang_shaders: bump version to 3d57e977b892eee945f3347be506c37ddc1b11b5

### [Update method]
use `./libretro_update.sh -r` command
and modify packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk by editor

### [Confirmation]
- building
  All 30 devices build were passed.
  > All successful!
  > :-)
- retroarch starting
  I tested it with OK on the following 2 devices.
  RPi4 with RPi4.aarch64 image is able to start retroarch (both gl and vulkan)
  N150 PC with Generic.x86_64 image is able to start retroarch (both gl and vulkan)
  (persona 3 portable on PPSSPP core was able to start)

### [Note]
My USB controller A<->B button mapping was changed.

Thanks
ASAI, Shigeaki