### PR TITLE
udevil: update to githash 666e443 and move to maintained github - https://github.com/Arnie97/udevil-ng/

### DIFF
--- a/packages/sysutils/udevil/package.mk
+++ b/packages/sysutils/udevil/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="udevil"
-PKG_VERSION="f2b715d1d821e4b69b2fb0864a5a178dd67877f0"
-PKG_SHA256="3351d56c553c518cb2ce7b24892a4b62d630ba4f6ebee2c3994c4be9828f0629"
+PKG_VERSION="666e443c36182751c81f3be3115d0ed9f8f2af58"
+PKG_SHA256="55980a67c0fdc25e3dce7a2d70b9528b8ae3de5cb64a35696f22907175a7272f"
 PKG_LICENSE="GPL"
-PKG_SITE="https://github.com/alpharde/udevil"
-PKG_URL="https://github.com/alpharde/udevil/archive/${PKG_VERSION}.tar.gz"
+PKG_SITE="https://github.com/arnie97/udevil-ng"
+PKG_URL="https://github.com/arnie97/udevil-ng/archive/${PKG_VERSION}.tar.gz"
 PKG_DEPENDS_TARGET="toolchain systemd glib"
 PKG_LONGDESC="Mounts and unmounts removable devices and networks without a password."
 


### PR DESCRIPTION
This pull requests fix the udevil package build fail.
https://github.com/libretro/Lakka-LibreELEC/issues/2197

It uses upstream [LibreELEC mastar branch commit](https://github.com/LibreELEC/LibreELEC.tv/commit/c68da8639af3741775f8e123c45af0583d72db0b)

The following 4 types(ARCH=i386/x86_64/arm/) build are passed.
- DISTRO=Lakka PROJECT=Generic DEVICE=Generic ARCH=i386 make image
- DISTRO=Lakka PROJECT=Generic DEVICE=Generic ARCH=x86_64 make image
- DISTRO=Lakka PROJECT=Samsung DEVICE=Exynos ARCH=arm make image
- DISTRO=Lakka PROJECT=RPi DEVICE=RPi5 ARCH=aarch64 make image


Thanks
ASAI, Shigeaki