### PR TITLE
azahar: update libretro core to fix build error when DEBUG=yes

### DIFF
--- a/packages/lakka/libretro_cores/azahar/package.mk
+++ b/packages/lakka/libretro_cores/azahar/package.mk
@@ -29,5 +29,9 @@ fi
 
 makeinstall_target() {
   mkdir -p ${INSTALL}/usr/lib/libretro
-    cp -v bin/Release/azahar_libretro.so ${INSTALL}/usr/lib/libretro/
+    if [ "${DEBUG}" = "yes" ]; then
+      cp -v bin/Debug/azahar_libretro.so ${INSTALL}/usr/lib/libretro/
+    else
+      cp -v bin/Release/azahar_libretro.so ${INSTALL}/usr/lib/libretro/
+    fi
 }


### PR DESCRIPTION
the azahar core build shows error when DEBUG=yes is set.

```
[1459/1459] Linking CXX shared library bin/Debug/azahar_libretro.so
cp: cannot stat 'bin/Release/azahar_libretro.so': No such file or directory
FAILURE: scripts/build azahar:target during makeinstall_target (package.mk)
*********** FAILED COMMAND ***********
cp -v bin/Release/azahar_libretro.so ${INSTALL}/usr/lib/libretro/
**************************************
*********** FAILED COMMAND ***********
${SCRIPTS}/build "${1}" "${PARENT_PKG}"
**************************************
FAILURE: scripts/install azahar:target has failed!
```

the linked binary azahar_libretro.so is located to bin/Debug/ directory when DEBUG=yes.

This Pull requests fixes this.

Thanks
ASAI, Shigeaki