### PR TITLE
gdk-pixbuf: Add a GDK PIXBUF_VERSION_2_44 macro to fix -Wundef warnings for devel branch (backport of #2107)

### DIFF
--- a/packages/graphics/gdk-pixbuf/patches/Add_a_GDK_PIXBUF_VERSION_2_44_macro_to_fix_-Wundef_warnings.patch
+++ b/packages/graphics/gdk-pixbuf/patches/Add_a_GDK_PIXBUF_VERSION_2_44_macro_to_fix_-Wundef_warnings.patch
@@ -1,0 +1,27 @@
+commit 101805761797283449bc3d02df1efc43c8be3b8a
+Author: correctmost <136447-correctmost@users.noreply.gitlab.gnome.org>
+Date:   Mon Jun 16 01:21:00 2025 -0400
+
+    Add a GDK_PIXBUF_VERSION_2_44 macro to fix -Wundef warnings
+
+diff --git a/gdk-pixbuf/gdk-pixbuf-macros.h b/gdk-pixbuf/gdk-pixbuf-macros.h
+index 335285f5c..f831a308a 100644
+--- a/gdk-pixbuf/gdk-pixbuf-macros.h
++++ b/gdk-pixbuf/gdk-pixbuf-macros.h
+@@ -258,6 +258,16 @@
+  */
+ #define GDK_PIXBUF_VERSION_2_40 (G_ENCODE_VERSION (2, 40))
+ 
++/**
++ * GDK_PIXBUF_VERSION_2_44:
++ *
++ * A macro that evaluates to the 2.44 version of GdkPixbuf,
++ * in a format that can be used by the C pre-processor.
++ *
++ * Since: 2.44
++ */
++#define GDK_PIXBUF_VERSION_2_44 (G_ENCODE_VERSION (2, 44))
++
+ #ifndef __GTK_DOC_IGNORE__
+ #if (GDK_PIXBUF_MINOR % 2)
+ #define GDK_PIXBUF_VERSION_CUR_STABLE (G_ENCODE_VERSION (GDK_PIXBUF_MAJOR, GDK_PIXBUF_MINOR + 1))


### PR DESCRIPTION
## This pull requests does backport of pull requests #2107 into Lakka devel branch

### [Confirmation]
I tried the following device swaybg build. (build check only)
Build is passed on devel branch (base:efc9824ba44198c91cf810403b5d7c1adde4f22a).
- wayland.x86_64
  DISTRO=Lakka PROJECT=Generic DEVICE=wayland ARCH=x86_64 scripts/build swaybg

Thanks
ASAI, Shigeaki