### PR TITLE
scripts/checkdeps: add curl as required for virtualxt package

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -58,6 +58,7 @@ dep_map=(
   [bash]=bash
   [bc]=bc
   [bzip2]=bzip2
+  [curl]=curl
   [diff]=diffutils
   [gawk]=gawk
   [gcc]=gcc


### PR DESCRIPTION
## This Pull requests fixes Issues #2142 
Default Debian 13.2 installation doesn't contain "curl" package.

RPi4.aarch64 Lakka-v6.1 virtualxt:target build is failed because it needs "curl" package.
```
curl -L -o odin.zip https://github.com/odin-lang/Odin/releases/download/dev-2025-09/odin-linux-amd64-dev-2025-09.zip && mkdir odin && unzip -o odin.zip && tar -xf dist.tar.gz -C ./odin --strip-components=1
/bin/sh: 1: curl: not found
```
[This is virtualxt:target build failure log).log](https://github.com/user-attachments/files/24147656/342.virtualxt_build_fail.log)

This problem is only occurred in Lakka.

**It is better to add "curl" dependency into scripts/checkdeps I think.**

### Confirmation
RPi4.aarch64 virtualxt:target build is [passed](https://github.com/user-attachments/files/24147698/381.virtualxt_build_pass.log) with this commit.

Thanks
ASAI, Shigeaki