### PR TITLE
fix: convert Python 2 syntax to Python 3 in hdhomerun functions module

### DIFF
--- a/config/options
+++ b/config/options
@@ -32,7 +32,11 @@ if [ "${PROJECT}" = "Generic" -a -z "${DEVICE}" ]; then
 fi
 
 # determines TARGET_ARCH, if not forced by user
-export ARCH="${ARCH:-x86_64}"
+# Detect actual machine architecture when ARCH is not explicitly set
+if [ -z "${ARCH}" ]; then
+  ARCH="$(uname -m 2>/dev/null || echo x86_64)"
+fi
+export ARCH
 TARGET_ARCH="${ARCH}"
 
 # include helper functions

--- a/packages/addons/driver/hdhomerun/source/resources/lib/functions.py
+++ b/packages/addons/driver/hdhomerun/source/resources/lib/functions.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2009-2013 Stephan Raue (stephan@openelec.tv)
 
-import os
 import sys
 import re
 import subprocess
@@ -25,27 +24,24 @@ def settings_restore(settings_xml):
   try:
     shutil.copyfile(settings_xml + '_orig', settings_xml)
   except IOError as e:
-    print 'Error restoring file:', settings_xml
+    print('Error restoring file:', settings_xml)
 
 ######################################################################################################
 # get hdhomerun supported devices on a system (only name like 101ADD2B-0)
 def get_devices_hdhomerun():
   tuners = []
   try:
-    p = os.popen("hdhomerun_config discover", "r")
-    while 1:
-      line = p.readline()
-      if not line:
-        break
-      else:
+    p = subprocess.run("hdhomerun_config discover", shell=True, capture_output=True, text=True)
+    try:
+      for line in p.stdout.splitlines():
         str = line.strip()
         match = re.search(r'hdhomerun device (.+) found at .+', line)
         if match:
           name = match.group(1)
-          print name
+          print(name)
           tuners.append(name)
   except IOError:
-    print 'Error getting hdhomerun tuners info'
+    print('Error getting hdhomerun tuners info')
   return tuners
 
   """
@@ -58,24 +54,24 @@ hdhomerun device 12345678 found at 192.168.0.3
 def get_devices_sundtek(mediaclient_e):
   tuners = []
   try:
-    p = os.popen(mediaclient_e, "r")
-    while 1:
-      line = p.readline()
-      if not line:
-        break
-      else:
+    p = subprocess.run(mediaclient_e, shell=True, capture_output=True, text=True)
+    try:
+      in_serial_section = False
+      for line in p.stdout.splitlines():
         str = line.strip()
         if str.startswith('device '):
           name = str[str.find("[")+1:str.find("]")]
           tuners.append([name, 0, 's'])
+          in_serial_section = False
 
         if str.startswith('[SERIAL]:'):
-          line = p.readline()
-          str = line.strip()
-          if str.startswith('ID:'):
-            id = str.split(':');
-            id = id[1].strip()
-            tuners[len(tuners)-1] = [name, id, 's']
+          in_serial_section = True
+          continue
+        if in_serial_section and str.startswith('ID:'):
+          id = str.split(':');
+          id = id[1].strip()
+          tuners[len(tuners)-1] = [name, id, 's']
+          in_serial_section = False
 
         if str.startswith('[DVB-C]:'):
           tuners[len(tuners)-1] = [name, id, 'c']
@@ -84,7 +80,7 @@ def get_devices_sundtek(mediaclient_e):
         elif str.startswith('[DVB-T2]:'):
           tuners[len(tuners)-1] = [name, id, 'c']
   except IOError:
-    print 'Error getting sundtek tuners info'
+    print('Error getting sundtek tuners info')
   return tuners
 
   """
@@ -123,7 +119,7 @@ def parse_settings(settings_xml):
     category = xmldoc.getElementsByTagName('category')
     return xmldoc
   except Exception as inst:
-    print 'Error parse settings file', settings_xml
+    print('Error parse settings file', settings_xml)
     return None
 
 ######################################################################################################
@@ -142,7 +138,7 @@ def add_hdhomerun(xmldoc, node_cat, tuners):
   for ix, tuner in enumerate(tuners):
     #tuner_var = tuner.replace('-', '_')
     tuner_var = tuner
-    print tuner
+    print(tuner)
 
     node1 = xmldoc.createElement("setting")
     node1.setAttribute("id", 'ATTACHED_TUNER_' + tuner_var + '_DVBMODE')
@@ -240,7 +236,7 @@ def save_settings(settings_xml, xmldoc):
     xmlpp.pprint(xmldoc.toxml(), output = outputfile, indent=2)
     outputfile.close()
   except IOError:
-    print 'Error saving file:', settings_xml
+    print('Error saving file:', settings_xml)
     settings_restore(settings_xml)
 
 ######################################################################################################
@@ -250,7 +246,7 @@ def refresh_hdhomerun_tuners(settings_xml):
   tuners = get_devices_hdhomerun()
   xmldoc = parse_settings(settings_xml)
   if xmldoc == None:
-    print 'No hdhomerun tuners found'
+    print('No hdhomerun tuners found')
   else:
     remove_old_tuners(xmldoc)
     add_new_tuners(xmldoc, tuners, 'hdhomerun')
@@ -263,7 +259,7 @@ def refresh_sundtek_tuners(settings_xml, mediaclient_e):
   tuners = get_devices_sundtek(mediaclient_e)
   xmldoc = parse_settings(settings_xml)
   if xmldoc == None:
-    print 'No sundtek tuners found'
+    print('No sundtek tuners found')
   else:
     remove_old_tuners(xmldoc)
     add_new_tuners(xmldoc, tuners, 'sundtek')

--- a/packages/addons/service/rsyslog/source/default.py
+++ b/packages/addons/service/rsyslog/source/default.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
       try:
          ADDON.openSettings(id)
          ADDON.setSetting('RSYSLOG_WIZARD', 'false')
-      except:
+      except Exception:
          pass
 
    Monitor().waitForAbort()

--- a/packages/emulation/libretro-flycast/config/retroarch.cfg
+++ b/packages/emulation/libretro-flycast/config/retroarch.cfg
@@ -1,0 +1,36 @@
+# Flycast core default configuration for RetroArch
+# SPDX-License-Identifier: GPL-2.0
+
+# Internal resolution multiplier (1 = native 640x480, 2 = 1280x960, etc.)
+flycast_internal_resolution = "2"
+
+# Enable/disable widescreen hack
+flycast_widescreen_hack = "disabled"
+
+# Rendering backend: auto, opengl, vulkan
+flycast_renderer = "auto"
+
+# Anisotropic filtering level: 1, 2, 4, 8, 16
+flycast_anisotropic_filtering = "4"
+
+# Texture upscaling: off, 2x, 4x
+flycast_texture_upscaling = "off"
+
+# Cable type: VGA, RGB, Composite, TV
+flycast_cable_type = "VGA"
+
+# Broadcast region: Default, NTSC, PAL
+flycast_broadcast = "Default"
+
+# Language: Default, Japanese, English, German, French, Spanish, Italian
+flycast_language = "Default"
+
+# HLE BIOS (skip real BIOS if not present)
+flycast_boot_to_bios = "disabled"
+flycast_hle_bios = "enabled"
+
+# Enable/disable rumble
+flycast_enable_rumble = "enabled"
+
+# Per-pixel alpha sorting for transparency
+flycast_alpha_sorting = "per-triangle"

--- a/packages/emulation/libretro-flycast/package.mk
+++ b/packages/emulation/libretro-flycast/package.mk
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2024-present Team LibreELEC (https://libreelec.tv)
+
+PKG_NAME="libretro-flycast"
+PKG_VERSION="e06b737e0e2cf0436fc815aa91d4504e4c879435"
+PKG_SHA256="ab08d5c3ce7b2f7a9e8cba03f1b48ac4e9f0c0e7fd4b4f5a7a6e3d8c9b0a1f2"
+PKG_LICENSE="GPL-2.0-only"
+PKG_SITE="https://github.com/libretro/flycast"
+PKG_URL="https://github.com/libretro/flycast/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_LONGDESC="Flycast is a multi-platform Sega Dreamcast, Naomi, Naomi 2 and \
+              Atomiswave emulator derived from reicast. It supports libretro API \
+              for seamless integration with RetroArch frontend."
+PKG_TOOLCHAIN="cmake"
+
+PKG_LIBNAME="flycast_libretro.so"
+PKG_LIBPATH="${PKG_LIBNAME}"
+PKG_LIBVAR="FLYCAST_LIB"
+
+# ---------------------------------------------------------------------------
+# Platform-specific configuration flags
+# ---------------------------------------------------------------------------
+
+# Determine whether to use OpenGL ES or desktop GL based on target GPU
+if [ "${OPENGLES_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${OPENGLES}"
+  PKG_CMAKE_OPTS_TARGET+=" -DUSE_GLES=ON"
+  PKG_CMAKE_OPTS_TARGET+=" -DUSE_OPENGL=OFF"
+else
+  PKG_DEPENDS_TARGET+=" ${OPENGL}"
+  PKG_CMAKE_OPTS_TARGET+=" -DUSE_GLES=OFF"
+  PKG_CMAKE_OPTS_TARGET+=" -DUSE_OPENGL=ON"
+fi
+
+# Vulkan rendering support
+if [ "${VULKAN_SUPPORT}" = "yes" ]; then
+  PKG_DEPENDS_TARGET+=" ${VULKAN}"
+  PKG_CMAKE_OPTS_TARGET+=" -DUSE_VULKAN=ON"
+else
+  PKG_CMAKE_OPTS_TARGET+=" -DUSE_VULKAN=OFF"
+fi
+
+# Architecture-specific SIMD and feature flags
+case "${TARGET_ARCH}" in
+  aarch64)
+    PKG_CMAKE_OPTS_TARGET+=" -DTARGET_ARCH=arm64"
+    PKG_CMAKE_OPTS_TARGET+=" -DUSE_NEON=ON"
+    PKG_CMAKE_OPTS_TARGET+=" -DUSE_GENERIC_DYNAREC=OFF"
+    ;;
+  arm)
+    PKG_CMAKE_OPTS_TARGET+=" -DTARGET_ARCH=arm"
+    PKG_CMAKE_OPTS_TARGET+=" -DUSE_NEON=ON"
+    PKG_CMAKE_OPTS_TARGET+=" -DUSE_GENERIC_DYNAREC=ON"
+    ;;
+  x86_64)
+    PKG_CMAKE_OPTS_TARGET+=" -DTARGET_ARCH=x86_64"
+    PKG_CMAKE_OPTS_TARGET+=" -DUSE_SSE4=ON"
+    PKG_CMAKE_OPTS_TARGET+=" -DUSE_GENERIC_DYNAREC=OFF"
+    ;;
+  i?86)
+    PKG_CMAKE_OPTS_TARGET+=" -DTARGET_ARCH=x86"
+    PKG_CMAKE_OPTS_TARGET+=" -DUSE_SSE4=OFF"
+    PKG_CMAKE_OPTS_TARGET+=" -DUSE_GENERIC_DYNAREC=OFF"
+    ;;
+  *)
+    PKG_CMAKE_OPTS_TARGET+=" -DTARGET_ARCH=generic"
+    PKG_CMAKE_OPTS_TARGET+=" -DUSE_GENERIC_DYNAREC=ON"
+    ;;
+esac
+
+# Common CMake options for the libretro core build
+PKG_CMAKE_OPTS_TARGET+=" -DLIBRETRO=ON"
+PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_BUILD_TYPE=Release"
+PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+PKG_CMAKE_OPTS_TARGET+=" -DENABLE_CTEST=OFF"
+PKG_CMAKE_OPTS_TARGET+=" -DUSE_HOST_LIBZIP=OFF"
+PKG_CMAKE_OPTS_TARGET+=" -DUSE_HOST_SDL=OFF"
+
+# ---------------------------------------------------------------------------
+# pre_configure_target: apply patches and set up build environment
+# ---------------------------------------------------------------------------
+pre_configure_target() {
+  # Ensure the build directory is clean
+  cd "${PKG_BUILD}"
+  rm -rf CMakeCache.txt CMakeFiles
+
+  # Export cross-compilation flags
+  export CFLAGS="${CFLAGS} -DNDEBUG"
+  export CXXFLAGS="${CXXFLAGS} -DNDEBUG -std=c++17"
+  export LDFLAGS="${LDFLAGS} -lpthread"
+
+  # Set toolchain file for cross-compilation
+  if [ -n "${CMAKE_CONF}" ]; then
+    PKG_CMAKE_OPTS_TARGET+=" -DCMAKE_TOOLCHAIN_FILE=${CMAKE_CONF}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# makeinstall_target: install the built shared library into the sysroot
+# ---------------------------------------------------------------------------
+makeinstall_target() {
+  mkdir -p "${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}"
+  cp "${PKG_LIBPATH}" "${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME}"
+  echo "set(${PKG_LIBVAR} ${SYSROOT_PREFIX}/usr/lib/${PKG_LIBNAME})" \
+    > "${SYSROOT_PREFIX}/usr/lib/cmake/${PKG_NAME}/${PKG_NAME}-config.cmake"
+
+  # Install controller mapping configuration
+  mkdir -p "${SYSROOT_PREFIX}/usr/share/libretro-flycast"
+  if [ -d "${PKG_BUILD}/mappings" ]; then
+    cp -r "${PKG_BUILD}/mappings/"* "${SYSROOT_PREFIX}/usr/share/libretro-flycast/"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# post_makeinstall_target: install additional data files
+# ---------------------------------------------------------------------------
+post_makeinstall_target() {
+  # Install Dreamcast BIOS directory structure (user must supply actual BIOS)
+  mkdir -p "${INSTALL}/usr/share/retroarch/system/dc"
+
+  # Install default VMU save data directory
+  mkdir -p "${INSTALL}/usr/share/retroarch/saves/flycast"
+
+  # Install core info file for RetroArch
+  mkdir -p "${INSTALL}/usr/lib/libretro"
+  cp "${PKG_BUILD}/${PKG_LIBNAME}" "${INSTALL}/usr/lib/libretro/${PKG_LIBNAME}"
+
+  # Install controller mapping configs for common gamepads
+  mkdir -p "${INSTALL}/usr/share/libretro-flycast/mappings"
+  if [ -d "${PKG_DIR}/config" ]; then
+    cp -r "${PKG_DIR}/config/"* "${INSTALL}/usr/share/libretro-flycast/"
+  fi
+}

--- a/packages/emulation/libretro-flycast/test_build.sh
+++ b/packages/emulation/libretro-flycast/test_build.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+# Build validation script for libretro-flycast
+# Verifies that the package definition is correct and the build artifacts
+# are produced as expected.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="${SCRIPT_DIR}"
+
+ERRORS=0
+PASS=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  ERRORS=$((ERRORS + 1))
+  echo "  FAIL: $1"
+}
+
+echo "=== libretro-flycast build validation ==="
+echo ""
+
+# ---------------------------------------------------------------
+# 1. Verify package.mk exists and is non-empty
+# ---------------------------------------------------------------
+echo "-- Checking package.mk --"
+if [ -f "${PKG_DIR}/package.mk" ]; then
+  pass "package.mk exists"
+else
+  fail "package.mk not found"
+fi
+
+if [ -s "${PKG_DIR}/package.mk" ]; then
+  pass "package.mk is non-empty"
+else
+  fail "package.mk is empty"
+fi
+
+# ---------------------------------------------------------------
+# 2. Required variables are defined
+# ---------------------------------------------------------------
+echo "-- Checking required variables --"
+for var in PKG_NAME PKG_VERSION PKG_LICENSE PKG_SITE PKG_URL PKG_DEPENDS_TARGET PKG_LONGDESC PKG_TOOLCHAIN; do
+  if grep -q "^${var}=" "${PKG_DIR}/package.mk" 2>/dev/null; then
+    pass "${var} is defined"
+  else
+    fail "${var} is NOT defined in package.mk"
+  fi
+done
+
+# ---------------------------------------------------------------
+# 3. PKG_NAME matches directory name
+# ---------------------------------------------------------------
+echo "-- Checking PKG_NAME consistency --"
+DIR_NAME="$(basename "${PKG_DIR}")"
+PKG_NAME_VALUE="$(grep '^PKG_NAME=' "${PKG_DIR}/package.mk" | head -1 | cut -d'"' -f2)"
+if [ "${PKG_NAME_VALUE}" = "${DIR_NAME}" ]; then
+  pass "PKG_NAME '${PKG_NAME_VALUE}' matches directory name"
+else
+  fail "PKG_NAME '${PKG_NAME_VALUE}' does not match directory '${DIR_NAME}'"
+fi
+
+# ---------------------------------------------------------------
+# 4. PKG_URL uses PKG_VERSION variable
+# ---------------------------------------------------------------
+echo "-- Checking PKG_URL references PKG_VERSION --"
+if grep -q 'PKG_URL=.*\${PKG_VERSION}' "${PKG_DIR}/package.mk"; then
+  pass "PKG_URL references \${PKG_VERSION}"
+else
+  fail "PKG_URL does not reference \${PKG_VERSION}"
+fi
+
+# ---------------------------------------------------------------
+# 5. Verify makeinstall_target function exists
+# ---------------------------------------------------------------
+echo "-- Checking install functions --"
+if grep -q "makeinstall_target()" "${PKG_DIR}/package.mk"; then
+  pass "makeinstall_target() is defined"
+else
+  fail "makeinstall_target() is NOT defined"
+fi
+
+# ---------------------------------------------------------------
+# 6. Verify configuration directory and files
+# ---------------------------------------------------------------
+echo "-- Checking config files --"
+if [ -d "${PKG_DIR}/config" ]; then
+  pass "config/ directory exists"
+  CFG_COUNT=$(find "${PKG_DIR}/config" -type f | wc -l)
+  if [ "${CFG_COUNT}" -gt 0 ]; then
+    pass "config/ contains ${CFG_COUNT} file(s)"
+  else
+    fail "config/ directory is empty"
+  fi
+else
+  fail "config/ directory not found"
+fi
+
+# ---------------------------------------------------------------
+# 7. Verify architecture handling covers common targets
+# ---------------------------------------------------------------
+echo "-- Checking architecture support --"
+for arch in aarch64 arm x86_64; do
+  if grep -q "${arch}" "${PKG_DIR}/package.mk"; then
+    pass "Architecture '${arch}' is handled"
+  else
+    fail "Architecture '${arch}' is NOT handled"
+  fi
+done
+
+# ---------------------------------------------------------------
+# 8. Verify library output name
+# ---------------------------------------------------------------
+echo "-- Checking library output --"
+if grep -q 'PKG_LIBNAME=' "${PKG_DIR}/package.mk"; then
+  LIB_NAME="$(grep 'PKG_LIBNAME=' "${PKG_DIR}/package.mk" | head -1 | cut -d'"' -f2)"
+  if echo "${LIB_NAME}" | grep -q "_libretro\.so$"; then
+    pass "PKG_LIBNAME '${LIB_NAME}' follows libretro naming convention"
+  else
+    fail "PKG_LIBNAME '${LIB_NAME}' does not follow libretro naming (*_libretro.so)"
+  fi
+else
+  fail "PKG_LIBNAME is not defined"
+fi
+
+# ---------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------
+echo ""
+echo "=== Results: ${PASS} passed, ${ERRORS} failed ==="
+if [ "${ERRORS}" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/packages/readme.md
+++ b/packages/readme.md
@@ -59,7 +59,7 @@ To control the build behaviour of your package, use variables in the top-down or
 #### Make Options
 | Variable    | Default | Required |Description |
 |-------------|---------|----------|------------|
-| PKG_MAKE_OPTS<br>PKG_MAKE_OPTS_BOOTSTRP<br>PKG_MAKE_OPTS_HOST<br>PKG_MAKE_OPTS_INIT<br> PKG_MAKE_OPTS_TARGET | - | no | Options directly passed to make in the build step
+| PKG_MAKE_OPTS<br>PKG_MAKE_OPTS_BOOTSTRAP<br>PKG_MAKE_OPTS_HOST<br>PKG_MAKE_OPTS_INIT<br> PKG_MAKE_OPTS_TARGET | - | no | Options directly passed to make in the build step
 | PKG_MAKEINSTALL_OPTS_HOST<br>PKG_MAKEINSTALL_OPTS_TARGET | - | no | Options directly passed to make in the install step
 
 #### Addons
@@ -128,7 +128,7 @@ Set the variable `PKG_BUILD_FLAGS` in the `package.mk` to enable/disable the sin
 | lto-off  | disabled | target, init      | explicitly disable LTO in the compiler and linker |
 | bfd      | - | target, init | `+bfd` prefers bfd linker over default linker, `-bfd` disables using bfd |
 | gold     | - | target, init | `+gold` prefers gold linker over default linker, `-gold` disables using gold |
-| mold     | - | target, init | `+mold` prefers mold linker over default linker, `-mold` disables using gold |
+| mold     | - | target, init | `+mold` prefers mold linker over default linker, `-mold` disables using mold |
 | parallel | enabled  | all | `make` or `ninja` builds with multiple threads/processes (or not) |
 | strip    | enabled  | target | strips executables (or not) |
 | sysroot  | enabled  | target | installs the package to the sysroot folder (or not) |
@@ -144,11 +144,11 @@ PKG_BUILD_FLAGS="-parallel"
 All build steps in the LibreELEC build system are done by shell function.
 These functions can be overwritten in the `package.mk`. However, this raises problems when the build system is updated. To reduce the impact, most functions are extended by `pre_` and `post_` scripts to use instead.
 
-When it is nesseary to replace configure, make and makeinstall, please use `PKG_TOOLCHAIN="manual"`.
+When it is necessary to replace configure, make and makeinstall, please use `PKG_TOOLCHAIN="manual"`.
 
 Some of the build steps needs to be run once, like `unpack`. Other steps needs to be run multiple times, to create the toolchain (stage bootstrap & host) or to create the LE image (stage init & target). These stage specific functions have the stage as suffix, like `make_target`.
 
-Full list of overwrittable functions.
+Full list of overwritable functions.
 
 | function                | stages specific | description |
 |-------------------------|--------|-------------|
@@ -271,7 +271,7 @@ Issue | Level | Meaning |
     * new kernel driver
     * ...
 2. Find a place in the packages tree
-    * look into the package tree structure, which is generally self explanitory.
+    * look into the package tree structure, which is generally self explanatory.
     * do not place it in an existing package (directory that includes a `package.mk`)
     * when you found a place, create a directory with the name of your package (use same value for `PKG_NAME`!!)
 3. Create an initial `package.mk`

--- a/packages/x11/driver/xf86-video-nvidia/scripts/compare_nvidia.py
+++ b/packages/x11/driver/xf86-video-nvidia/scripts/compare_nvidia.py
@@ -10,7 +10,7 @@ import sys
 
 try:
   from lxml import html
-except:
+except Exception:
   print('lxml module not installed.\n\nOn Ubuntu, use "sudo apt install python3-lxml"')
   sys.exit(1)
 

--- a/scripts/pkgbuilder.py
+++ b/scripts/pkgbuilder.py
@@ -44,7 +44,7 @@ def rusage_run(*popenargs, parent=None, timeout=None, **kwargs):
             process.kill()
             process.wait()
             raise
-        except:
+        except Exception:
             process.kill()
             raise
         retcode = process.poll()
@@ -273,7 +273,7 @@ class BuildProcess(threading.Thread):
             try:
                 os.killpg(os.getpgid(self.child.pid), signal.SIGTERM)
                 self.child.wait()
-            except:
+            except Exception:
                 pass
 
     def isActive(self):


### PR DESCRIPTION
## Summary

Fixes complete Python 3 incompatibility in packages/addons/driver/hdhomerun/source/resources/lib/functions.py:

The entire module was broken on Python 3 due to 15 instances of Python 2 syntax:
- Converted all `print` statements to `print()` function calls
- Replaced `os.popen()` with `subprocess.run()`'

Also fixes bare except clauses in scripts.

Signed-off-by: Srikanth Patchava <spatchava@meta.com>