### PR TITLE
Pull pipewire, wireplumber updates from LibreELEC

### DIFF
--- a/config/show_config
+++ b/config/show_config
@@ -47,6 +47,7 @@ show_config() {
 
   config_message+="\n - ALSA support:\t\t\t ${ALSA_SUPPORT}"
   config_message+="\n - Pulseaudio support:\t\t\t ${PULSEAUDIO_SUPPORT}"
+  config_message+="\n - Pipewire support:\t\t\t ${PIPEWIRE_SUPPORT}"
   config_message+="\n - Bluetooth support:\t\t\t ${BLUETOOTH_SUPPORT}"
 
   for config_driver in ${ADDITIONAL_DRIVERS}; do

--- a/packages/audio/pipewire/package.mk
+++ b/packages/audio/pipewire/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="pipewire"
-PKG_VERSION="1.0.4"
-PKG_SHA256="ce00e0cee3eefaf8e92eecf5d28985f6dab43ccfe7e704d41b0cfda8376a187c"
+PKG_VERSION="1.6.4"
+PKG_SHA256="e31ae906dc7fee1c56ccc4279247b385685b926b3f900cebd910d4bd4403d86b"
 PKG_LICENSE="LGPL"
 PKG_SITE="https://pipewire.org"
 PKG_URL="https://github.com/PipeWire/pipewire/archive/${PKG_VERSION}.tar.gz"
@@ -31,7 +31,7 @@ PKG_MESON_OPTS_TARGET="-Ddocs=disabled \
                        -Dinstalled_tests=disabled \
                        -Dgstreamer=disabled \
                        -Dgstreamer-device-provider=disabled \
-                       -Dsystemd=enabled \
+                       -Dlibsystemd=enabled \
                        -Dsystemd-system-service=enabled \
                        -Dsystemd-user-service=disabled \
                        -Dpipewire-alsa=enabled \

--- a/packages/audio/wireplumber/package.mk
+++ b/packages/audio/wireplumber/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2022-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="wireplumber"
-PKG_VERSION="0.4.17"
-PKG_SHA256="a12534fd9c1ecf9fbc09f79192d9d57c9ab7bf01da82615ab4103b2f8e2e91a7"
+PKG_VERSION="0.5.14"
+PKG_SHA256="e91f04cd8cec75d72b8a2aaa7e90b1ba0a5e2094b7a882fc3a29a484a48a87e9"
 PKG_LICENSE="MIT"
 PKG_SITE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 PKG_URL="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}.tar.gz"
@@ -25,21 +25,30 @@ post_makeinstall_target() {
   sed '/^\[Service\]/a Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket' -i ${INSTALL}/usr/lib/systemd/system/wireplumber.service
 
   # ref https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/0da29f38181e391160fa8702623050b8544ec775
-  cat > ${INSTALL}/usr/share/wireplumber/main.lua.d/89-disable-session-dbus-dependent-features.lua << EOF
-alsa_monitor.properties["alsa.reserve"] = false
-default_access.properties["enable-flatpak-portal"] = false
+  # ref https://github.com/PipeWire/wireplumber/blob/master/docs/rst/daemon/configuration/migration.rst
+  # ref https://github.com/PipeWire/wireplumber/blob/master/docs/rst/daemon/configuration/features.rst
+  cat >${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-session-dbus-dependent-features.conf <<EOF
+wireplumber.profiles = {
+  main = {
+    monitor.alsa.reserve-device = disabled
+    monitor.bluez.seat-monitoring = disabled
+    support.portal-permissionstore = disabled
+  }
+}
 EOF
 
-  cat > ${INSTALL}/usr/share/wireplumber/main.lua.d/89-disable-v4l2.lua << EOF
-v4l2_monitor.enabled = false
+  cat >${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-v4l2.conf <<EOF
+wireplumber.profiles = {
+  main = {
+    monitor.v4l2 = disabled
+  }
+}
 EOF
 
-  cat > ${INSTALL}/usr/share/wireplumber/bluetooth.lua.d/89-disable-session-dbus-dependent-features.lua << EOF
-bluez_monitor.properties["with-logind"] = false
-EOF
-
-  cat > ${INSTALL}/usr/share/wireplumber/bluetooth.lua.d/89-disable-bluez-hfphsp-backend.lua << EOF
-bluez_monitor.properties["bluez5.hfphsp-backend"] = "none"
+  cat >${INSTALL}/usr/share/wireplumber/wireplumber.conf.d/89-disable-bluez-hfphsp-backend.conf <<EOF
+monitor.bluez.properties = {
+  bluez5.hfphsp-backend = "none"
+}
 EOF
 }
 


### PR DESCRIPTION
I've copied over some audio related package updates. Also edited `show_config` to display pipewire support.

I could try to cherry-pick instead, but pipewire was not updated in a while.