### PR TITLE
retroarch: bump retroarch and related packages on devel branch

### DIFF
--- a/packages/lakka/retroarch_base/core_info/package.mk
+++ b/packages/lakka/retroarch_base/core_info/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="core_info"
-PKG_VERSION="1141733f88c4693a35e1f94cf0e091142e845666"
+PKG_VERSION="938f24313afe37f62ac122bb77980decdf1b1b4f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-core-info"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/core_info/package.mk
+++ b/packages/lakka/retroarch_base/core_info/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="core_info"
-PKG_VERSION="938f24313afe37f62ac122bb77980decdf1b1b4f"
+PKG_VERSION="20e7d555f911f5aa6712d5937f7b9b834015d88d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-core-info"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/core_info/package.mk
+++ b/packages/lakka/retroarch_base/core_info/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="core_info"
-PKG_VERSION="52fe3598d8cacce6c2d688c26e9ee00b773c971e"
+PKG_VERSION="1141733f88c4693a35e1f94cf0e091142e845666"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-core-info"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/glsl_shaders/package.mk
+++ b/packages/lakka/retroarch_base/glsl_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="glsl_shaders"
-PKG_VERSION="909415db527c98a59464c52d531a9c1b71122dfd"
+PKG_VERSION="468f67b6f6788e2719d1dd28dfb2c9b7c3db3cc7"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/glsl-shaders"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/glsl_shaders/package.mk
+++ b/packages/lakka/retroarch_base/glsl_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="glsl_shaders"
-PKG_VERSION="6d5c3fe803d2ebe2b44ef42d2b421f5b6df3e045"
+PKG_VERSION="909415db527c98a59464c52d531a9c1b71122dfd"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/glsl-shaders"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/libretro_database/package.mk
+++ b/packages/lakka/retroarch_base/libretro_database/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="libretro_database"
-PKG_VERSION="97ca969d058f5401ee06fb8e36a9b6ad7ef82bf2"
+PKG_VERSION="fbcc8c1c24d8b20b6aaca95b4da6a2f39ad85f05"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-database"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/libretro_database/package.mk
+++ b/packages/lakka/retroarch_base/libretro_database/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="libretro_database"
-PKG_VERSION="fbcc8c1c24d8b20b6aaca95b4da6a2f39ad85f05"
+PKG_VERSION="06bf35279fc476f1b1d48acc169a273a3428a664"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-database"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/libretro_database/package.mk
+++ b/packages/lakka/retroarch_base/libretro_database/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="libretro_database"
-PKG_VERSION="1cefb4efff91a76bdc92afd79e46ae3cd60627ad"
+PKG_VERSION="97ca969d058f5401ee06fb8e36a9b6ad7ef82bf2"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-database"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch"
-PKG_VERSION="a15217dbaf2c0794f62c64511839d4f72d71cfd9"
+PKG_VERSION="69a4f0ea1e8aaf442ae4858f2e7f2b31a1776576"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch"
-PKG_VERSION="baee906ef35b99283f9a1a060a2ce5ac86159b63"
+PKG_VERSION="a15217dbaf2c0794f62c64511839d4f72d71cfd9"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch"
-PKG_VERSION="ab3b175848fa6cd8b2340809631e30bc0fe1d136"
+PKG_VERSION="baee906ef35b99283f9a1a060a2ce5ac86159b63"
 PKG_LICENSE="GPLv3"
 PKG_SITE="https://github.com/libretro/RetroArch"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_assets/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_assets/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_assets"
-PKG_VERSION="2d24ef2972a709f870cc3f73853158fa2376f37d"
+PKG_VERSION="76cc6cf03507429c5a136cb50d83a14e05430fcd"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/retroarch-assets"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_assets/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_assets/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_assets"
-PKG_VERSION="76cc6cf03507429c5a136cb50d83a14e05430fcd"
+PKG_VERSION="a7b711dfd74871e9985ba3b2fe2c15048a928aaf"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/retroarch-assets"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_assets/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_assets/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_assets"
-PKG_VERSION="c4f1ec8bddba15e1b1a00a7e56c50cf0eca8b5c9"
+PKG_VERSION="2d24ef2972a709f870cc3f73853158fa2376f37d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/retroarch-assets"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_joypad_autoconfig"
-PKG_VERSION="c730e2b27df33268ab4d195bf6eb15c92abc59c0"
+PKG_VERSION="38cf938bba0adbde375972053068f10d955a9d14"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/retroarch-joypad-autoconfig"
 PKG_URL="${PKG_SITE}.git"
@@ -10,8 +10,8 @@ makeinstall_target() {
   make -C ${PKG_BUILD} install INSTALLDIR="${INSTALL}/etc/retroarch-joypad-autoconfig" DOC_DIR="${INSTALL}/etc/doc/."
 
   #Remove non tested joycon configs
-  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Co., Ltd. Pro Controller (old).cfg"
-  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Co., Ltd. Pro Controller.cfg"
+  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Switch Pro Controller (non-HID) (default-off).cfg"
+  rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Switch Pro Controller.cfg"
   rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo-Switch-Online_NES-Controller_Left.cfg"
   rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo-Switch-Online_NES-Controller_Right.cfg"
   rm -v "${INSTALL}/etc/retroarch-joypad-autoconfig/udev/Nintendo Switch Left Joy-Con.cfg"

--- a/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_joypad_autoconfig"
-PKG_VERSION="e7881a84d9a5fc1569f6d50f675dce7fdd7a0480"
+PKG_VERSION="c730e2b27df33268ab4d195bf6eb15c92abc59c0"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/retroarch-joypad-autoconfig"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_overlays/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_overlays/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_overlays"
-PKG_VERSION="e2568e3ff9abaeddd087e093ac0b3acd4b649f7d"
+PKG_VERSION="6da725ba4533b609714b094b70f1133ae48fae11"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/common-overlays"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_overlays/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_overlays/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_overlays"
-PKG_VERSION="de100b2ae7789a2428ab318df3e51c3eea353b44"
+PKG_VERSION="e2568e3ff9abaeddd087e093ac0b3acd4b649f7d"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/common-overlays"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_overlays/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_overlays/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_overlays"
-PKG_VERSION="d591850bfe60ef31cfac582b302f320949dd7807"
+PKG_VERSION="de100b2ae7789a2428ab318df3e51c3eea353b44"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/common-overlays"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/slang_shaders/package.mk
+++ b/packages/lakka/retroarch_base/slang_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="slang_shaders"
-PKG_VERSION="3d57e977b892eee945f3347be506c37ddc1b11b5"
+PKG_VERSION="b80bba0c71e98250717acc5f4e6b9bb9f75bd091"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/slang-shaders"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/slang_shaders/package.mk
+++ b/packages/lakka/retroarch_base/slang_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="slang_shaders"
-PKG_VERSION="1ed1b59acec51a3156ec70522fb98be3c74f95f4"
+PKG_VERSION="3d57e977b892eee945f3347be506c37ddc1b11b5"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/slang-shaders"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/slang_shaders/package.mk
+++ b/packages/lakka/retroarch_base/slang_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="slang_shaders"
-PKG_VERSION="e2236e6a637a9396394ff238ea151bc0dbe4968e"
+PKG_VERSION="1ed1b59acec51a3156ec70522fb98be3c74f95f4"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/slang-shaders"
 PKG_URL="${PKG_SITE}.git"


### PR DESCRIPTION
### Updates retroarch and related packages version.
It becomes same versions with Lakka-v6.1 by this Pull requests.

- core_info: version 20e7d555f911f5aa6712d5937f7b9b834015d88d
- glsl_shaders: version 468f67b6f6788e2719d1dd28dfb2c9b7c3db3cc7
- libretro_database: version 06bf35279fc476f1b1d48acc169a273a3428a664
- retroarch: version v1.22.2(69a4f0ea1e8aaf442ae4858f2e7f2b31a1776576)
- retroarch_assets: version a7b711dfd74871e9985ba3b2fe2c15048a928aaf
- retroarch_joypad_autoconfig: version 38cf938bba0adbde375972053068f10d955a9d14
- retroarch_overlays: version 6da725ba4533b609714b094b70f1133ae48fae11
- slang_shaders: version b80bba0c71e98250717acc5f4e6b9bb9f75bd091

Note
retroarch build shows another fail after use this.
```
input/input_driver.c: In function 'input_driver_init_command':
input/input_driver.c:5154:33: error: implicit declaration of function 'command_uds_new'; did you mean 'command_stdin_new'? [-Wimplicit-function-declaration]
 5154 |    if (!(input_st->command[2] = command_uds_new()))
      |                                 ^~~~~~~~~~~~~~~
      |                                 command_stdin_new
input/input_driver.c:5154:31: error: assignment to 'command_t *' {aka 'struct command_handler *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
 5154 |    if (!(input_st->command[2] = command_uds_new()))
      |                               ^

```

Thanks
ASAI, Shigeaki