### PR TITLE
addons/sundtek-mediatv: Fix error handling in the driver update script

### DIFF
--- a/packages/addons/driver/sundtek-mediatv/source/bin/sundtek-update-driver.sh
+++ b/packages/addons/driver/sundtek-mediatv/source/bin/sundtek-update-driver.sh
@@ -38,8 +38,7 @@ cd tmp
 logger -t Sundtek "### Starting updating driver ###"
 kodi-send -a "Notification(Sundtek, Starting updating driver, 3000, $SUNDTEK_ADDON_DIR/icon.png)"
 
-wget -O ../version.used http://sundtek.de/media/latest.phtml
-if [ $? -ne 0 ]; then
+if ! wget -O ../version.used http://sundtek.de/media/latest.phtml; then
   logger -t Sundtek "### Can't get latest version ###"
   kodi-send -a "Notification(Sundtek, Cant get latest version, 8000, $SUNDTEK_ADDON_DIR/icon.png)"
   cd ..
@@ -64,8 +63,7 @@ fi
 
 logger -t Sundtek "### Downloading driver archive for $ARCH ###"
 kodi-send -a "Notification(Sundtek, Downloading driver archive for $ARCH, 3000, $SUNDTEK_ADDON_DIR/icon.png)"
-wget -O installer.tar.gz $INSTALLER_URL
-if [ $? -ne 0 ]; then
+if ! wget -O installer.tar.gz $INSTALLER_URL; then
   logger -t Sundtek "### Archive damaged ###"
   kodi-send -a "Notification(Sundtek, Download failed, 8000, $SUNDTEK_ADDON_DIR/icon.png)"
   cd ..
@@ -75,8 +73,7 @@ fi
 
 logger -t Sundtek "### Extracting archive ###"
 kodi-send -a "Notification(Sundtek, Extracting archive, 3000, $SUNDTEK_ADDON_DIR/icon.png)"
-tar -xzf installer.tar.gz
-if [ $? -ne 0 ]; then
+if ! tar -xzf installer.tar.gz; then
   logger -t Sundtek "### Archive damaged ###"
   kodi-send -a "Notification(Sundtek, Archive damaged, 8000, $SUNDTEK_ADDON_DIR/icon.png)"
   cd ..


### PR DESCRIPTION
`packages/addons/driver/sundtek-mediatv/source/bin/sundtek-update-driver.sh` enables `set -e` which causes the script to exit on any non-0 exit status. At the same time it tries to check `$?` which can only be 0 since any non-0 status prevents the script from reaching that statement. This PR fixes that issue and enables the original error handling functionality to work.