### PR TITLE
Lakka 6.2 switch fixes

### DIFF
--- a/projects/L4T/devices/Switch/packages/kodi/system.d/kodi.service
+++ b/projects/L4T/devices/Switch/packages/kodi/system.d/kodi.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 [Service]
 User=LibreELEC
 Group=LibreELEC
-Environment=HOME=/storage DISPLAY=:0 PULSE_SERVER=127.0.0.1
+Environment=HOME=/storage DISPLAY=:0 PULSE_SERVER=127.0.0.1 __GL_SYNCK_TO_VBLANK=1
 EnvironmentFile=/usr/lib/kodi/kodi.conf
 EnvironmentFile=-/run/libreelec/kodi.conf
 EnvironmentFile=-/run/libreelec/debug/kodi.conf

--- a/projects/L4T/devices/Switch/packages/retroarch/system.d/retroarch.service
+++ b/projects/L4T/devices/Switch/packages/retroarch/system.d/retroarch.service
@@ -5,7 +5,7 @@ ConditionKernelCommandLine=!retroarch=0
 Requires=graphical.target
 
 [Service]
-Environment=HOME=/storage DISPLAY=:0 PULSE_SERVER=127.0.0.1
+Environment=HOME=/storage DISPLAY=:0 PULSE_SERVER=127.0.0.1 __GL_SYNC_TO_VBLANK=1
 User=Lakka
 Group=Lakka
 EnvironmentFile=-/run/libreelec/retroarch.conf

--- a/projects/L4T/devices/Switch/packages/switch-bsp/package.mk
+++ b/projects/L4T/devices/Switch/packages/switch-bsp/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="switch-bsp"
-PKG_VERSION="1.3"
+PKG_VERSION="1.4"
 PKG_LICENSE="GPL"
 PKG_DEPENDS_TARGET="joycond rewritefs xdotool alsa-lib alsa-ucm-conf usb-gadget-scripts"
 PKG_SECTION="virtual"

--- a/projects/L4T/devices/Switch/packages/switch-bsp/scripts/dock-hotplug
+++ b/projects/L4T/devices/Switch/packages/switch-bsp/scripts/dock-hotplug
@@ -38,7 +38,7 @@ dock_hotplug_handle() {
                 sleep 0.2
                 xrandr --output DSI-0 --off --output DP-0 $DP_SETTINGS
             else
-                xrandr --output DSI-0 --primary --mode 720x1280 --rotate left --panning 1280x720+0+0 --pos 0x0 --dpi 237  --output DP-0 --off
+                xrandr --output DSI-0 --primary --mode 1280x720 --panning 1280x720+0+0 --pos 0x0 --dpi 237  --output DP-0 --off
                 pactl set-card-profile 1 HiFi
                 pactl set-card-profile 0 off
                 #Fix volume if needed(Pulseaudio sink volume's should not change ever in libreelec builds
@@ -47,7 +47,7 @@ dock_hotplug_handle() {
                 fi
                 # Reapply config to avoid X stubbornness.
                 sleep 0.2
-                xrandr --output DP-0 --off --output DSI-0 --primary --mode 720x1280 --rotate left --panning 1280x720+0+0 --pos 0x0 --dpi 237
+                xrandr --output DP-0 --off --output DSI-0 --primary --mode 1280x720 --panning 1280x720+0+0 --pos 0x0 --dpi 237
            fi
         done
 

--- a/projects/L4T/devices/Switch/patches/LibreELEC-settings/0001-libreelec-addon-Bluetooth-scope-PropertiesChanged.patch
+++ b/projects/L4T/devices/Switch/patches/LibreELEC-settings/0001-libreelec-addon-Bluetooth-scope-PropertiesChanged.patch
@@ -1,0 +1,65 @@
+From 97f72a222fe2a34a55ed9ced9bf7ec155e588a60 Mon Sep 17 00:00:00 2001
+From: Patcher <patcher@local>
+Date: Tue, 28 Apr 2026 13:40:42 +0000
+Subject: [PATCH] Bluetooth: scope PropertiesChanged subscription to /org/bluez
+
+The Listener was subscribing to PropertiesChanged with path='/' and
+fallback=True, which in ravel produces the D-Bus match rule
+path_namespace='/'. That makes the dbus-daemon deliver every
+PropertiesChanged signal on the system bus to this process, regardless
+of which service emitted it -- UPower, NetworkManager, systemd1 and
+others all emit these (UPower fires several per second per battery
+device for Percentage / EnergyRate / Voltage updates).
+
+Each delivery walks ravel's dispatch tree and calls
+bluetooth.on_properties_changed, which for any path it doesn't already
+know about runs discover_devices() -- so under UPower bursts the addon
+ends up scheduling back-to-back BlueZ enumerations on its asyncio
+thread and the UI freezes.
+
+All BlueZ objects (org.bluez adapters/devices/GATT services and the
+org.bluez.obex transfer objects) live under /org/bluez, so
+path_namespace='/org/bluez' is sufficient and lets the dbus-daemon
+filter unrelated signals out before they reach us.
+---
+ resources/lib/dbus_bluez.py | 20 +++++++++++++++++++-
+ 1 file changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/resources/lib/dbus_bluez.py b/resources/lib/dbus_bluez.py
+index 579c7c6..bf2bec5 100644
+--- a/resources/lib/dbus_bluez.py
++++ b/resources/lib/dbus_bluez.py
+@@ -113,11 +113,29 @@ class Listener(object):
+     def __init__(self):
+         dbus_utils.BUS.listen_objects_added(func=self._on_interfaces_added)
+         dbus_utils.BUS.listen_objects_removed(func=self._on_interfaces_removed)
++        # Scope PropertiesChanged subscription to the BlueZ object subtree.
++        #
++        # Previously this listened on path='/' with fallback=True, which in
++        # ravel translates to a D-Bus match rule of path_namespace='/' --
++        # meaning the dbus-daemon delivers every PropertiesChanged signal on
++        # the system bus to this process, regardless of which service emitted
++        # it. UPower, NetworkManager, systemd1 and others all emit these
++        # frequently (UPower in particular fires several per second per
++        # battery device for Percentage/EnergyRate/Voltage updates), and each
++        # one was being dispatched into our asyncio loop and then handed to
++        # bluetooth.py's on_properties_changed handler -- which calls
++        # discover_devices() for any path it doesn't already know about,
++        # i.e. every UPower path. Under load this could lock up the addon UI.
++        #
++        # All BlueZ objects (adapters, devices, GATT services/chars/descs,
++        # and the org.bluez.obex transfer objects) live under /org/bluez,
++        # so path_namespace='/org/bluez' is sufficient and lets the
++        # dbus-daemon filter unrelated signals out before they reach us.
+         dbus_utils.BUS.listen_propchanged(
+             interface=dbussy.DBUS.INTERFACE_PROPERTIES,
+             fallback=True,
+             func=self._on_properties_changed,
+-            path='/')
++            path=PATH_BLUEZ)
+ 
+     @ravel.signal(name='InterfacesAdded', in_signature='oa{sa{sv}}', arg_keys=('path', 'interfaces'))
+     def _on_interfaces_added(self, path, interfaces):
+-- 
+2.43.0
+

--- a/projects/L4T/devices/Switch/patches/kodi/0001-Platform-Linux-PowerManagement-Logind-Upower-Fix-bat.patch
+++ b/projects/L4T/devices/Switch/patches/kodi/0001-Platform-Linux-PowerManagement-Logind-Upower-Fix-bat.patch
@@ -1,199 +1,203 @@
-From 47f068c420ede9c30bd177cd86d31c38782eb809 Mon Sep 17 00:00:00 2001
-From: Ronald Brown <rbrown4014@yahoo.com>
-Date: Mon, 26 Feb 2024 20:44:32 +0100
-Subject: [PATCH] Platform: Linux: PowerManagement: Logind/Upower: Fix battery
- info/Upower Dbus Handling.
-
----
- .../powermanagement/LogindUPowerSyscall.cpp   | 99 ++++++++++++++++---
- .../powermanagement/LogindUPowerSyscall.h     | 14 +--
- 2 files changed, 93 insertions(+), 20 deletions(-)
-
 diff --git a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
-index bd04197a51..2fc0ceb043 100644
+index bd04197a51..47266604b9 100644
 --- a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
 +++ b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
-@@ -48,7 +48,7 @@ CLogindUPowerSyscall::CLogindUPowerSyscall()
+@@ -28,8 +28,6 @@
  
-   m_batteryLevel = 0;
+ CLogindUPowerSyscall::CLogindUPowerSyscall()
+ {
+-  m_lowBattery = false;
+-
+   CLog::Log(LOGINFO, "Selected Logind/UPower as PowerSyscall");
+ 
+   // Check if we have UPower. If not, we avoid any battery related operations.
+@@ -46,9 +44,8 @@ CLogindUPowerSyscall::CLogindUPowerSyscall()
+ 
+   InhibitDelayLockSleep();
+ 
+-  m_batteryLevel = 0;
    if (m_hasUPower)
 -    UpdateBatteryLevel();
 +    UpdatePowerSupplyInfo();
  
    if (!m_connection.Connect(DBUS_BUS_SYSTEM, true))
    {
-@@ -60,7 +60,8 @@ CLogindUPowerSyscall::CLogindUPowerSyscall()
+@@ -60,7 +57,34 @@ CLogindUPowerSyscall::CLogindUPowerSyscall()
    dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'", error);
  
    if (!error && m_hasUPower)
 -    dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.UPower',member='DeviceChanged'", error);
-+    dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',path_namespace='/org/freedesktop/UPower/devices'", error);
-+
++  {
++    // UPower 0.99+ exposes /org/freedesktop/UPower/devices/DisplayDevice as a
++    // composite battery aggregating all power sources on the system. We only
++    // need its PropertiesChanged signal plus the daemon-level OnBattery
++    // change. This is dramatically narrower than matching every device under
++    // /org/freedesktop/UPower/devices: peripheral mice, keyboards, headsets
++    // and external chargers don't trigger any work for us.
++    //
++    // Pre-0.99 UPower (Released 2013-10-29) is well past EOL and its API
++    // (DeviceChanged signal, OnLowBattery property) has been removed for
++    // over a decade, so we don't try to support both.
++    dbus_bus_add_match(m_connection,
++                       "type='signal',interface='org.freedesktop.DBus.Properties',"
++                       "member='PropertiesChanged',"
++                       "path='/org/freedesktop/UPower/devices/DisplayDevice'",
++                       error);
++  }
++  if (!error && m_hasUPower)
++  {
++    // The daemon's OnBattery property is the authoritative "is the system on
++    // mains or battery power" flag. PropertiesChanged on the daemon path
++    // covers it.
++    dbus_bus_add_match(m_connection,
++                       "type='signal',interface='org.freedesktop.DBus.Properties',"
++                       "member='PropertiesChanged',"
++                       "path='/org/freedesktop/UPower'",
++                       error);
++  }
  
    dbus_connection_flush(m_connection);
  
-@@ -186,12 +187,16 @@ int CLogindUPowerSyscall::BatteryLevel()
+@@ -186,44 +210,50 @@ int CLogindUPowerSyscall::BatteryLevel()
    return m_batteryLevel;
  }
  
 -void CLogindUPowerSyscall::UpdateBatteryLevel()
-+
-+
 +void CLogindUPowerSyscall::UpdatePowerSupplyInfo()
  {
-   char** source  = NULL;
-   int    length = 0;
+-  char** source  = NULL;
+-  int    length = 0;
 -  double batteryLevelSum = 0;
-   int    batteryCount = 0;
-+  int    chargerCount = 0;
-+  int    deviceBatteryCount = 0;
-+  bool   hasBattery = false;
- 
-   CDBusMessage message("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower", "EnumerateDevices");
-   DBusMessage *reply = message.SendSystem();
-@@ -209,21 +214,87 @@ void CLogindUPowerSyscall::UpdateBatteryLevel()
+-  int    batteryCount = 0;
+-
+-  CDBusMessage message("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower", "EnumerateDevices");
+-  DBusMessage *reply = message.SendSystem();
+-
+-  if (!reply)
+-    return;
+-
+-  if (!dbus_message_get_args(reply, NULL, DBUS_TYPE_ARRAY, DBUS_TYPE_OBJECT_PATH, &source, &length, DBUS_TYPE_INVALID))
+-  {
+-    CLog::Log(LOGWARNING, "LogindUPowerSyscall: failed to enumerate devices");
+-    return;
+-  }
+-
+-  for (int i = 0; i < length; i++)
++  // Read the aggregate DisplayDevice properties. UPower computes them from
++  // every battery and UPS on the system and atomically publishes them on a
++  // single object, so we don't need to enumerate or call GetAll per device.
++  // This matches what GNOME Shell, KDE Solid, COSMIC, HandBrake and similar
++  // status indicators do.
++  const CVariant displayProps =
++      CDBusUtil::GetAll("org.freedesktop.UPower", "/org/freedesktop/UPower/devices/DisplayDevice",
++                        "org.freedesktop.UPower.Device");
++
++  // For DisplayDevice, IsPresent indicates "should a status icon be shown",
++  // i.e. whether there is something worth reading. On battery-less machines
++  // (typical desktops, set-top boxes) this is false.
++  m_displayDevicePresent = displayProps["IsPresent"].asBoolean();
++
++  if (m_displayDevicePresent)
    {
-     CVariant properties = CDBusUtil::GetAll("org.freedesktop.UPower", source[i], "org.freedesktop.UPower.Device");
-     bool isRechargeable = properties["IsRechargeable"].asBoolean();
-+    bool isPowerSupply = properties["PowerSupply"].asBoolean();
-+    int  isType = properties["Type"].asInteger();
+-    CVariant properties = CDBusUtil::GetAll("org.freedesktop.UPower", source[i], "org.freedesktop.UPower.Device");
+-    bool isRechargeable = properties["IsRechargeable"].asBoolean();
++    m_batteryLevel = (int)displayProps["Percentage"].asDouble();
  
 -    if (isRechargeable)
-+    switch(isType)
-     {
+-    {
 -      batteryCount++;
 -      batteryLevelSum += properties["Percentage"].asDouble();
 -    }
--  }
-+      case 1: // Line Power
-+      {
-+        chargerCount++;
-+        if(chargerCount > 1){
-+           CLog::Log(LOGDEBUG, "LogindUPowerSyscall: More than one non battery powersupply found. Ignoring");
-+           continue;
-+        }
-+        m_chargerState = properties["Online"].asBoolean();
-+      }
-+
-+      case 2: // Battery
-+      {
-+        if (isPowerSupply && isRechargeable) //Verify this is a System Battery
-+        {
-+
-+          //TODO:Add check for upower reporting backlight/display as battery.
-+          batteryCount++;
-+
-+          if(batteryCount > 1){
-+             CLog::Log(LOGDEBUG, "LogindUPowerSyscall: More than one system battery found Ignoring");
-+             continue;
-+          }
-+
-+          m_batteryLevel = (int)properties["Percentage"].asDouble();
-+          //WAR: Some devices come up with screwy info for battery and dont seem to update the battery state properly, work around this....
-+          //Connecting charger on such devices fixes this, TODO: add check if charger has been connected before.
-+          if ((properties["State"].asInteger() == 4 || properties["State"].asInteger() == 0) && (int)properties["Percentage"].asDouble() != 100 )
-+            m_batteryState = 2; // Discharging.
-+          else
-+            m_batteryState = properties["State"].asInteger();
- 
-+        }
-+        else
-+        {
-+          //TODO: Deal with other device that show as battery type, and arent PowerSupply's
-+          deviceBatteryCount++;
-+         continue;
-+        }
-+      }
-+      default:
-+        //TODO: Implement more device types for periphereals.
-+
-+        // Skip unspecified Device types
-+        continue;
-+   }
-+  }
-   dbus_free_string_array(source);
- 
++    // WarningLevel: 0=Unknown, 1=None, 2=Discharging (UPS), 3=Low,
++    // 4=Critical, 5=Action. UPower computes this for us based on the
++    // user's UPower.conf thresholds, so we don't need to hard-code 10/15%.
++    const int warningLevel = (int)displayProps["WarningLevel"].asInteger();
++    m_lowBattery = (warningLevel >= 3); // Low or worse
+   }
+-
+-  dbus_free_string_array(source);
+-
 -  if (batteryCount > 0)
-+  if (batteryCount > 0){
-+    CLog::Log(LOGDEBUG, "LogindUPowerSyscall: Battery State: {}", m_batteryState);
-+    hasBattery = true;
-+  }
-+
-+  if(batteryCount > 1)
-+    CLog::Log(LOGDEBUG, "LogindUPowerSyscall: {} Unhandled Device Batteries found", (deviceBatteryCount - 1));
-+
-+  if(deviceBatteryCount > 0) // TODO: Actually do something with this data
-+    CLog::Log(LOGDEBUG, "LogindUPowerSyscall: {} Unhandled Device Batteries found", deviceBatteryCount);
-+
-+  if (chargerCount > 1)
-+    CLog::Log(LOGDEBUG, "LogindUPowerSyscall: {} Unhandled Line Power Supplies found", (chargerCount - 1));
-+
-+  if (hasBattery)
++  else
    {
 -    m_batteryLevel = (int)(batteryLevelSum / (double)batteryCount);
 -    m_lowBattery = CDBusUtil::GetVariant("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower", "OnLowBattery").asBoolean();
-+    CLog::Log(LOGDEBUG, "LogindUPowerSyscall: Battery State: {}", m_batteryState);
-+    if(chargerCount > 0)
-+      CLog::Log(LOGDEBUG, "LogindUPowerSyscall: Line Power Supply Status: {}", m_chargerState);
-+    //Set Low battery level at 15% since upower doesnt calculate this anymore. 
-+    //Other backends that do this use 10%, but not all devices have properly calibrated fuel gages
-+    //So set this a little higher to compinsate. Other backends that dont calculate this hard set to 10% Capacity.
-+    if (m_batteryLevel < 15 && !m_chargerState  == 0)
-+      m_lowBattery = true;
-+    else
-+      m_lowBattery = false;
++    // No system battery -> not low, level 0.
++    m_batteryLevel = 0;
++    m_lowBattery = false;
    }
 +
++  // OnBattery on the daemon is the authoritative "running on battery" flag.
++  m_onBattery =
++      CDBusUtil::GetVariant("org.freedesktop.UPower", "/org/freedesktop/UPower",
++                            "org.freedesktop.UPower", "OnBattery")
++          .asBoolean();
++
++  if (m_displayDevicePresent)
++    CLog::Log(LOGDEBUG,
++              "LogindUPowerSyscall: battery {}%, on_battery={}, warning_level={}, low={}",
++              m_batteryLevel, m_onBattery,
++              (int)displayProps["WarningLevel"].asInteger(), m_lowBattery);
  }
  
  bool CLogindUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
-@@ -257,10 +328,10 @@ bool CLogindUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
+@@ -257,11 +287,16 @@ bool CLogindUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
  
          result = true;
        }
 -      else if (dbus_message_is_signal(msg.get(), "org.freedesktop.UPower", "DeviceChanged"))
-+      else if (dbus_message_is_signal(msg.get(), "org.freedesktop.DBus.Properties", "PropertiesChanged"))
++      else if (dbus_message_is_signal(msg.get(), "org.freedesktop.DBus.Properties",
++                                      "PropertiesChanged"))
        {
-         bool lowBattery = m_lowBattery;
+-        bool lowBattery = m_lowBattery;
 -        UpdateBatteryLevel();
+-        if (m_lowBattery && !lowBattery)
++        // The match rules limit this to either the DisplayDevice or the
++        // UPower daemon path, so any signal here means one of the two
++        // values we care about may have changed. A single call to
++        // UpdatePowerSupplyInfo() refreshes the aggregate.
++        const bool wasLow = m_lowBattery;
 +        UpdatePowerSupplyInfo();
-         if (m_lowBattery && !lowBattery)
++        if (m_lowBattery && !wasLow)
            callback->OnLowBattery();
  
+         result = true;
 diff --git a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.h b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.h
-index 998e706326..6d4d3976da 100644
+index 998e706326..85345fa061 100644
 --- a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.h
 +++ b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.h
-@@ -25,7 +25,7 @@ public:
-   bool CanSuspend() override;
-   bool CanHibernate() override;
-   bool CanReboot() override;
--  int BatteryLevel() override;
-+  int  BatteryLevel() override;
+@@ -29,6 +29,7 @@ public:
    bool PumpPowerEvents(IPowerEventsCallback *callback) override;
    // we don't require UPower because everything except the battery level works fine without it
    static bool HasLogind();
-@@ -37,13 +37,15 @@ private:
++
+ private:
+   CDBusConnection m_connection;
+   bool m_canPowerdown;
+@@ -36,14 +37,21 @@ private:
+   bool m_canHibernate;
    bool m_canReboot;
    bool m_hasUPower;
-   bool m_lowBattery;
+-  bool m_lowBattery;
 -  int m_batteryLevel;
--  int m_delayLockSleepFd = -1; // file descriptor for the logind sleep delay lock
--  int m_delayLockShutdownFd = -1; // file descriptor for the logind powerdown delay lock
++  bool m_lowBattery{false};
++  bool m_onBattery{false}; // mirrors org.freedesktop.UPower.OnBattery
++  bool m_displayDevicePresent{false};
++  int m_batteryLevel{0};
+   int m_delayLockSleepFd = -1; // file descriptor for the logind sleep delay lock
+   int m_delayLockShutdownFd = -1; // file descriptor for the logind powerdown delay lock
 -  void UpdateBatteryLevel();
-+  bool m_chargerState;
-+  int  m_batteryState;
-+  int  m_batteryLevel;
-+  int  m_delayLockSleepFd = -1; // file descriptor for the logind sleep delay lock
-+  int  m_delayLockShutdownFd = -1; // file descriptor for the logind powerdown delay lock
++
++  // Read the aggregate DisplayDevice properties (Percentage, IsPresent,
++  // WarningLevel, ...) and the daemon-level OnBattery property and update
++  // m_batteryLevel / m_lowBattery / m_onBattery / m_displayDevicePresent.
 +  void UpdatePowerSupplyInfo();
++
    void InhibitDelayLockSleep();
-   void InhibitDelayLockShutdown();  
+-  void InhibitDelayLockShutdown();  
 -  int InhibitDelayLock(const char *what);
-+  int  InhibitDelayLock(const char *what);
++  void InhibitDelayLockShutdown();
++  int InhibitDelayLock(const char* what);
    void ReleaseDelayLockSleep();
    void ReleaseDelayLockShutdown();
    void ReleaseDelayLock(int lockFd, const char *what);
--- 
-2.25.1
-

--- a/projects/L4T/devices/Switch/patches/linux/0005-keep-dimensions-display-native-even-if-userspace-att.patch
+++ b/projects/L4T/devices/Switch/patches/linux/0005-keep-dimensions-display-native-even-if-userspace-att.patch
@@ -1,0 +1,73 @@
+From f0a204ec13992d8c39f8624864222d49593e10a2 Mon Sep 17 00:00:00 2001
+From: theofficialgman <28281419+theofficialgman@users.noreply.github.com>
+Date: Sat, 2 May 2026 22:15:15 -0400
+Subject: [PATCH 5/6] keep dimensions display native even if userspace attempts
+ to swap them
+
+userspace may attempt to check or set swapped dimensions due to having the dimensions switched in tegra_fb_modedb.
+
+without this, not working in the display's native dimensions for fb can cause an out of bounds read/write leading to a kernel panic
+Signed-off-by: theofficialgman <dofficialgman@gmail.com>
+---
+ drivers/video/tegra/fb.c | 38 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/drivers/video/tegra/fb.c b/drivers/video/tegra/fb.c
+index b46aa983c..48030fdd1 100644
+--- a/drivers/video/tegra/fb.c
++++ b/drivers/video/tegra/fb.c
+@@ -168,6 +168,25 @@ static int tegra_fb_check_var(struct fb_var_screeninfo *var,
+ 	struct tegra_dc *dc = tegra_fb->win.dc;
+ 	struct tegra_dc_out_ops *ops = dc->out_ops;
+ 	struct fb_videomode mode;
++	u32 tmp;
++
++	if (dc->out && (dc->out->rotation == 90 || dc->out->rotation == 270)) {
++		if (var->xres > var->yres) {
++			/* Swap dimensions back to native if they have been modified by userspace */
++			tmp = var->xres;
++			var->xres = var->yres;
++			var->yres = tmp;
++			tmp = var->left_margin;
++			var->left_margin  = var->upper_margin;
++			var->upper_margin = tmp;
++			tmp = var->right_margin;
++			var->right_margin  = var->lower_margin;
++			var->lower_margin  = tmp;
++			tmp = var->hsync_len;
++			var->hsync_len = var->vsync_len;
++			var->vsync_len = tmp;
++		}
++	}
+ 
+ 	if (tegra_fb->valid &&
+ 		(var->yres * var->xres * var->bits_per_pixel /
+@@ -207,6 +226,25 @@ static int tegra_fb_set_par(struct fb_info *info)
+ 	struct tegra_fb_info *tegra_fb = info->par;
+ 	struct fb_var_screeninfo *var = &info->var;
+ 	struct tegra_dc *dc = tegra_fb->win.dc;
++	u32 tmp;
++
++	if (dc->out && (dc->out->rotation == 90 || dc->out->rotation == 270)) {
++		if (var->xres > var->yres) {
++			/* Swap dimensions back to native if they have been modified by userspace */
++			tmp = var->xres;
++			var->xres = var->yres;
++			var->yres = tmp;
++			tmp = var->left_margin;
++			var->left_margin  = var->upper_margin;
++			var->upper_margin = tmp;
++			tmp = var->right_margin;
++			var->right_margin  = var->lower_margin;
++			var->lower_margin  = tmp;
++			tmp = var->hsync_len;
++			var->hsync_len = var->vsync_len;
++			var->vsync_len = tmp;
++		}
++	}
+ 
+ 	if (var->bits_per_pixel) {
+ 		/* we only support RGB ordering for now */
+-- 
+2.43.0
+

--- a/projects/L4T/devices/Switch/patches/linux/0006-add-fbcon-logging.patch
+++ b/projects/L4T/devices/Switch/patches/linux/0006-add-fbcon-logging.patch
@@ -1,0 +1,29 @@
+From d3c4457d4b2d7c5ba916241baa0ad17a82540829 Mon Sep 17 00:00:00 2001
+From: theofficialgman <28281419+theofficialgman@users.noreply.github.com>
+Date: Mon, 27 Apr 2026 23:18:54 -0400
+Subject: [PATCH 1/2] add fbcon logging
+
+---
+ drivers/video/console/fbcon.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/video/console/fbcon.c b/drivers/video/console/fbcon.c
+index 275d9a61836c..9a610109f83f 100644
+--- a/drivers/video/console/fbcon.c
++++ b/drivers/video/console/fbcon.c
+@@ -1007,9 +1007,9 @@ static const char *fbcon_startup(void)
+ 	rows /= vc->vc_font.height;
+ 	vc_resize(vc, cols, rows);
+ 
+-	DPRINTK("mode:   %s\n", info->fix.id);
+-	DPRINTK("visual: %d\n", info->fix.visual);
+-	DPRINTK("res:    %dx%d-%d\n", info->var.xres,
++	pr_warn("mode:   %s\n", info->fix.id);
++	pr_warn("visual: %d\n", info->fix.visual);
++	pr_warn("res:    %dx%d-%d\n", info->var.xres,
+ 		info->var.yres,
+ 		info->var.bits_per_pixel);
+ 
+-- 
+2.43.0
+

--- a/projects/L4T/devices/Switch/patches/linux/0007-add-fbmem-logging.patch
+++ b/projects/L4T/devices/Switch/patches/linux/0007-add-fbmem-logging.patch
@@ -1,0 +1,38 @@
+From 604bd4ccc0020c0f509d8307a6401bec66ea81e4 Mon Sep 17 00:00:00 2001
+From: theofficialgman <28281419+theofficialgman@users.noreply.github.com>
+Date: Sat, 2 May 2026 10:04:43 -0400
+Subject: [PATCH 2/2] add fbmem logging
+
+---
+ drivers/video/fbdev/core/fbmem.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/video/fbdev/core/fbmem.c b/drivers/video/fbdev/core/fbmem.c
+index 5cec93e3f3cf..0e0197dd4c26 100644
+--- a/drivers/video/fbdev/core/fbmem.c
++++ b/drivers/video/fbdev/core/fbmem.c
+@@ -1113,6 +1113,10 @@ static long do_fb_ioctl(struct fb_info *info, unsigned int cmd,
+ 		var = info->var;
+ 		unlock_fb_info(info);
+ 
++		pr_info("[fbmem] FBIOGET_VSCREENINFO from '%s' on fb%d: xres=%u yres=%u bpp=%u pixclock=%u\n",
++			current->comm, info->node,
++			var.xres, var.yres, var.bits_per_pixel, var.pixclock);
++
+ 		ret = copy_to_user(argp, &var, sizeof(var)) ? -EFAULT : 0;
+ 		break;
+ 	case FBIOPUT_VSCREENINFO:
+@@ -1137,6 +1141,10 @@ static long do_fb_ioctl(struct fb_info *info, unsigned int cmd,
+ 		fix = info->fix;
+ 		unlock_fb_info(info);
+ 
++		pr_info("[fbmem] FBIOGET_FSCREENINFO from '%s' on fb%d: id='%s' line_length=%u smem_len=%u\n",
++			current->comm, info->node,
++			fix.id, fix.line_length, fix.smem_len);
++
+ 		ret = copy_to_user(argp, &fix, sizeof(fix)) ? -EFAULT : 0;
+ 		break;
+ 	case FBIOPUTCMAP:
+-- 
+2.43.0
+

--- a/projects/L4T/devices/Switch/patches/linux/0008-Add-support-for-rotated-embedded-DSI-displays-and-ro.patch
+++ b/projects/L4T/devices/Switch/patches/linux/0008-Add-support-for-rotated-embedded-DSI-displays-and-ro.patch
@@ -1,0 +1,154 @@
+From fd35a0c4d950d853eb2e02ca5b6835ae0be87f0e Mon Sep 17 00:00:00 2001
+From: theofficialgman <28281419+theofficialgman@users.noreply.github.com>
+Date: Mon, 20 Apr 2026 18:22:48 -0400
+Subject: [PATCH 1/6] Add support for rotated embedded DSI displays and rotate
+ in hardware
+
+Rotates the DSI panel based the orientation of the display set in the device tree (nvidia,out-rotation).
+Uses the display controller to rotate the framebuffer in hardware.
+Presents the panel as a normal display to Xorg, so that no changes are needed in userspace to support the rotated panel.
+
+Assisted-by: Claude:claude-sonnet-4-6
+Signed-off-by: theofficialgman <dofficialgman@gmail.com>
+---
+ drivers/video/tegra/dc/ext/dev.c | 73 ++++++++++++++++++++++++++++----
+ drivers/video/tegra/fb.c         | 17 ++++++++
+ 2 files changed, 81 insertions(+), 9 deletions(-)
+
+diff --git a/nvidia/drivers/video/tegra/dc/ext/dev.c b/nvidia/drivers/video/tegra/dc/ext/dev.c
+index f52472a05..d1612bcc1 100644
+--- a/nvidia/drivers/video/tegra/dc/ext/dev.c
++++ b/nvidia/drivers/video/tegra/dc/ext/dev.c
+@@ -429,6 +429,16 @@ fail:
+ 	return -EINVAL;
+ }
+ 
++static u32 tegra_dc_rotation_to_win_flags(unsigned rotation)
++{
++	switch (rotation) {
++	case 90:  return TEGRA_WIN_FLAG_SCAN_COLUMN | TEGRA_WIN_FLAG_INVERT_H;
++	case 180: return TEGRA_WIN_FLAG_INVERT_H | TEGRA_WIN_FLAG_INVERT_V;
++	case 270: return TEGRA_WIN_FLAG_SCAN_COLUMN | TEGRA_WIN_FLAG_INVERT_V;
++	default:  return 0;
++	}
++}
++
+ static void tegra_dc_ext_set_windowattr_basic(struct tegra_dc_win *win,
+ 		       const struct tegra_dc_ext_flip_windowattr *flip_win)
+ {
+@@ -540,6 +550,30 @@ static int tegra_dc_ext_set_windowattr(struct tegra_dc_ext *ext,
+ 
+ 	tegra_dc_ext_set_windowattr_basic(win, &flip_win->attr);
+ 
++	/* Force hardware rotation from dc->out->rotation, overriding userspace */
++	if (ext->dc->out) {
++		u32 rot_flags =
++			tegra_dc_rotation_to_win_flags(ext->dc->out->rotation);
++		if (rot_flags) {
++			win->flags &= ~(TEGRA_WIN_FLAG_INVERT_H |
++					TEGRA_WIN_FLAG_INVERT_V |
++					TEGRA_WIN_FLAG_SCAN_COLUMN);
++			win->flags |= rot_flags;
++			if (ext->dc->out->rotation == 90 ||
++			    ext->dc->out->rotation == 270) {
++				/* Hardware always needs portrait physical coords.
++				 * If userspace sent landscape dims (out_w > out_h,
++				 * e.g. 1280x720), swap to portrait (720x1280).
++				 * If already portrait (out_w=720, out_h=1280), no swap. */
++				if (win->out_w > win->out_h) {
++					u32 tmp = win->out_w;
++					win->out_w = win->out_h;
++					win->out_h = tmp;
++				}
++			}
++		}
++	}
++
+ 	memcpy(ext_win->cur_handle, flip_win->handle,
+ 	       sizeof(ext_win->cur_handle));
+ 
+@@ -1437,16 +1471,37 @@ static int sanitize_flip_args(struct tegra_dc_ext_user *user,
+ 
+ 		/*
+ 		 * Window output geometry including width/height + offset
+-		 * should not exceed hActive/vActive of current mode
++		 * should not exceed hActive/vActive of current mode.
++		 * For 90/270° rotated panels, userspace may send either portrait
++		 * dims (if it reads DC hardware, rasterSize=720x1280) or landscape
++		 * dims (if it reads FBIOGET_VSCREENINFO, rasterSize=1280x720).
++		 * Accept whichever fits; set_windowattr will translate to portrait.
+ 		 */
+-		if ((win->out_w + win->out_x) > dc->mode.h_active ||
+-			(win->out_h + win->out_y) > dc->mode.v_active) {
+-
+-			dev_err(&dc->ndev->dev,
+-			"Invalid out_w + out_x (%u) > hActive (%u)\n OR/AND out_h + out_y (%u) > vActive (%u)\n for WIN %d\n",
+-				win->out_w + win->out_x, dc->mode.h_active,
+-				win->out_h + win->out_y, dc->mode.v_active, i);
+-			return -EINVAL;
++		if (dc->out && (dc->out->rotation == 90 ||
++				dc->out->rotation == 270)) {
++			bool portrait_valid =
++				(win->out_w + win->out_x) <= dc->mode.h_active &&
++				(win->out_h + win->out_y) <= dc->mode.v_active;
++			bool landscape_valid =
++				(win->out_w + win->out_x) <= dc->mode.v_active &&
++				(win->out_h + win->out_y) <= dc->mode.h_active;
++			if (!portrait_valid && !landscape_valid) {
++				dev_err(&dc->ndev->dev,
++				"Invalid out_w+out_x (%u) out_h+out_y (%u) vs hActive (%u) vActive (%u) for WIN %d\n",
++					win->out_w + win->out_x,
++					win->out_h + win->out_y,
++					dc->mode.h_active, dc->mode.v_active, i);
++				return -EINVAL;
++			}
++		} else {
++			if ((win->out_w + win->out_x) > dc->mode.h_active ||
++				(win->out_h + win->out_y) > dc->mode.v_active) {
++				dev_err(&dc->ndev->dev,
++				"Invalid out_w + out_x (%u) > hActive (%u)\n OR/AND out_h + out_y (%u) > vActive (%u)\n for WIN %d\n",
++					win->out_w + win->out_x, dc->mode.h_active,
++					win->out_h + win->out_y, dc->mode.v_active, i);
++				return -EINVAL;
++			}
+ 		}
+ 
+ 		if (tegra_dc_is_nvdisplay()) {
+diff --git a/nvidia/drivers/video/tegra/fb.c b/nvidia/drivers/video/tegra/fb.c
+index fb840831a..b46aa983c 100644
+--- a/nvidia/drivers/video/tegra/fb.c
++++ b/nvidia/drivers/video/tegra/fb.c
+@@ -638,6 +638,7 @@ static int tegra_get_modedb(struct tegra_dc *dc, struct tegra_fb_modedb *modedb,
+ 
+ 	list_for_each_entry(modelist, &info->modelist, list) {
+ 		struct fb_var_screeninfo var;
++		u32 tmp;
+ 
+ 		/* fb_videomode_to_var doesn't fill out all the members
+ 		   of fb_var_screeninfo */
+@@ -646,6 +647,22 @@ static int tegra_get_modedb(struct tegra_dc *dc, struct tegra_fb_modedb *modedb,
+ 		fb_videomode_to_var(&var, &modelist->mode);
+ 		var.width = tegra_dc_get_out_width(dc);
+ 		var.height = tegra_dc_get_out_height(dc);
++		if (dc->out && (dc->out->rotation == 90 || dc->out->rotation == 270)) {
++			/* Swap h/v blanking so refresh rate computes correctly for
++			* landscape dims: htotal uses vblanking, vtotal uses hblanking. */
++			tmp = var.xres;
++			var.xres = var.yres;
++			var.yres = tmp;
++			tmp = var.left_margin;
++			var.left_margin  = var.upper_margin;
++			var.upper_margin = tmp;
++			tmp = var.right_margin;
++			var.right_margin  = var.lower_margin;
++			var.lower_margin  = tmp;
++			tmp = var.hsync_len;
++			var.hsync_len = var.vsync_len;
++			var.vsync_len = tmp;
++		}
+ 		var.bits_per_pixel = dc->pdata->fb->bits_per_pixel;
+ 		if (i < modedb->modedb_len) {
+ 			void __user *ptr = &modedb_ptr[i];
+-- 
+2.43.0
+

--- a/projects/L4T/devices/Switch/patches/linux/0009-add-cursor-position-rotation-support.patch
+++ b/projects/L4T/devices/Switch/patches/linux/0009-add-cursor-position-rotation-support.patch
@@ -1,0 +1,49 @@
+From da39344c20623ad4910e8fe692e110165d6f0303 Mon Sep 17 00:00:00 2001
+From: theofficialgman <28281419+theofficialgman@users.noreply.github.com>
+Date: Wed, 22 Apr 2026 18:19:38 -0400
+Subject: [PATCH 2/6] add cursor position rotation support
+
+Assisted-by: Claude:claude-sonnet-4-6
+Signed-off-by: theofficialgman <dofficialgman@gmail.com>
+---
+ drivers/video/tegra/dc/ext/cursor.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/video/tegra/dc/ext/cursor.c b/drivers/video/tegra/dc/ext/cursor.c
+index 8e5fbb7d9..1de51c066 100644
+--- a/nvidia/drivers/video/tegra/dc/ext/cursor.c
++++ b/nvidia/drivers/video/tegra/dc/ext/cursor.c
+@@ -209,7 +209,29 @@ int tegra_dc_ext_set_cursor(struct tegra_dc_ext_user *user,
+ 
+ 	tegra_dc_scrncapt_disp_pause_lock(dc);
+ 
+-	ret = tegra_dc_cursor_set(dc, enable, args->x, args->y);
++	{
++		int phys_x = args->x;
++		int phys_y = args->y;
++
++		if (dc->out) {
++			switch (dc->out->rotation) {
++			case 90:
++				phys_x = args->y;
++				phys_y = (int)dc->mode.v_active - 1 - args->x;
++				break;
++			case 180:
++				phys_x = (int)dc->mode.h_active - 1 - args->x;
++				phys_y = (int)dc->mode.v_active - 1 - args->y;
++				break;
++			case 270:
++				phys_x = (int)dc->mode.h_active - 1 - args->y;
++				phys_y = args->x;
++				break;
++			}
++		}
++
++		ret = tegra_dc_cursor_set(dc, enable, phys_x, phys_y);
++	}
+ 
+ 	tegra_dc_scrncapt_disp_pause_unlock(dc);
+ 	mutex_unlock(&ext->cursor.lock);
+-- 
+2.43.0
+

--- a/projects/L4T/devices/Switch/patches/linux/0010-add-cursor-bitmap-rotation-support.patch
+++ b/projects/L4T/devices/Switch/patches/linux/0010-add-cursor-bitmap-rotation-support.patch
@@ -1,0 +1,341 @@
+From a0c6cd40cc634f9cb502d291142c307ac630f079 Mon Sep 17 00:00:00 2001
+From: theofficialgman <28281419+theofficialgman@users.noreply.github.com>
+Date: Fri, 24 Apr 2026 18:07:39 -0400
+Subject: [PATCH 3/6] add cursor bitmap rotation support
+
+Assisted-by: Claude:claude-sonnet-4-6
+Signed-off-by: theofficialgman <dofficialgman@gmail.com>
+---
+ drivers/video/tegra/dc/ext/cursor.c           | 219 ++++++++++++++++--
+ drivers/video/tegra/dc/ext/dev.c              |   2 +
+ .../video/tegra/dc/ext/tegra_dc_ext_priv.h    |   5 +
+ 3 files changed, 207 insertions(+), 19 deletions(-)
+
+diff --git a/nvidia/drivers/video/tegra/dc/ext/cursor.c b/nvidia/drivers/video/tegra/dc/ext/cursor.c
+index 1de51c066..b5246f52f 100644
+--- a/nvidia/drivers/video/tegra/dc/ext/cursor.c
++++ b/nvidia/drivers/video/tegra/dc/ext/cursor.c
+@@ -16,6 +16,7 @@
+  * more details.
+  */
+ 
++#include <linux/dma-buf.h>
+ #include <uapi/video/tegra_dc_ext.h>
+ #include "tegra_dc_ext_priv.h"
+ 
+@@ -24,6 +25,82 @@
+ #include "../dc_priv.h"
+ #include "../dc_reg.h"
+ 
++static size_t cursor_buf_size(unsigned int n, enum CURSOR_COLOR_FORMAT colorfmt)
++{
++	if (colorfmt == a1r5g5b5)
++		return (size_t)n * n * 2;
++	/* legacy, r8g8b8a8, a8r8g8b8 — all 32bpp in hardware */
++	return (size_t)n * n * 4;
++}
++
++/*
++ * Rotate an N×N cursor bitmap to match the display rotation, reading from
++ * the unmodified user buffer (src) and writing into a DMA-coherent output
++ * buffer (dst).  Never touches the user buffer after reading it.
++ *
++ * Rotation angles match dc->out->rotation:
++ *   90  → 90° CCW  (bottom-left of original goes to top-left of output)
++ *   180 → 180°
++ *   270 → 90° CW   (top-right of original goes to top-left of output)
++ */
++static void tegra_dc_ext_rotate_cursor(const void *src, void *dst,
++				       unsigned int n,
++				       enum CURSOR_COLOR_FORMAT colorfmt,
++				       int rotation)
++{
++	unsigned int r, c;
++	size_t sz = cursor_buf_size(n, colorfmt);
++
++#define ROTATE_PIXELS(type)						\
++	do {								\
++		const type *s = src;					\
++		type *d = dst;						\
++		switch (rotation) {					\
++		case 90: /* CCW */					\
++			for (r = 0; r < n; r++)				\
++				for (c = 0; c < n; c++)			\
++					d[(n-1-c)*n + r] = s[r*n + c]; \
++			break;						\
++		case 180:						\
++			for (r = 0; r < n; r++)				\
++				for (c = 0; c < n; c++)			\
++					d[(n-1-r)*n + (n-1-c)] = s[r*n + c]; \
++			break;						\
++		case 270: /* CW */					\
++			for (r = 0; r < n; r++)				\
++				for (c = 0; c < n; c++)			\
++					d[c*n + (n-1-r)] = s[r*n + c]; \
++			break;						\
++		default:						\
++			memcpy(d, s, sz);				\
++			break;						\
++		}							\
++	} while (0)
++
++	switch (colorfmt) {
++	case legacy:
++	case r8g8b8a8:
++	case a8r8g8b8:
++		ROTATE_PIXELS(u32);
++		break;
++	case a1r5g5b5:
++		ROTATE_PIXELS(u16);
++		break;
++	}
++#undef ROTATE_PIXELS
++}
++
++void tegra_dc_ext_cursor_cleanup(struct tegra_dc_ext *ext)
++{
++	if (ext->cursor.rot_vaddr) {
++		dma_free_coherent(&ext->dc->ndev->dev, ext->cursor.rot_size,
++				  ext->cursor.rot_vaddr, ext->cursor.rot_dma);
++		ext->cursor.rot_vaddr = NULL;
++		ext->cursor.rot_dma   = 0;
++		ext->cursor.rot_size  = 0;
++	}
++}
++
+ int tegra_dc_ext_get_cursor(struct tegra_dc_ext_user *user)
+ {
+ 	struct tegra_dc_ext *ext = user->ext;
+@@ -78,19 +155,24 @@ int tegra_dc_ext_set_cursor_image(struct tegra_dc_ext_user *user,
+ 	enum tegra_dc_cursor_size size;
+ 	enum tegra_dc_cursor_blend_format blendfmt;
+ 	enum CURSOR_COLOR_FORMAT colorfmt;
++	unsigned int cursor_n;
+ 
+ 	switch (extsize) {
+ 	case TEGRA_DC_EXT_CURSOR_IMAGE_FLAGS_SIZE_32x32:
+ 		size = TEGRA_DC_CURSOR_SIZE_32X32;
++		cursor_n = 32;
+ 		break;
+ 	case TEGRA_DC_EXT_CURSOR_IMAGE_FLAGS_SIZE_64x64:
+ 		size = TEGRA_DC_CURSOR_SIZE_64X64;
++		cursor_n = 64;
+ 		break;
+ 	case TEGRA_DC_EXT_CURSOR_IMAGE_FLAGS_SIZE_128x128:
+ 		size = TEGRA_DC_CURSOR_SIZE_128X128;
++		cursor_n = 128;
+ 		break;
+ 	case TEGRA_DC_EXT_CURSOR_IMAGE_FLAGS_SIZE_256x256:
+ 		size = TEGRA_DC_CURSOR_SIZE_256X256;
++		cursor_n = 256;
+ 		break;
+ 	default:
+ 		return -EINVAL;
+@@ -147,25 +229,93 @@ int tegra_dc_ext_set_cursor_image(struct tegra_dc_ext_user *user,
+ 	if (ret)
+ 		goto unlock;
+ 
+-	tegra_dc_scrncapt_disp_pause_lock(dc);
++	/*
++	 * Rotate cursor bitmap to match the display rotation.  A persistent
++	 * DMA-coherent scratch buffer is used so the user buffer is never
++	 * modified — re-reading the original data each call means repeated
++	 * set_cursor_image calls on the same buffer don't accumulate rotations.
++	 */
++	{
++		int display_rotation = (dc->out) ? dc->out->rotation : 0;
++		size_t rot_sz = cursor_buf_size(cursor_n, colorfmt);
++		struct device *dma_dev = &dc->ndev->dev;
++		dma_addr_t hw_phys = phys_addr; /* fallback if rotation fails */
++
++		if (display_rotation != 0) {
++			if (ext->cursor.rot_size < rot_sz) {
++				if (ext->cursor.rot_vaddr)
++					dma_free_coherent(dma_dev,
++							  ext->cursor.rot_size,
++							  ext->cursor.rot_vaddr,
++							  ext->cursor.rot_dma);
++				ext->cursor.rot_vaddr =
++					dma_alloc_coherent(dma_dev, rot_sz,
++							   &ext->cursor.rot_dma,
++							   GFP_KERNEL);
++				ext->cursor.rot_size =
++					ext->cursor.rot_vaddr ? rot_sz : 0;
++				if (!ext->cursor.rot_vaddr)
++					dev_warn(dma_dev,
++						 "cursor: alloc %zu byte rot buf failed\n",
++						 rot_sz);
++			}
+ 
+-	ext->cursor.cur_handle = handle;
+-	ret = tegra_dc_cursor_image(dc, blendfmt, size, fg, bg, phys_addr,
+-				colorfmt, args->alpha, args->flags,
+-				!!old_handle);
++			if (ext->cursor.rot_vaddr) {
++				int cret = dma_buf_begin_cpu_access(
++						handle->buf, 0, rot_sz,
++						DMA_BIDIRECTIONAL);
++				if (!cret) {
++					void *uva = dma_buf_vmap(handle->buf);
++
++					if (uva) {
++						tegra_dc_ext_rotate_cursor(
++							uva,
++							ext->cursor.rot_vaddr,
++							cursor_n, colorfmt,
++							display_rotation);
++						dma_buf_vunmap(handle->buf, uva);
++						hw_phys = ext->cursor.rot_dma;
++						dev_dbg(dma_dev,
++							 "cursor rotate: %ddeg n=%u fmt=%d sz=%zu\n",
++							 display_rotation,
++							 cursor_n,
++							 (int)colorfmt,
++							 rot_sz);
++					} else {
++						dev_warn(dma_dev,
++							 "cursor rotate: vmap failed\n");
++					}
++					dma_buf_end_cpu_access(handle->buf, 0,
++							       rot_sz,
++							       DMA_BIDIRECTIONAL);
++				} else {
++					dev_warn(dma_dev,
++						 "cursor rotate: begin_cpu_access failed: %d\n",
++						 cret);
++				}
++			}
++		}
+ 
+-	tegra_dc_scrncapt_disp_pause_unlock(dc);
+-	mutex_unlock(&ext->cursor.lock);
++		tegra_dc_scrncapt_disp_pause_lock(dc);
+ 
+-	if (old_handle) {
+-		dma_buf_unmap_attachment(old_handle->attach,
+-			old_handle->sgt, DMA_TO_DEVICE);
+-		dma_buf_detach(old_handle->buf, old_handle->attach);
+-		dma_buf_put(old_handle->buf);
+-		kfree(old_handle);
+-	}
++		ext->cursor.cur_handle = handle;
++		ret = tegra_dc_cursor_image(dc, blendfmt, size, fg, bg, hw_phys,
++					    colorfmt, args->alpha, args->flags,
++					    !!old_handle);
+ 
+-	return ret;
++		tegra_dc_scrncapt_disp_pause_unlock(dc);
++		mutex_unlock(&ext->cursor.lock);
++
++		if (old_handle) {
++			dma_buf_unmap_attachment(old_handle->attach,
++				old_handle->sgt, DMA_TO_DEVICE);
++			dma_buf_detach(old_handle->buf, old_handle->attach);
++			dma_buf_put(old_handle->buf);
++			kfree(old_handle);
++		}
++
++		return ret;
++	}
+ 
+ unlock:
+ 	mutex_unlock(&ext->cursor.lock);
+@@ -212,24 +362,55 @@ int tegra_dc_ext_set_cursor(struct tegra_dc_ext_user *user,
+ 	{
+ 		int phys_x = args->x;
+ 		int phys_y = args->y;
++		int cursor_n;
++
++		switch (dc->cursor.size) {
++		case TEGRA_DC_CURSOR_SIZE_32X32:   cursor_n = 32;  break;
++		case TEGRA_DC_CURSOR_SIZE_64X64:   cursor_n = 64;  break;
++		case TEGRA_DC_CURSOR_SIZE_128X128: cursor_n = 128; break;
++		case TEGRA_DC_CURSOR_SIZE_256X256: cursor_n = 256; break;
++		default:                           cursor_n = 0;   break;
++		}
+ 
+ 		if (dc->out) {
+ 			switch (dc->out->rotation) {
+ 			case 90:
++				/*
++				 * Bitmap rotated 90deg CCW: original top-left
++				 * hot-spot moves to bottom-left of rotated bitmap.
++				 * Correct: pull phys_y back by (n-1).
++				 */
+ 				phys_x = args->y;
+-				phys_y = (int)dc->mode.v_active - 1 - args->x;
++				phys_y = (int)dc->mode.v_active - 1 - args->x
++					 - (cursor_n - 1);
+ 				break;
+ 			case 180:
+-				phys_x = (int)dc->mode.h_active - 1 - args->x;
+-				phys_y = (int)dc->mode.v_active - 1 - args->y;
++				/*
++				 * Bitmap rotated 180deg: hot-spot moves to
++				 * bottom-right.  Correct both axes.
++				 */
++				phys_x = (int)dc->mode.h_active - 1 - args->x
++					 - (cursor_n - 1);
++				phys_y = (int)dc->mode.v_active - 1 - args->y
++					 - (cursor_n - 1);
+ 				break;
+ 			case 270:
+-				phys_x = (int)dc->mode.h_active - 1 - args->y;
++				/*
++				 * Bitmap rotated 90deg CW: hot-spot moves to
++				 * top-right of rotated bitmap.  Correct phys_x.
++				 */
++				phys_x = (int)dc->mode.h_active - 1 - args->y
++					 - (cursor_n - 1);
+ 				phys_y = args->x;
+ 				break;
+ 			}
+ 		}
+ 
++		dev_dbg(&dc->ndev->dev,
++			 "cursor set: logical=(%d,%d) phys=(%d,%d) n=%d rot=%d\n",
++			 args->x, args->y, phys_x, phys_y, cursor_n,
++			 dc->out ? dc->out->rotation : 0);
++
+ 		ret = tegra_dc_cursor_set(dc, enable, phys_x, phys_y);
+ 	}
+ 
+diff --git a/nvidia/drivers/video/tegra/dc/ext/dev.c b/nvidia/drivers/video/tegra/dc/ext/dev.c
+index d1612bcc1..0c4d28ce1 100644
+--- a/nvidia/drivers/video/tegra/dc/ext/dev.c
++++ b/nvidia/drivers/video/tegra/dc/ext/dev.c
+@@ -3909,6 +3909,8 @@ void tegra_dc_ext_unregister(struct tegra_dc_ext *ext)
+ {
+ 	int i;
+ 
++	tegra_dc_ext_cursor_cleanup(ext);
++
+ 	for (i = 0; i < ext->dc->n_windows; i++) {
+ 		struct tegra_dc_ext_win *win = &ext->win[i];
+ 
+diff --git a/nvidia/drivers/video/tegra/dc/ext/tegra_dc_ext_priv.h b/nvidia/drivers/video/tegra/dc/ext/tegra_dc_ext_priv.h
+index 017e86eac..120052d6b 100644
+--- a/nvidia/drivers/video/tegra/dc/ext/tegra_dc_ext_priv.h
++++ b/nvidia/drivers/video/tegra/dc/ext/tegra_dc_ext_priv.h
+@@ -84,6 +84,10 @@ struct tegra_dc_ext {
+ 	struct {
+ 		struct tegra_dc_ext_user	*user;
+ 		struct tegra_dc_dmabuf		*cur_handle;
++		/* DMA-coherent scratch buffer for the rotated cursor bitmap */
++		void				*rot_vaddr;
++		dma_addr_t			rot_dma;
++		size_t				rot_size;
+ 		struct mutex			lock;
+ 	} cursor;
+ 
+@@ -153,6 +157,7 @@ extern int tegra_dc_ext_cpy_caps_from_user(void __user *user_arg,
+ 				struct tegra_dc_ext_caps **caps_ptr,
+ 				u32 *nr_elements_ptr);
+ 
++extern void tegra_dc_ext_cursor_cleanup(struct tegra_dc_ext *ext);
+ extern int tegra_dc_ext_get_cursor(struct tegra_dc_ext_user *user);
+ extern int tegra_dc_ext_put_cursor(struct tegra_dc_ext_user *user);
+ extern int tegra_dc_ext_set_cursor_image(struct tegra_dc_ext_user *user,
+-- 
+2.43.0
+

--- a/projects/L4T/devices/Switch/patches/linux/0011-potentially-avoid-a-diagnonal-tear-when-rotating.patch
+++ b/projects/L4T/devices/Switch/patches/linux/0011-potentially-avoid-a-diagnonal-tear-when-rotating.patch
@@ -1,0 +1,31 @@
+From 44d01b7c6ebbad19df71b8f162b16eab8c5c70bc Mon Sep 17 00:00:00 2001
+From: theofficialgman <28281419+theofficialgman@users.noreply.github.com>
+Date: Sat, 25 Apr 2026 09:36:56 -0400
+Subject: [PATCH 4/6] potentially avoid a diagnonal tear when rotating
+
+Assisted-by: Claude:claude-sonnet-4-6
+Signed-off-by: theofficialgman <dofficialgman@gmail.com>
+---
+ drivers/video/tegra/dc/window.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/nvidia/drivers/video/tegra/dc/window.c b/nvidia/drivers/video/tegra/dc/window.c
+index 399bc81ff..e0d652eb0 100644
+--- a/nvidia/drivers/video/tegra/dc/window.c
++++ b/nvidia/drivers/video/tegra/dc/window.c
+@@ -449,6 +449,12 @@ static inline void __maybe_unused tegra_dc_update_scaling(
+ bool  update_is_hsync_safe(struct tegra_dc_win *cur_win,
+ 			   struct tegra_dc_win *new_win)
+ {
++	/* SCAN_COLUMN reads memory in column-major order. A buffer address
++	 * change mid-column produces a diagonal tear in landscape-user space,
++	 * so treat every SCAN_COLUMN flip as requiring a full vblank. */
++	if ((cur_win->flags | new_win->flags) & TEGRA_WIN_FLAG_SCAN_COLUMN)
++		return false;
++
+ 	return ((cur_win->fmt == new_win->fmt) &&
+ 		(cur_win->flags == new_win->flags) &&
+ 		(dfixed_trunc(cur_win->x) == dfixed_trunc(new_win->x)) &&
+-- 
+2.43.0
+

--- a/projects/L4T/devices/Switch/patches/linux/0012-add-tegra-dc-and-fb-logging.patch
+++ b/projects/L4T/devices/Switch/patches/linux/0012-add-tegra-dc-and-fb-logging.patch
@@ -1,0 +1,138 @@
+From dc8b23708fe1328d7dfe264f125ab14d59b5f282 Mon Sep 17 00:00:00 2001
+From: theofficialgman <28281419+theofficialgman@users.noreply.github.com>
+Date: Sat, 2 May 2026 10:33:10 -0400
+Subject: [PATCH 6/6] add tegra dc and fb logging
+
+Assisted-by: Claude:claude-sonnet-4-6
+Signed-off-by: theofficialgman <dofficialgman@gmail.com>
+---
+ drivers/video/tegra/dc/ext/dev.c | 31 ++++++++++++++++++++++++++++++
+ drivers/video/tegra/fb.c         | 33 ++++++++++++++++++++++++++++++++
+ 2 files changed, 64 insertions(+)
+
+diff --git a/nvidia/drivers/video/tegra/dc/ext/dev.c b/nvidia/drivers/video/tegra/dc/ext/dev.c
+index 0c4d28ce1..d6f44ea9e 100644
+--- a/nvidia/drivers/video/tegra/dc/ext/dev.c
++++ b/nvidia/drivers/video/tegra/dc/ext/dev.c
+@@ -2931,8 +2931,39 @@ static long tegra_dc_ioctl(struct file *filp, unsigned int cmd,
+ {
+ 	void __user *user_arg = (void __user *)arg;
+ 	struct tegra_dc_ext_user *user = filp->private_data;
++	struct tegra_dc *_log_dc = user->ext->dc;
+ 	int ret;
+ 
++	/* Log every ioctl that reads display state so we can see what
++	 * userspace (e.g. the NVIDIA Xorg driver) is querying. */
++	switch (cmd) {
++	case TEGRA_DC_EXT_GET_WINDOW:
++	case TEGRA_DC_EXT_GET_WINMASK:
++	case TEGRA_DC_EXT_GET_VBLANK_SYNCPT:
++	case TEGRA_DC_EXT_GET_STATUS:
++	case TEGRA_DC_EXT_GET_CMU:
++	case TEGRA_DC_EXT_GET_CUSTOM_CMU:
++	case TEGRA_DC_EXT_GET_CMU_ADBRGB:
++	case TEGRA_DC_EXT_GET_NVDISP_CMU:
++	case TEGRA_DC_EXT_GET_CUSTOM_NVDISP_CMU:
++	case TEGRA_DC_EXT_GET_IMP_USER_INFO:
++	case TEGRA_DC_EXT_GET_CAP_INFO:
++	case TEGRA_DC_EXT_GET_SCANLINE:
++		dev_info(&_log_dc->ndev->dev,
++			"[tegra-dc-ext] GET ioctl 0x%x from '%s' on DC%d (enabled=%d mode=%dx%d)\n",
++			cmd, current->comm, _log_dc->ctrl_num,
++			_log_dc->enabled,
++			_log_dc->mode.h_active, _log_dc->mode.v_active);
++		break;
++	case TEGRA_DC_EXT_GET_CURSOR:
++		dev_info(&_log_dc->ndev->dev,
++			"[tegra-dc-ext] GET_CURSOR from '%s' on DC%d\n",
++			current->comm, _log_dc->ctrl_num);
++		break;
++	default:
++		break;
++	}
++
+ 	switch (cmd) {
+ 	case TEGRA_DC_EXT_SET_NVMAP_FD:
+ 		return 0;
+diff --git a/nvidia/drivers/video/tegra/fb.c b/nvidia/drivers/video/tegra/fb.c
+index 48030fdd1..7f6dde044 100644
+--- a/nvidia/drivers/video/tegra/fb.c
++++ b/nvidia/drivers/video/tegra/fb.c
+@@ -188,6 +188,11 @@ static int tegra_fb_check_var(struct fb_var_screeninfo *var,
+ 		}
+ 	}
+ 
++	dev_info(&tegra_fb->ndev->dev,
++		"[tegra-fb] check_var from '%s': xres=%u yres=%u bpp=%u pixclock=%u rotation=%d\n",
++		current->comm, var->xres, var->yres, var->bits_per_pixel,
++		var->pixclock, dc->out ? dc->out->rotation : 0);
++
+ 	if (tegra_fb->valid &&
+ 		(var->yres * var->xres * var->bits_per_pixel /
+ 		 8 * FB_BUFFERING_FACTOR) > info->screen_size) {
+@@ -246,6 +251,11 @@ static int tegra_fb_set_par(struct fb_info *info)
+ 		}
+ 	}
+ 
++	dev_info(&tegra_fb->ndev->dev,
++		"[tegra-fb] set_par from '%s': xres=%u yres=%u bpp=%u pixclock=%u\n",
++		current->comm, var->xres, var->yres,
++		var->bits_per_pixel, var->pixclock);
++
+ 	if (var->bits_per_pixel) {
+ 		/* we only support RGB ordering for now */
+ 		switch (var->bits_per_pixel) {
+@@ -651,6 +661,10 @@ static int tegra_get_modedb(struct tegra_dc *dc, struct tegra_fb_modedb *modedb,
+ 	struct fb_var_screeninfo __user *modedb_ptr = NULL;
+ 	struct fb_modelist *modelist = NULL;
+ 
++	dev_info(&dc->ndev->dev,
++		"[tegra-fb] FBIO_TEGRA_GET_MODEDB from '%s': requested_len=%u\n",
++		current->comm, modedb->modedb_len);
++
+ 	i = 0;
+ 
+ 	if (list_empty(&info->modelist)) {
+@@ -702,6 +716,10 @@ static int tegra_get_modedb(struct tegra_dc *dc, struct tegra_fb_modedb *modedb,
+ 			var.vsync_len = tmp;
+ 		}
+ 		var.bits_per_pixel = dc->pdata->fb->bits_per_pixel;
++		dev_info(&dc->ndev->dev,
++			"[tegra-fb] modedb[%u]: %ux%u@%u pixclock=%u\n",
++			i, var.xres, var.yres, modelist->mode.refresh,
++			var.pixclock);
+ 		if (i < modedb->modedb_len) {
+ 			void __user *ptr = &modedb_ptr[i];
+ 
+@@ -736,6 +754,9 @@ static int tegra_fb_ioctl(struct fb_info *info,
+ 	struct tegra_fb_modedb __user modedb;
+ 	struct fb_vblank vblank = {};
+ 
++	dev_info(&tegra_fb->ndev->dev,
++		"[tegra-fb] ioctl from '%s': cmd=0x%x\n", current->comm, cmd);
++
+ 	switch (cmd) {
+ #ifdef CONFIG_COMPAT
+ 	case FBIO_TEGRA_GET_MODEDB_COMPAT: {
+@@ -1414,6 +1435,18 @@ struct tegra_fb_info *tegra_fb_register(struct platform_device *ndev,
+ 
+ 	tegra_fb_set_par(info);
+ 
++	dev_info(&ndev->dev,
++		"[tegra-fb] registering fb: xres=%u yres=%u bpp=%u pixclock=%u rotation=%d\n"
++		"[tegra-fb]   var: left=%u right=%u hsync=%u upper=%u lower=%u vsync=%u\n"
++		"[tegra-fb]   DC mode: h_active=%u v_active=%u (FBIOGET_VSCREENINFO will return these)\n",
++		info->var.xres, info->var.yres, info->var.bits_per_pixel,
++		info->var.pixclock,
++		dc->out ? dc->out->rotation : 0,
++		info->var.left_margin, info->var.right_margin,
++		info->var.hsync_len, info->var.upper_margin,
++		info->var.lower_margin, info->var.vsync_len,
++		dc->mode.h_active, dc->mode.v_active);
++
+ 	if (register_framebuffer(info)) {
+ 		dev_err(&ndev->dev, "failed to register framebuffer\n");
+ 		ret = -ENODEV;
+-- 
+2.43.0
+

--- a/projects/L4T/devices/Switch/patches/linux/0013-change-panel-rotation-to-90-from-270.patch
+++ b/projects/L4T/devices/Switch/patches/linux/0013-change-panel-rotation-to-90-from-270.patch
@@ -1,0 +1,138 @@
+From c353aa7ab9aea12ba594cbdf5d2a09dfce844096 Mon Sep 17 00:00:00 2001
+From: theofficialgman <28281419+theofficialgman@users.noreply.github.com>
+Date: Tue, 21 Apr 2026 18:32:10 -0400
+Subject: [PATCH 1/2] change panel rotation to 90 from 270
+
+---
+ nvidia/kernel-dts/nx-panels/panel-a-720p-5-5.dtsi           | 2 +-
+ nvidia/kernel-dts/nx-panels/panel-a-720p-6-2.dtsi           | 2 +-
+ nvidia/kernel-dts/nx-panels/panel-i-720p-5-5.dtsi           | 2 +-
+ nvidia/kernel-dts/nx-panels/panel-i-720p-6-2.dtsi           | 2 +-
+ nvidia/kernel-dts/nx-panels/panel-j-720p-6-2.dtsi           | 2 +-
+ nvidia/kernel-dts/nx-panels/panel-o-720p-6-2.dtsi           | 2 +-
+ nvidia/kernel-dts/nx-panels/panel-s-720p-5-5.dtsi           | 2 +-
+ nvidia/kernel-dts/nx-panels/panel-s-720p-7-0.dtsi           | 2 +-
+ nvidia/kernel-dts/nx-platforms/tegra210-nx-common-disp.dtsi | 3 ---
+ 9 files changed, 8 insertions(+), 11 deletions(-)
+
+diff --git a/nvidia/kernel-dts/nx-panels/panel-a-720p-5-5.dtsi b/nvidia/kernel-dts/nx-panels/panel-a-720p-5-5.dtsi
+index d959875..8a271b2 100644
+--- a/nvidia/kernel-dts/nx-panels/panel-a-720p-5-5.dtsi
++++ b/nvidia/kernel-dts/nx-panels/panel-a-720p-5-5.dtsi
+@@ -82,7 +82,7 @@
+ 					nvidia,out-parent-clk = "pll_d_out0";
+ 					nvidia,out-xres = <720>;
+ 					nvidia,out-yres = <1280>;
+-					nvidia,out-rotation = <270>;
++					nvidia,out-rotation = <90>;
+ 				};
+ 				display-timings {
+ 					720x1280-24 {
+diff --git a/nvidia/kernel-dts/nx-panels/panel-a-720p-6-2.dtsi b/nvidia/kernel-dts/nx-panels/panel-a-720p-6-2.dtsi
+index 7bbd727..28c9a5d 100644
+--- a/nvidia/kernel-dts/nx-panels/panel-a-720p-6-2.dtsi
++++ b/nvidia/kernel-dts/nx-panels/panel-a-720p-6-2.dtsi
+@@ -108,7 +108,7 @@
+ 					nvidia,out-parent-clk = "pll_d_out0";
+ 					nvidia,out-xres = <720>;
+ 					nvidia,out-yres = <1280>;
+-					nvidia,out-rotation = <270>;
++					nvidia,out-rotation = <90>;
+ 				};
+ 				display-timings {
+ 					720x1280-24 {
+diff --git a/nvidia/kernel-dts/nx-panels/panel-i-720p-5-5.dtsi b/nvidia/kernel-dts/nx-panels/panel-i-720p-5-5.dtsi
+index dd599e3..58ea2e8 100644
+--- a/nvidia/kernel-dts/nx-panels/panel-i-720p-5-5.dtsi
++++ b/nvidia/kernel-dts/nx-panels/panel-i-720p-5-5.dtsi
+@@ -82,7 +82,7 @@
+ 					nvidia,out-parent-clk = "pll_d_out0";
+ 					nvidia,out-xres = <720>;
+ 					nvidia,out-yres = <1280>;
+-					nvidia,out-rotation = <270>;
++					nvidia,out-rotation = <90>;
+ 				};
+ 				display-timings {
+ 					720x1280-24 {
+diff --git a/nvidia/kernel-dts/nx-panels/panel-i-720p-6-2.dtsi b/nvidia/kernel-dts/nx-panels/panel-i-720p-6-2.dtsi
+index f63a52f..371ff6b 100644
+--- a/nvidia/kernel-dts/nx-panels/panel-i-720p-6-2.dtsi
++++ b/nvidia/kernel-dts/nx-panels/panel-i-720p-6-2.dtsi
+@@ -82,7 +82,7 @@
+ 					nvidia,out-parent-clk = "pll_d_out0";
+ 					nvidia,out-xres = <720>;
+ 					nvidia,out-yres = <1280>;
+-					nvidia,out-rotation = <270>;
++					nvidia,out-rotation = <90>;
+ 				};
+ 				display-timings {
+ 					720x1280-24 {
+diff --git a/nvidia/kernel-dts/nx-panels/panel-j-720p-6-2.dtsi b/nvidia/kernel-dts/nx-panels/panel-j-720p-6-2.dtsi
+index bdfb83f..a3a137d 100644
+--- a/nvidia/kernel-dts/nx-panels/panel-j-720p-6-2.dtsi
++++ b/nvidia/kernel-dts/nx-panels/panel-j-720p-6-2.dtsi
+@@ -120,7 +120,7 @@
+ 					nvidia,out-parent-clk = "pll_d_out0";
+ 					nvidia,out-xres = <720>;
+ 					nvidia,out-yres = <1280>;
+-					nvidia,out-rotation = <270>;
++					nvidia,out-rotation = <90>;
+ 				};
+ 				display-timings {
+ 					720x1280-24 {
+diff --git a/nvidia/kernel-dts/nx-panels/panel-o-720p-6-2.dtsi b/nvidia/kernel-dts/nx-panels/panel-o-720p-6-2.dtsi
+index 7562141..49c3bbe 100644
+--- a/nvidia/kernel-dts/nx-panels/panel-o-720p-6-2.dtsi
++++ b/nvidia/kernel-dts/nx-panels/panel-o-720p-6-2.dtsi
+@@ -74,7 +74,7 @@
+ 					nvidia,out-parent-clk = "pll_d_out0";
+ 					nvidia,out-xres = <720>;
+ 					nvidia,out-yres = <1280>;
+-					nvidia,out-rotation = <270>;
++					nvidia,out-rotation = <90>;
+ 				};
+ 				display-timings {
+ 					720x1280-24 {
+diff --git a/nvidia/kernel-dts/nx-panels/panel-s-720p-5-5.dtsi b/nvidia/kernel-dts/nx-panels/panel-s-720p-5-5.dtsi
+index b888efc..fc975e0 100644
+--- a/nvidia/kernel-dts/nx-panels/panel-s-720p-5-5.dtsi
++++ b/nvidia/kernel-dts/nx-panels/panel-s-720p-5-5.dtsi
+@@ -82,7 +82,7 @@
+ 					nvidia,out-parent-clk = "pll_d_out0";
+ 					nvidia,out-xres = <720>;
+ 					nvidia,out-yres = <1280>;
+-					nvidia,out-rotation = <270>;
++					nvidia,out-rotation = <90>;
+ 				};
+ 				display-timings {
+ 					720x1280-24 {
+diff --git a/nvidia/kernel-dts/nx-panels/panel-s-720p-7-0.dtsi b/nvidia/kernel-dts/nx-panels/panel-s-720p-7-0.dtsi
+index fa3a389..0e7317b 100644
+--- a/nvidia/kernel-dts/nx-panels/panel-s-720p-7-0.dtsi
++++ b/nvidia/kernel-dts/nx-panels/panel-s-720p-7-0.dtsi
+@@ -88,7 +88,7 @@
+ 					nvidia,out-parent-clk = "pll_d_out0";
+ 					nvidia,out-xres = <720>;
+ 					nvidia,out-yres = <1280>;
+-					nvidia,out-rotation = <270>;
++					nvidia,out-rotation = <90>;
+ 				};
+ 				display-timings {
+ 					720x1280-24 {
+diff --git a/nvidia/kernel-dts/nx-platforms/tegra210-nx-common-disp.dtsi b/nvidia/kernel-dts/nx-platforms/tegra210-nx-common-disp.dtsi
+index 161854a..bc7f420 100644
+--- a/nvidia/kernel-dts/nx-platforms/tegra210-nx-common-disp.dtsi
++++ b/nvidia/kernel-dts/nx-platforms/tegra210-nx-common-disp.dtsi
+@@ -106,9 +106,6 @@
+ 				nvidia,dsi-dpd-pads = <DSIC_DPD_EN DSID_DPD_EN>;
+ 				nvidia,panel-rst-gpio = <&gpio TEGRA_GPIO(V, 2) 0>; /* PV2 */
+ 				nvidia,panel-irq-gpio = <&gpio TEGRA_GPIO(H, 0) 0>; /* WIFI_EN_PH0 */
+-				disp-default-out {
+-					nvidia,out-rotation = <270>;
+-				};
+ 			};
+ 		};
+ 
+-- 
+2.43.0
+

--- a/projects/L4T/devices/Switch/patches/linux/0014-change-IMU-mount-matrix-to-match-landscape-as-defaul.patch
+++ b/projects/L4T/devices/Switch/patches/linux/0014-change-IMU-mount-matrix-to-match-landscape-as-defaul.patch
@@ -1,0 +1,34 @@
+From fa59e3a771fd27a64e753e29f78194366eb05d08 Mon Sep 17 00:00:00 2001
+From: theofficialgman <28281419+theofficialgman@users.noreply.github.com>
+Date: Sat, 25 Apr 2026 23:55:11 -0400
+Subject: [PATCH 2/2] change IMU mount matrix to match landscape as default
+
+---
+ nvidia/kernel-dts/nx-platforms/tegra210-nx-sensor.dtsi | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/nvidia/kernel-dts/nx-platforms/tegra210-nx-sensor.dtsi b/nvidia/kernel-dts/nx-platforms/tegra210-nx-sensor.dtsi
+index f7620e6..f52afd3 100644
+--- a/nvidia/kernel-dts/nx-platforms/tegra210-nx-sensor.dtsi
++++ b/nvidia/kernel-dts/nx-platforms/tegra210-nx-sensor.dtsi
+@@ -77,12 +77,12 @@
+ 
+ 			st,mount-matrix =
+ 				"0", "1",  "0", /* X:  y */
+-				"1", "0",  "0", /* Y:  x */
+-				"0", "0", "-1"; /* Z: -z */
++				"-1", "0",  "0", /* Y:  x */
++				"0", "0", "1"; /* Z: -z */
+ 			invensense,mount-matrix =
+-				"0", "-1",  "0", /* X: -y */
+-				"1",  "0",  "0", /* Y:  x */
+-				"0",  "0", "-1"; /* Z: -z */
++				"0", "1",  "0", /* X: -y */
++				"-1",  "0",  "0", /* Y:  x */
++				"0",  "0", "1"; /* Z: -z */
+ 		};
+ 
+ 		/delete-node/ spi-touch19x12@0;
+-- 
+2.43.0
+

--- a/projects/L4T/options
+++ b/projects/L4T/options
@@ -54,7 +54,9 @@
 
   # Vulkan Support
     VULKAN="vulkan-loader"
-
+    if [ "${VULKAN}" != "no" -a "${VULKAN}" != "" ]; then
+       ADDITIONAL_PACKAGES+=" vk_layer_tegra_x11_present"
+    fi
   # include uvesafb support (yes / no)
     UVESAFB_SUPPORT="no"
 

--- a/projects/L4T/packages/tegra-bsp/assets/10-monitor.conf
+++ b/projects/L4T/packages/tegra-bsp/assets/10-monitor.conf
@@ -8,10 +8,9 @@ Section "Screen"
     Device         "Tegra0"
     Monitor        "Monitor0"
     DefaultDepth   24
-    Option         "metamodes" "DSI-0: nvidia-auto-select @1280x720 +0+0 {ViewPortIn=1280x720, ViewPortOut=720x1280+0+0, Rotation=90}"
+    Option         "metamodes" "DSI-0: nvidia-auto-select @1280x720 +0+0 {ViewPortIn=1280x720, ViewPortOut=1280x720+0+0}"
     Option         "AllowIndirectGLXProtocol" "off"
     Option         "TripleBuffer" "on"
-    Option         "UseNvKmsCompositionPipeline" "false"
     SubSection     "Display"
         Depth       24
     EndSubSection

--- a/projects/L4T/packages/tegra-bsp/assets/20-touchscreen.conf
+++ b/projects/L4T/packages/tegra-bsp/assets/20-touchscreen.conf
@@ -1,5 +1,0 @@
-Section "InputClass"
-	Identifier	"calibration"
-	MatchProduct	"touchscreen"
-	Option       "TransformationMatrix" "0 1 0 -1 0 1"
-EndSection

--- a/projects/L4T/packages/tegra-bsp/package.mk
+++ b/projects/L4T/packages/tegra-bsp/package.mk
@@ -473,7 +473,6 @@ makeinstall_target() {
       cp -P ${PKG_DIR}/assets/xorg.conf ${INSTALL}/etc/X11/
       cat ${PKG_DIR}/assets/10-monitor.conf >> ${INSTALL}/etc/X11/xorg.conf
       cat ${PKG_DIR}/assets/50-joysticks.conf >> ${INSTALL}/etc/X11/xorg.conf
-      cat ${PKG_DIR}/assets/20-touchscreen.conf >> ${INSTALL}/etc/X11/xorg.conf
     fi
   fi
 }

--- a/projects/L4T/packages/vk_layer_tegra_x11_present/package.mk
+++ b/projects/L4T/packages/vk_layer_tegra_x11_present/package.mk
@@ -1,0 +1,11 @@
+PKG_NAME="vk_layer_tegra_x11_present"
+PKG_VERSION="ebee69459788aff5a8d51a9d0558669c15ac6536"
+PKG_LICENSE="GPLv3"
+PKG_SITE="https://github.com/GavinDarkglider/vk_layer_tegra_x11_present"
+PKG_URL="${PKG_SITE}.git"
+PKG_DEPENDS_TARGET="toolchain tegra-bsp vulkan-loader xorg-server"
+PKG_LONGDESC="Vulkan layer to fix tearing issues"
+PKG_TOOLCHAIN="make"
+
+
+PKG_MAKEINSTALL_OPTS_TARGET="LAYERLIBDIR=/usr/lib LAYERJSONDIR=/etc/vulkan/implicit_layer.d"


### PR DESCRIPTION
1. kernel patching to remove need to rotate in X11 which causes a driver level frame stutter.
2. vsync issues for switch all around. There are some driver issues that needed working around, since drivers are eol. Since we don't use a compositor, we get terrible vulkan tearing
3. Update Kodi battery patches to fix an issue with libreelec addon locking up interface. Useless for lakka, but libreelec doesn't want the switch build upstream.