### PR TITLE
libretro_cores: dice: Add DICE for machines without a CPU

### DIFF
--- a/packages/lakka/libretro_cores/dice/package.mk
+++ b/packages/lakka/libretro_cores/dice/package.mk
@@ -1,0 +1,13 @@
+PKG_NAME="dice"
+PKG_VERSION="beb422a68dbb7f78d73b1fd6cd0807288a6613c6"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://github.com/mittonk/dice-libretro"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="DICE is a Discrete Integrated Circuit Emulator for games without any type of CPU."
+PKG_TOOLCHAIN="make"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+    cp -v dice_libretro.so ${INSTALL}/usr/lib/libretro/
+}

--- a/packages/lakka/libretro_cores/package.mk
+++ b/packages/lakka/libretro_cores/package.mk
@@ -41,6 +41,7 @@ LIBRETRO_CORES="\
                 daphne \
                 desmume \
                 desmume_2015 \
+                dice \
                 dinothawr \
                 dirksimple \
                 dolphin \


### PR DESCRIPTION
Tested on Raspberry Pi 4.

Core runs well, playlist recognizes items from the DB.

lr-dice is already in devel, but I noticed while working on another branch it wasn't in 6.1.  If that's intentional, great; if it got missed during merges and branching and syncs, this branch will patch that up.