### PR TITLE
scripts/checkdeps: add rsync for linux:host build fail on fresh Debian

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -70,6 +70,7 @@ dep_map=(
   [patch]=patch
   [perl]=perl
   [rdfind]=rdfind
+  [rsync]=rsync
   [sed]=sed
   [tar]=tar
   [unzip]=unzip


### PR DESCRIPTION
## This Pull requests fixes Issues #2142 
Default Debian 13.2 installation doesn't contain "rsync" package.

RPi4.aarch64 Lakka-v6.1 linux:host build is failed because it needs "rsync" package.
> /bin/sh: 1: rsync: not found

[This is linux:host build failure log](https://github.com/user-attachments/files/24142323/37.linux_build_fail.log)

This problem also occurs on LibreELEC 12.2.
But LibreELEC master branch [added dependency "rsync" into scripts/checkdeps](https://github.com/LibreELEC/LibreELEC.tv/commit/d6218c04096772289eff1584311738be27bf0300).

**Lakka-v6.1 also needs this LibreELEC master branch's scripts/checkdeps update I think.**

### Confirmation
RPi4.aarch64 linux:host build is [passed](https://github.com/user-attachments/files/24142377/37.linux_build_passed.log) with this commit.

### Note
If this PR is merged, other virtualxt package build will be failed.
Because virtualxt package needs "curl" package, but default Debian 13.2 installation doesn't contain "curl" package.
I will create new PR for "curl" package.

Thanks
ASAI, Shigeaki