### PR TITLE
virtualxt: change repository address for devel branch (backport of #2136)

### DIFF
--- a/packages/lakka/libretro_cores/virtualxt/package.mk
+++ b/packages/lakka/libretro_cores/virtualxt/package.mk
@@ -5,7 +5,7 @@ PKG_LICENSE="zlib"
 # https://github.com/virtualxt/virtualxt/issues/97
 # please enable (remove "!arm" in PKG_ARCH ) when build failure is fixed.
 PKG_ARCH="any !arm"
-PKG_SITE="https://github.com/virtualxt/virtualxt"
+PKG_SITE="https://codeberg.org/virtualxt/virtualxt"
 PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Lightweight Turbo PC/XT emulator."


### PR DESCRIPTION
## This pull requests does backport of pull requests #2136 into Lakka devel branch

### [Confirmation]
I tried the following device virtualxt build. (build check only)
Build is passed on devel branch (base:efc9824ba44198c91cf810403b5d7c1adde4f22a).
- Generic.x86_64
  DISTRO=Lakka PROJECT=Generic DEVICE=Generic ARCH=x86_64 scripts/build virtualxt

Thanks
ASAI, Shigeaki