### PR TITLE
[WIP] bcm2835-bootloader: add "#usb_max_current_enable=1" into distroconfig*.txt for RPi5 and RPi5-Composite

### DIFF
--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -52,5 +52,9 @@ makeinstall_target() {
       echo "hdmi_max_pixel_freq:0=200000000" >> ${INSTALL}/usr/share/bootloader/distroconfig.txt
       echo "hdmi_max_pixel_freq:1=200000000" >> ${INSTALL}/usr/share/bootloader/distroconfig.txt
       echo "force_turbo=0" >> ${INSTALL}/usr/share/bootloader/config.txt
+      if [ "${DEVICE:0:4}" = "RPi5" ]; then
+        echo "#usb_max_current_enable=1" >> "${INSTALL}/usr/share/bootloader/distroconfig.txt"
+        echo "#usb_max_current_enable=1" >> "${INSTALL}/usr/share/bootloader/distroconfig-composite.txt"
+      fi
     fi
 }


### PR DESCRIPTION
## This pull request prepares a workaround for the power insufficient case with the USB3 ports on the RPi5. 
RPI5 power supply recommends with 5V/5A unit.
The USB3 ports power is provided 1.6A when a 5V/5A power supply unit is connected.

But the USB3 ports power is only provided 600mA if a 5V/3A power supply unit is connected.
https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#typical-power-requirements

This is a specification of the Raspberry Pi 5, but it seems that USB devices may not function properly due to insufficient power.
It's better to use 5V/5A PSU, but there is workaround.
https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#differences-on-raspberry-pi-5
https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#power-supplies-and-raspberry-pi-os

When "usb_max_current_enable=1" is set in "config.txt", more power is provided to USB3 ports on RPi5.

However this is only needed USB power insufficient case and it should set disable as default. 

Therefore, it's better to prepare this workaround and faq for user I think.

### Build
RPi5.aarch64, RPi5-Composite.aarch64 and RPi4.aarch64 build are passed.

### Test
- RPi5.aarch64
  a) "#usb_max_current_enable=1" is contained in "${INSTALL}/usr/share/bootloader/distroconfig.txt"
  b) "#usb_max_current_enable=1" is contained in "${INSTALL}/usr/share/bootloader/distroconfig-composite.txt"
- RPi5-Composite.aarch64
  a) "#usb_max_current_enable=1" is contained in "${INSTALL}/usr/share/bootloader/distroconfig.txt"
  b) "#usb_max_current_enable=1" is contained in "${INSTALL}/usr/share/bootloader/distroconfig-composite.txt"
- RPi4.aarch64
  a) "#usb_max_current_enable=1" is NOT contained in "${INSTALL}/usr/share/bootloader/distroconfig.txt"
  b) "#usb_max_current_enable=1" is NOT contained in "${INSTALL}/usr/share/bootloader/distroconfig-composite.txt"

### Note
please create faq for this workaround.

Thanks
ASAI, Shigeaki