### PR TITLE
sameboy: uses upstream repo and libretro branch - Lakka-v6.1 branch

### DIFF
--- a/packages/lakka/libretro_cores/sameboy/package.mk
+++ b/packages/lakka/libretro_cores/sameboy/package.mk
@@ -1,15 +1,21 @@
 PKG_NAME="sameboy"
-PKG_VERSION="51433012a871a44555492273fd22f29867d12655"
+PKG_VERSION="8230189896a8bb6598574d302ba0ad3658f98ab4"
 PKG_LICENSE="MIT"
-PKG_SITE="https://github.com/libretro/sameboy"
+PKG_SITE="https://github.com/LIJI32/SameBoy"
 PKG_URL="${PKG_SITE}.git"
+PKG_GIT_CLONE_BRANCH="libretro"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_LONGDESC="Gameboy and Gameboy Color emulator written in C"
 PKG_TOOLCHAIN="make"
 
-PKG_MAKE_OPTS_TARGET="-C libretro/"
+PKG_MAKE_OPTS_TARGET="libretro"
+PKG_BUILD_FLAGS="-parallel"
+
+pre_make_target() {
+  export BOOTROMS_DIR="${PKG_BUILD}/BootROMs/prebuilt"
+}
 
 makeinstall_target() {
-  mkdir -p ${INSTALL}/usr/lib/libretro
-    cp -v libretro/sameboy_libretro.so ${INSTALL}/usr/lib/libretro/
+  mkdir -p "${INSTALL}/usr/lib/libretro"
+    cp -v "${PKG_BUILD}/build/bin/sameboy_libretro.so" "${INSTALL}/usr/lib/libretro/"
 }

--- a/packages/lakka/libretro_cores/sameboy/patches/sameboy-001-workaround_rgbasm_not_found.patch
+++ b/packages/lakka/libretro_cores/sameboy/patches/sameboy-001-workaround_rgbasm_not_found.patch
@@ -1,0 +1,16 @@
+diff -uNr a/Makefile b/Makefile
+--- a/Makefile	2026-04-18 19:12:56.000000000 +0900
++++ b/Makefile	2026-04-21 20:12:58.011943683 +0900
+@@ -171,10 +171,12 @@
+ RGBLINK := $(RGBDS)rgblink
+ RGBGFX  := $(RGBDS)rgbgfx
+ 
++ifneq ("$(wildcard $(RGBASM))", "")
+ # RGBASM 0.7+ deprecate and remove `-h`
+ RGBASM_FLAGS := $(if $(filter $(shell echo 'println __RGBDS_MAJOR__ || (!__RGBDS_MAJOR__ && __RGBDS_MINOR__ > 6)' | $(RGBASM) -), $$0), -h,) --include $(OBJ)/BootROMs/ --include BootROMs/
+ # RGBGFX 0.6+ replace `-h` with `-Z`, and need `-c embedded`
+ RGBGFX_FLAGS := $(if $(filter $(shell echo 'println __RGBDS_MAJOR__ || (!__RGBDS_MAJOR__ && __RGBDS_MINOR__ > 5)' | $(RGBASM) -), $$0), -h -u, -Z -u -c embedded)
++endif
+ 
+ 
+ # Set compilation and linkage flags based on target, platform and configuration


### PR DESCRIPTION
## Description
This Pull requests changes repository for sameboy core
before: https://github.com/libretro/sameboy ("buildbot" branch)
after: https://github.com/LIJI32/SameBoy ("libretro" branch)

and adds workaround patch for rgbasm not found in build time

Related issue : #2012 

### Build
Exynos.arm buils is passed
Generic.i386 buils is passed
Generic.x86_64 is passed
RPi5.aarch64 is passed

### Test
This sameboy core is able to start on RPi5.aarch64

### Note
- I will create backport PR to devel branch later
- It may needs to update the core_info package.
  Because this sameboy core has bios files inside.

Thanks
ASAI, Shigeaki