### PR TITLE
Lakka-v6.1: retroarch_base: bump 5 retroarch_base packages on 8th May 2026

### DIFF
--- a/packages/lakka/retroarch_base/glsl_shaders/package.mk
+++ b/packages/lakka/retroarch_base/glsl_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="glsl_shaders"
-PKG_VERSION="ad982c951e70a5a9609b173a2c5fa50afb5f58ad"
+PKG_VERSION="42fa8a98ab19bdaffb53280746a30819eb21f807"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/glsl-shaders"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/libretro_database/package.mk
+++ b/packages/lakka/retroarch_base/libretro_database/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="libretro_database"
-PKG_VERSION="4c856a61cdff938e5f440b8f5f4b042accee1d24"
+PKG_VERSION="8ae09ff74c9883a9170ffde1d69b4151f99d944f"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/libretro-database"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_assets/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_assets/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_assets"
-PKG_VERSION="a7b711dfd74871e9985ba3b2fe2c15048a928aaf"
+PKG_VERSION="cd17f64cff4eaff187a0702d17520ccb9a760fe3"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/retroarch-assets"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
+++ b/packages/lakka/retroarch_base/retroarch_joypad_autoconfig/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroarch_joypad_autoconfig"
-PKG_VERSION="739cee1ef16e3583122446caffa1bf4449eb323c"
+PKG_VERSION="794a2f18cdb7b5c3565e75c2a663f598e3f90e24"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/retroarch-joypad-autoconfig"
 PKG_URL="${PKG_SITE}.git"

--- a/packages/lakka/retroarch_base/slang_shaders/package.mk
+++ b/packages/lakka/retroarch_base/slang_shaders/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="slang_shaders"
-PKG_VERSION="33420e54fc9b1f3583f635c920692d4ee7bea743"
+PKG_VERSION="cef2de6123cccbf0393ed6071ffd6e4a8d092145"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/libretro/slang-shaders"
 PKG_URL="${PKG_SITE}.git"


### PR DESCRIPTION
## This pull requests is "bump 5 retroarch_base packages" for Lakka-v6.1
update check command : `./libretro_update.sh -r`
update check date : `8th May, 2026`

### Bump 5 retroarch_base packages
- glsl_shaders
- libretro_database
- retroarch_assets
- retroarch_joypad_autoconfig
- slang_shaders

### Additional info
none

### Confirmation
- All projects/devices build were done with no error.
  > All successful!
  > :-)

  Base Lakka-v6.1 commit: e3a70d3ac50e0ef79d02da02a30eece2591ce15a
  The following projects are passed.
  \-  Allwinner
  \-  Amlogic
  \-  Ayn
  \-  Generic
  \-  L4T
  \-  NXP
  \-  RPi
  \-  Rockchip
  \-  Samsung

- just only check build is passed

### Note
none.

Thanks
ASAI, Shigeaki