### PR TITLE
linux: RK3326: adds enable 2nd microSD slot on ANBERNIC RG351V

### DIFF
--- a/projects/Rockchip/devices/RK3326/patches/linux/0008-rk3326-dts-adjustments-RG351.patch
+++ b/projects/Rockchip/devices/RK3326/patches/linux/0008-rk3326-dts-adjustments-RG351.patch
@@ -1,18 +1,6 @@
-From 9a794c7f5e61b7919d2bab3754466e9c545982eb Mon Sep 17 00:00:00 2001
-From: Demetris Ierokipides <ierokipides.dem@gmail.com>
-Date: Wed, 7 Feb 2024 17:34:53 -0400
-Subject: [PATCH] rk3326: dts adjustments (RG351)
-
----
- .../dts/rockchip/rk3326-anbernic-rg351m.dts   | 25 +++++++++
- .../dts/rockchip/rk3326-anbernic-rg351m.dtsi  |  6 +++
- .../dts/rockchip/rk3326-anbernic-rg351v.dts   | 53 ++++++++++++++++---
- 3 files changed, 76 insertions(+), 8 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dts b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dts
-index f4d20f2..a624375 100644
---- a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dts
+diff -uNr a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dts b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dts
+--- a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dts	2026-02-09 06:03:27.000000000 +0900
++++ b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dts	2026-03-09 17:17:05.722368387 +0900
 @@ -11,6 +11,25 @@
  / {
  	model = "Anbernic RG351M";
@@ -39,7 +27,7 @@ index f4d20f2..a624375 100644
  };
  
  &internal_display {
-@@ -19,3 +38,9 @@ &internal_display {
+@@ -19,3 +38,9 @@
  	rotation = <270>;
  	vdd-supply = <&vcc_lcd>;
  };
@@ -49,12 +37,18 @@ index f4d20f2..a624375 100644
 +	//rockchip,resistor-sense-micro-ohms = <0>;
 +	monitored-battery = <&battery>;
 +};
-\ No newline at end of file
-diff --git a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dtsi b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dtsi
-index b6d041d..96a029c 100644
---- a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dtsi
-@@ -339,6 +339,12 @@ usb_midu: BOOST {
+diff -uNr a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dtsi b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dtsi
+--- a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dtsi	2026-02-09 06:03:27.000000000 +0900
++++ b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351m.dtsi	2026-03-09 17:37:00.940816921 +0900
+@@ -15,6 +15,7 @@
+ / {
+ 	aliases {
+ 		mmc0 = &sdmmc;
++		mmc1 = &sdio;
+ 	};
+ 
+ 	chosen {
+@@ -341,6 +342,12 @@
  			};
  		};
  
@@ -67,11 +61,30 @@ index b6d041d..96a029c 100644
  		rk817_codec: codec {
  			rockchip,mic-in-differential;
  		};
-diff --git a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts
-index c79f7a7..c0a6985 100644
---- a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts
-@@ -7,26 +7,48 @@ / {
+@@ -393,6 +400,19 @@
+ 	status = "okay";
+ };
+ 
++&sdio {
++	cap-sd-highspeed;
++	card-detect-delay = <200>;
++	cd-gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_sd>;
++	vqmmc-supply = <&vccio_sd>;
++	status = "disabled";
++};
++
+ &sfc {
+ 	#address-cells = <1>;
+ 	pinctrl-0 = <&sfc_clk &sfc_cs0 &sfc_bus2>;
+diff -uNr a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts
+--- a/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts	2026-02-09 06:03:27.000000000 +0900
++++ b/arch/arm64/boot/dts/rockchip/rk3326-anbernic-rg351v.dts	2026-03-09 17:26:18.882440826 +0900
+@@ -7,9 +7,11 @@
  	model = "Anbernic RG351V";
  	compatible = "anbernic,rg351v", "rockchip,rk3326";
  
@@ -83,22 +96,9 @@ index c79f7a7..c0a6985 100644
 +		pinctrl-names = "default";
  
  		button-vol-down {
--			gpios = <&gpio2 RK_PA1 GPIO_ACTIVE_LOW>;
--			label = "VOLUMEDOWN";
--			linux,code = <KEY_VOLUMEDOWN>;
-+			gpios = <&gpio2 RK_PA1 GPIO_ACTIVE_LOW>;
-+			label = "VOLUMEDOWN";
-+			linux,code = <KEY_VOLUMEDOWN>;
- 		};
- 
--		button-vol-up {
--			gpios = <&gpio2 RK_PA0 GPIO_ACTIVE_LOW>;
--			label = "VOLUMEUP";
--			linux,code = <KEY_VOLUMEUP>;
-+		button-volume-up {
-+			gpios = <&gpio2 RK_PA0 GPIO_ACTIVE_LOW>;
-+			label = "VOLUMEUP";
-+			linux,code = <KEY_VOLUMEUP>;
+ 			gpios = <&gpio2 RK_PA1 GPIO_ACTIVE_LOW>;
+@@ -23,10 +25,30 @@
+ 			linux,code = <KEY_VOLUMEUP>;
  		};
  	};
 +
@@ -114,11 +114,11 @@ index c79f7a7..c0a6985 100644
 +
 +		ocv-capacity-celsius = <20>;
 +		ocv-capacity-table-0 =  <4046950 100>, <4001920 95>, <3967900 90>, <3919950 85>,
-+								<3888450 80>, <3861850 75>, <3831540 70>, <3799130 65>,
-+								<3768190 60>, <3745650 55>, <3726610 50>, <3711630 45>,
-+								<3696720 40>, <3685660 35>, <3674950 30>, <3663050 25>,
-+								<3649470 20>, <3635260 15>, <3616920 10>, <3592440 5>,
-+								<3574170 0>;
++					<3888450 80>, <3861850 75>, <3831540 70>, <3799130 65>,
++					<3768190 60>, <3745650 55>, <3726610 50>, <3711630 45>,
++					<3696720 40>, <3685660 35>, <3674950 30>, <3663050 25>,
++					<3649470 20>, <3635260 15>, <3616920 10>, <3592440 5>,
++					<3574170 0>;
 +	};
  };
  
@@ -128,29 +128,26 @@ index c79f7a7..c0a6985 100644
  	vdd-supply = <&vcc_lcd>;
  };
  
-@@ -39,6 +61,21 @@ &vcc_sd {
- 	regulator-min-microvolt = <1800000>;
+@@ -42,3 +64,22 @@
+ &vccio_sd {
+ 	regulator-max-microvolt = <1800000>;
  };
- 
++
++&sdio {
++	status = "okay";
++};
++
 +&rk817_charger {
 +       /* This device does not have a current sense resistor */
 +       rockchip,resistor-sense-micro-ohms = <0>;
 +       monitored-battery = <&battery>;
 +};
 +
- &vccio_sd {
- 	regulator-max-microvolt = <1800000>;
- };
-+
 +&pinctrl {
 +	btns {
 +		btn_pins_vol: btn-pins-vol {
 +			rockchip,pins = <2 RK_PA0 RK_FUNC_GPIO &pcfg_pull_up>,
-+							<2 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>;
++					<2 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>;
 +		};
 +	};
 +};
-\ No newline at end of file
--- 
-2.43.0
-


### PR DESCRIPTION
## This PR adds enable 2nd microSD slot on ANBERNIC RG351V
Base Lakka-v6.1 commit: cc2c149937a2185f26c6d16f8c44df7225c897fc

### Build 
RK3326.aarch64 build is passed.

### Test
It is able to access 2nd microSD slot on ANBERNIC RG351V

### Note
I will create a PR for the devel branch later.


Thanks
ASAI, Shigeaki