### PR TITLE
virtualxt: change repository address

### DIFF
--- a/packages/lakka/libretro_cores/virtualxt/package.mk
+++ b/packages/lakka/libretro_cores/virtualxt/package.mk
@@ -5,7 +5,7 @@ PKG_LICENSE="zlib"
 # https://github.com/virtualxt/virtualxt/issues/97
 # please enable (remove "!arm" in PKG_ARCH ) when build failure is fixed.
 PKG_ARCH="any !arm"
-PKG_SITE="https://github.com/virtualxt/virtualxt"
+PKG_SITE="https://codeberg.org/virtualxt/virtualxt"
 PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Lightweight Turbo PC/XT emulator."


### PR DESCRIPTION
The virtualxt core changed repository address.

new address)
https://codeberg.org/virtualxt/virtualxt.git
old address)
https://github.com/virtualxt/virtualxt.git

We need to change PKG_SITE description in virtualxt core's package.mk

[Confirmation]
Build is passed on RPi4.aarch64, Generic.x86_64 and Generic.i386
ARCH=arm is temporary disabled now

Thanks
ASAI, Shigeaki