### PR TITLE
RPi: Fix 2 packages build fail on linux v6.18 devel branch

### DIFF
--- a/packages/lakka/lakka_tools/mk_arcade_joystick_rpi/patches/add-kernel-timer-redefinition.patch
+++ b/packages/lakka/lakka_tools/mk_arcade_joystick_rpi/patches/add-kernel-timer-redefinition.patch
@@ -1,0 +1,19 @@
+diff --git a/mk_arcade_joystick_rpi.c b/mk_arcade_joystick_rpi.c
+index 344a475..66550f7 100755
+--- a/mk_arcade_joystick_rpi.c
++++ b/mk_arcade_joystick_rpi.c
+@@ -47,6 +47,14 @@ MODULE_LICENSE("GPL");
+ #define HAVE_TIMER_SETUP
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++#define del_timer_sync timer_delete_sync
++#endif
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++#define from_timer timer_container_of
++#endif
++
+ #define MK_MAX_DEVICES		2
+ #define MK_MAX_BUTTONS      13
+ 

--- a/projects/RPi/devices/RPi4-PiBoyDmg/packages/xpi_gamecon/sources/xpi_gamecon.c
+++ b/projects/RPi/devices/RPi4-PiBoyDmg/packages/xpi_gamecon/sources/xpi_gamecon.c
@@ -3,6 +3,7 @@
 #include <linux/of.h>
 #include <linux/module.h>
 #include <linux/slab.h>
+#include <linux/version.h>
 
 #include <asm/io.h>
 
@@ -41,6 +42,14 @@ volatile int stat_val = 0;
 volatile int vol_val = 0;
 
 struct kobject *kobj_ref;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+#define del_timer timer_delete
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+#define from_timer timer_container_of
+#endif
 
 #define GC_LENGTH 12
 


### PR DESCRIPTION
## This Pull fixes the followin 2 packages build failure on Linux v6.18 debel branch
- xpi_gamecon
- mk_arcade_joystick_rpi

### description
Both packages source files use linux timer interface that was renamed on linux version up.
It uses renamed timer interface.

### confirmation
Both packages build are passed on linux v6.18.
[mk_arcade_joystick_rpi_build_failure.log](https://github.com/user-attachments/files/25061893/mk_arcade_joystick_rpi_build_failure.log)
[mk_arcade_joystick_rpi_build_passed.log](https://github.com/user-attachments/files/25061894/mk_arcade_joystick_rpi_build_passed.log)
[xpi_gamecon_build_failure.log](https://github.com/user-attachments/files/25061895/xpi_gamecon_build_failure.log)
[xpi_gamecon_build_passed.log](https://github.com/user-attachments/files/25061896/xpi_gamecon_build_passed.log)

Thanks
ASAI, Shigeaki
