### PR TITLE
Lakka-v6.1: fix build failure on clean/fresh build and add to restore "${DISTRO}" = "Lakka" into 3 RPi GPI packages

### DIFF
--- a/packages/addons/addon-depends/icu/package.mk
+++ b/packages/addons/addon-depends/icu/package.mk
@@ -14,6 +14,10 @@ PKG_TOOLCHAIN="configure"
 
 PKG_BUILD_FLAGS="-sysroot"
 
+if [ "${DISTRO}" = "Lakka" ]; then
+  PKG_BUILD_FLAGS=""
+fi
+
 configure_package() {
   PKG_CONFIGURE_SCRIPT="${PKG_BUILD}/icu4c/source/configure"
   PKG_CONFIGURE_OPTS_TARGET="--disable-layout \

--- a/packages/addons/addon-depends/libzip/package.mk
+++ b/packages/addons/addon-depends/libzip/package.mk
@@ -23,6 +23,10 @@ PKG_CMAKE_OPTS_TARGET="-DENABLE_COMMONCRYPTO=OFF \
                        -DBUILD_DOC=OFF \
                        -DBUILD_SHARED_LIBS=OFF"
 
+if [ "${DISTRO}" = "Lakka" ]; then
+  PKG_BUILD_FLAGS="+pic"
+fi
+
 post_makeinstall_target() {
   rm -rf ${INSTALL}/usr/lib
 }

--- a/packages/addons/addon-depends/rpi-tools-depends/colorzero/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/colorzero/package.mk
@@ -11,3 +11,34 @@ PKG_URL="https://github.com/waveform80/colorzero/archive/release-${PKG_VERSION}.
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Another color manipulation library for Python (originally from picamera)."
 PKG_TOOLCHAIN="manual"
+
+[ "${DISTRO}" = "Lakka" ] && PKG_DEPENDS_TARGET+=" Python3 distutilscross:host" || true
+
+if [ "${DISTRO}" = "Lakka" ]; then
+  PKG_ARCH+=" aarch64"
+fi
+
+pre_make_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    export PYTHONXCPREFIX="${SYSROOT_PREFIX}/usr"
+    export LDSHARED="${CC} -shared"
+  fi
+}
+
+make_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    python setup.py build --cross-compile
+  fi
+}
+
+makeinstall_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    python setup.py install --root=${INSTALL} --prefix=/usr
+  fi
+}
+
+post_makeinstall_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    find ${INSTALL}/usr/lib -name "*.py" -exec rm -rf "{}" ";"
+  fi
+}

--- a/packages/addons/addon-depends/rpi-tools-depends/gpiozero/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/gpiozero/package.mk
@@ -11,3 +11,33 @@ PKG_URL="https://files.pythonhosted.org/packages/source/${PKG_NAME:0:1}/${PKG_NA
 PKG_DEPENDS_TARGET="toolchain colorzero"
 PKG_LONGDESC="A simple interface to everyday GPIO components used with Raspberry Pi."
 PKG_TOOLCHAIN="manual"
+
+if [ "${DISTRO}" = "Lakka" ]; then
+  PKG_ARCH+=" aarch64"
+fi
+
+pre_make_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    export PYTHONXCPREFIX="${SYSROOT_PREFIX}/usr"
+    export LDSHARED="${CC} -shared"
+  fi
+}
+
+make_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    python setup.py build --cross-compile
+  fi
+}
+
+makeinstall_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    python setup.py install --root=${INSTALL} --prefix=/usr
+  fi
+}
+
+post_makeinstall_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    find ${INSTALL}/usr/lib -name "*.py" -exec rm -rf "{}" ";"
+    rm -rf ${INSTALL}/usr/bin
+  fi
+}

--- a/packages/addons/addon-depends/rpi-tools-depends/lg-gpio/package.mk
+++ b/packages/addons/addon-depends/rpi-tools-depends/lg-gpio/package.mk
@@ -27,3 +27,20 @@ make_target() {
   )
 }
 
+makeinstall_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    mkdir -p "${INSTALL}/usr/lib"
+    cp -v ./liblgpio.so* "${INSTALL}/usr/lib"
+    (
+      cd PY_LGPIO
+      python setup.py install --root=${INSTALL} --prefix=/usr
+    )
+  fi
+}
+
+post_makeinstall_target() {
+  if [ "${DISTRO}" = "Lakka" ]; then
+    find ${INSTALL}/usr/lib -name "*.py" -exec rm -rf "{}" ";"
+    rm -rf ${INSTALL}/usr/bin
+  fi
+}

--- a/packages/lakka/libretro_cores/dosbox_core/package.mk
+++ b/packages/lakka/libretro_cores/dosbox_core/package.mk
@@ -20,6 +20,10 @@ elif [ "${ARCH}" = "i386" ]; then
   PKG_MAKE_OPTS_TARGET+=" WITH_DYNAREC=x86"
 fi
 
+pre_configure_target() {
+  export PKG_CONFIG_PATH="$(get_install_dir mpg123)/usr/lib/pkgconfig:${PKG_CONFIG_PATH}"
+}
+
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v ${PKG_BUILD}/libretro/dosbox_core_libretro.so ${INSTALL}/usr/lib/libretro

--- a/packages/lakka/libretro_cores/uae4arm/package.mk
+++ b/packages/lakka/libretro_cores/uae4arm/package.mk
@@ -18,6 +18,11 @@ else
   PKG_MAKE_OPTS_TARGET+=" platform=unix"
 fi
 
+pre_configure_target() {
+  sed -e "s|LDFLAGS := -lz -lpthread -lFLAC -lmpg123 -ldl|& -L$(get_install_dir mpg123)/usr/lib|" \
+    -i ${PKG_BUILD}/Makefile.libretro
+}
+
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
     cp -v uae4arm_libretro.so ${INSTALL}/usr/lib/libretro/


### PR DESCRIPTION
## This pull requests fixes build failure on Lakka-v6.1(a7604dfecb46b567dfc01c1b6122b1190cb3f4f7) clean/fresh build
- icu:
  The libretro easyrpg core depends the liblcf(packages/lakka/lakka_depends/liblcf) package.
  The liblcf package depends the icu(packages/addons/addon-depends/icu) package.
  liblcf can't find icu modules if PKG_BUILD_FLAGS="-sysroot" is set in the icu package.
  So PKG_BUILD_FLAGS="" is needed. 
- libzip:
  The libretro ppsspp core depends libzip(packages/addons/addon-depends/libzip) package.
  When x86_64 ppsspp build(linking), linker needs the libzip is built with +fPIC(something like this message is shown).
  So PKG_BUILD_FLAGS="+pic" is needed. 
- libretro_cores: uae4arm:
  The libretro uae4arm core depends mpg123(packages/addons/addon-depends/multimedia-tools-depends/mpg123) package.
  When uae4arm build, it can't find mpg123 related module.
  Upstream LibreELEC has [fixed patch](https://github.com/LibreELEC/LibreELEC.tv/commit/6a11a5770f5d045f895a7ffb4a1c687fc43d04ab), so we use this patch.
- libretro_cores: dosbox_core:
  The libretro dosbox_core core also depends mpg123 package.
  When dosbox_core build, it can't find mpg123 related module.
  I made modification that is referred with uae4arm upstream LibreELEC patch.

- colorzero:
  The gpicase_safeshutdown package depends the colorzero(packages/addons/addon-depends/rpi-tools-depends/colorzero) package.
  The colorzero package needs the lost "${DISTRO}" = "Lakka" part.
- gpiozero:
  The gpicase_safeshutdown package also depends the gpiozero(packages/addons/addon-depends/rpi-tools-depends/gpiozero) package.
  The gpiozero package also needs the lost "${DISTRO}" = "Lakka" part.
- lg-gpio:
  The gpicase_safeshutdown package also depends the lg-gpio(packages/addons/addon-depends/rpi-tools-depends/lg-gpio) package.
  The lg-gpio package also needs the lost "${DISTRO}" = "Lakka" part.

### Build
- RPi4.aarch64 clean/fresh build is passed
- Generic.x86_64 clean/fresh build is passed
- RPi4-GPiCase2 clean/fresh build is passed
- RPiZero2-GPiCase2W clean/fresh build is passed

### Test
- RPi4.aarch64
  linux is started
  retroarch shows GUI with gl and vulkan
  ppsspp - PERSONA 3 portable is working
- Generic.x86_64
  linux is started
  retroarch shows GUI with gl and vulkan
  ppsspp - PERSONA 3 portable is working
- RPi4-GPiCase2
  linux is started
  retroarch shows GUI with gl and vulkan
  gpicase_safeshutdown(lg-gpio) is working
- RPiZero2-GPiCase2W
  linux is started
  retroarch shows GUI with gl and vulkan
  gpicase_safeshutdown(colorzero/gpiozero) is working


Thanks
ASAI, Shigeaki