### PR TITLE
libretro_cores: enable 5 cores on Lakka-v6.1

### DIFF
--- a/packages/lakka/libretro_cores/package.mk
+++ b/packages/lakka/libretro_cores/package.mk
@@ -12,8 +12,10 @@ LIBRETRO_CORES="\
                 amiarcadia \
                 amiberry \
                 anarch \
+                applewin \
                 ardens \
                 atari800 \
+                azahar \
                 b2 \
                 beetle_bsnes \
                 beetle_lynx \
@@ -31,6 +33,7 @@ LIBRETRO_CORES="\
                 bluemsx \
                 bnes \
                 boom3 \
+                boytacean \
                 bsnes \
                 bsnes2014 \
                 bsnes_hd \
@@ -87,6 +90,7 @@ LIBRETRO_CORES="\
                 higan_sfc \
                 higan_sfc_balanced \
                 jaxe \
+                jollycv \
                 jumpnbump \
                 kronos \
                 lowres_nx \
@@ -140,6 +144,7 @@ LIBRETRO_CORES="\
                 race \
                 reminiscence \
                 retro8 \
+                rustation_ng \
                 same_cdi \
                 sameboy \
                 sameduck \


### PR DESCRIPTION
## This PR enables the following 5 libretro cores on Lakka-v6.1
\- azahar
\- applewin
\- boytacean
\- jollycv
\- rustation_ng

Lakka-v6.1 had these 5 cores package but these were not enabled.
These cores are enabled on devel branch.

### Build test
Base Lakka-v6.1 commit: bfd129c685e61288c6dfa7d5075e866ff32da679
Build command: ./build_all.sh (exclude DEVICE=H616)
Build result: all passed
> Build job 34/34, so far 33 successful builds, 0 failed builds
> Creating release files / images...done!
> Moving release files (.img.gz, .tar) to subfolder...done!
> Removing unused files (.ova,kernel,system)...done!
> 
> All successful!
> :-)

Thanks
ASAI, Shigeaki