### PR TITLE
Lakka-v6.1: linux: move *) part to after L4T) and ayn-odin) part and fix indent for raspberrypi) part

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -22,18 +22,12 @@ case "${LINUX}" in
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
 	PKG_PATCH_DIRS="default rtlwifi/6.18"
     ;;
- raspberrypi)
+  raspberrypi)
     PKG_VERSION="21b410140c47ffab5668399f6f143c7d7b935c8b" # 6.12.61
     PKG_SHA256="7c31df8061aae748a6e72417bfe743a54198fb5bdc96e229ecc605dc621d32ef"
     PKG_URL="https://github.com/raspberrypi/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     PKG_PATCH_DIRS="raspberrypi rtlwifi/6.13 rtlwifi/6.14 rtlwifi/6.15 rtlwifi/6.18"
-    ;;
-  *)
-    PKG_VERSION="6.16.12"
-    PKG_SHA256="7ca4debc5ca912ebb8a76944a5c118afd5d09e31ef43c494adb14273da29a26e"
-    PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
-    PKG_PATCH_DIRS="default rtlwifi/6.18"
     ;;
   L4T)
     if [ -z "${L4T_KERNEL_VERSION}" ]; then
@@ -59,6 +53,12 @@ case "${LINUX}" in
     PKG_URL="https://gitlab.com/sdm845-mainline/linux.git"
     PKG_PATCH_DIRS="ayn-odin"
     PKG_GIT_CLONE_BRANCH="sdm845-5.19.16"
+    ;;
+  *)
+    PKG_VERSION="6.16.12"
+    PKG_SHA256="7ca4debc5ca912ebb8a76944a5c118afd5d09e31ef43c494adb14273da29a26e"
+    PKG_URL="https://www.kernel.org/pub/linux/kernel/v${PKG_VERSION/.*/}.x/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+    PKG_PATCH_DIRS="default rtlwifi/6.18"
     ;;
 esac
 


### PR DESCRIPTION
### This Pull request has 2 fix.
a) odin.aarch64 and Switch.aarch64 linux:host build is failed
b) fix indent for raspberrypi) path in case "${LINUX}"

### a) odin.aarch64 and Switch.aarch64 linux:host build is failed
Both build fail are happened in patch hank.
- odin.aarch64 linux:host build is failed.
  odin.aarch64 wants to use linux version as 9aa25bf492928bc7a4542e87d28919c9ac36d27c
  https://github.com/libretro/Lakka-LibreELEC/blob/bc22969f45bf20f079ab38e9504b4697a2769b6b/projects/Ayn/devices/Odin/options#L91
  https://github.com/libretro/Lakka-LibreELEC/blob/bc22969f45bf20f079ab38e9504b4697a2769b6b/packages/linux/package.mk#L56
  But linux version 6.16.12 is used for building.
  https://github.com/libretro/Lakka-LibreELEC/blob/bc22969f45bf20f079ab38e9504b4697a2769b6b/packages/linux/package.mk#L33
  So odin linux patch was hanked.
- Switch.aarch64
  Switch.aarch64 wants to use linux version as 2023-06-10
  https://github.com/libretro/Lakka-LibreELEC/blob/bc22969f45bf20f079ab38e9504b4697a2769b6b/projects/L4T/options#L102
  https://github.com/libretro/Lakka-LibreELEC/blob/bc22969f45bf20f079ab38e9504b4697a2769b6b/packages/linux/package.mk#L38
  But linux version 6.16.12 is used for building.
  https://github.com/libretro/Lakka-LibreELEC/blob/bc22969f45bf20f079ab38e9504b4697a2769b6b/packages/linux/package.mk#L33
  So Switch linux patch was hanked.

This is caused by *) part position of case "${LINUX}".
If *) part located before than L4T) and ayn-odin), L4T) and ayn-odin) are ignored.
This is reason for both build fail.

### b) fix indent for raspberrypi) path in case "${LINUX}"
please refer both source codes difference :)
it is added only 1 white space.


### build
- odin.aarch64 build is all passed with this modification.
- switch.aarch64 linux:host build is passed with this modification.
  Another dolphin:taget build is failed.
  I will create new issue for this problem.
- RPi4.aarch64 build is all passed with this modification.

Thanks,
ASAI, Shigeaki