### PR TITLE
Lakka-v6.1: Bump retroarch version to v1.22.2 and related packages version

### DIFF
--- a/packages/lakka/retroarch_base/core_info/package.mk
+++ b/packages/lakka/retroarch_base/core_info/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="core_info"
-PKG_VERSION="938f24313afe37f62ac122bb77980decdf1b1b4f"
+PKG_VERSION="20e7d555f911f5aa6712d5937f7b9b834015d88d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-core-info"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/libretro_database/package.mk
+++ b/packages/lakka/retroarch_base/libretro_database/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="libretro_database"
-PKG_VERSION="fbcc8c1c24d8b20b6aaca95b4da6a2f39ad85f05"
+PKG_VERSION="06bf35279fc476f1b1d48acc169a273a3428a664"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-database"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch"
-PKG_VERSION="a15217dbaf2c0794f62c64511839d4f72d71cfd9"
+PKG_VERSION="69a4f0ea1e8aaf442ae4858f2e7f2b31a1776576"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_assets/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_assets/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_assets"
-PKG_VERSION="76cc6cf03507429c5a136cb50d83a14e05430fcd"
+PKG_VERSION="a7b711dfd74871e9985ba3b2fe2c15048a928aaf"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/retroarch-assets"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_overlays/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_overlays/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_overlays"
-PKG_VERSION="e2568e3ff9abaeddd087e093ac0b3acd4b649f7d"
+PKG_VERSION="6da725ba4533b609714b094b70f1133ae48fae11"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/common-overlays"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/slang_shaders/package.mk
+++ b/packages/lakka/retroarch_base/slang_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="slang_shaders"
-PKG_VERSION="3d57e977b892eee945f3347be506c37ddc1b11b5"
+PKG_VERSION="b80bba0c71e98250717acc5f4e6b9bb9f75bd091"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/slang-shaders"
 PKG_URL="${PKG_SITE}.git"


### PR DESCRIPTION
## Bump retroarch version to v1.22.2 and related packages version.
This pull requests has 5 packages update.
- libretro_database: bump version to 06bf35279fc476f1b1d48acc169a273a3428a664
- retroarch_assets: bump version to a7b711dfd74871e9985ba3b2fe2c15048a928aaf
- retroarch_overlays: bump version to 6da725ba4533b609714b094b70f1133ae48fae11
- slang_shaders: bump version to b80bba0c71e98250717acc5f4e6b9bb9f75bd091
- retroarch: bump version to v1.22.2(69a4f0ea1e8aaf442ae4858f2e7f2b31a1776576)

### [Update method]
use `./libretro_update.sh -r` command

### [Confirmation]
- building
  All 30 devices build were passed.
  > All successful!
  > :-)
- retroarch starting
  I tested it with OK on the following 2 devices.
  RPi4 with RPi4.aarch64 image is able to start retroarch (both gl and vulkan)
  N150 PC with Generic.x86_64 image is able to start retroarch (both gl and vulkan)
  (persona 3 portable on PPSSPP core was able to start)

### [Note]
- My USB controller A<->B button mapping was changed.
- Base commit is 0cd6fe2e595a3c71e356fdb85af7c65561173804 (checkdeps: add rsync as required package (#2143))

Thanks
ASAI, Shigeaki
