### PR TITLE
libretro_cores: pd777: added

### DIFF
--- a/packages/lakka/libretro_cores/package.mk
+++ b/packages/lakka/libretro_cores/package.mk
@@ -111,6 +111,7 @@ LIBRETRO_CORES="\
                 panda3ds \
                 parallel_n64 \
                 pcsx_rearmed \
+                pd777 \
                 picodrive \
                 play \
                 pocketcdg \

--- a/packages/lakka/libretro_cores/pd777/package.mk
+++ b/packages/lakka/libretro_cores/pd777/package.mk
@@ -1,0 +1,16 @@
+PKG_NAME="pd777"
+PKG_VERSION="56097d6ac5ee5202f3bf73c4d5eac4d443fe0fb7"
+PKG_LICENSE="MIT"
+PKG_SITE="https://github.com/mittonk/PD777"
+PKG_URL="${PKG_SITE}.git"
+PKG_GIT_CLONE_BRANCH="main"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="PD777 is an Epoch Cassette Vision emulator"
+PKG_TOOLCHAIN="make"
+
+PKG_MAKE_OPTS_TARGET="-C ../source/libretro -f Makefile.libretro"
+
+makeinstall_target() {
+  mkdir -p ${INSTALL}/usr/lib/libretro
+    cp -v ../source/libretro/pd777_libretro.so ${INSTALL}/usr/lib/libretro/
+}

--- a/packages/lakka/retroarch_base/core_info/package.mk
+++ b/packages/lakka/retroarch_base/core_info/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="core_info"
-PKG_VERSION="20e7d555f911f5aa6712d5937f7b9b834015d88d"
+PKG_VERSION="28f18a4d2fd75a88a8dff32ab60ee1c3b9f8a162"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-core-info"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/libretro_database/package.mk
+++ b/packages/lakka/retroarch_base/libretro_database/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="libretro_database"
-PKG_VERSION="06bf35279fc476f1b1d48acc169a273a3428a664"
+PKG_VERSION="203ff2c91cff8a738a066978182e979d66c36395"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-database"
 PKG_URL="${PKG_SITE}.git"


### PR DESCRIPTION
Add PD777 for the Epoch Cassette Vision.

Includes playlist DB.

Lakka branch tested on Raspberry Pi 4, 64 bits.

Core tested on these platforms supported by Lakka:
* Linux x64
* Raspberry Pi 4, 32 and 64
* Raspberry Pi Zero2w 64

Related PRs:
* https://github.com/libretro/retroarch-assets/pull/494 for playlist icons, not blocking. 