### PR TITLE
virtualxt: enable virtualxt core on ARCH=arm for Lakka-v6.1

### DIFF
--- a/packages/lakka/libretro_cores/virtualxt/package.mk
+++ b/packages/lakka/libretro_cores/virtualxt/package.mk
@@ -1,10 +1,6 @@
 PKG_NAME="virtualxt"
 PKG_VERSION="1f074e7c3f32d2c523d730d51b9f974c65e530e7"
 PKG_LICENSE="zlib"
-# temporarily disable on arm because build failure is occurred.
-# https://github.com/virtualxt/virtualxt/issues/97
-# please enable (remove "!arm" in PKG_ARCH ) when build failure is fixed.
-PKG_ARCH="any !arm"
 PKG_SITE="https://codeberg.org/virtualxt/virtualxt"
 PKG_URL="${PKG_SITE}.git"
 PKG_DEPENDS_TARGET="toolchain"


### PR DESCRIPTION
## This PR enables the virtualxt core on ARCH=arm for Lakka-v6.1 branch.
https://github.com/virtualxt/virtualxt/issues/97
This issue was not happened on newer virtualxt version and updated linker.

So we can enable/use the virtualxt core on ARCH=arm.

### Build
- All PROECT/DEVICE builds are passed with no error.
```
Build job 34/34, so far 33 successful builds, 0 failed builds
Creating release files / images...done!
Moving release files (.img.gz, .tar) to subfolder...done!
Removing unused files (.ova,kernel,system)...done!

All successful!
:-)
```
### Confirmation
- There is "virtualxt_libretro.so" file in the following all ARCH=arm builds "install_pkg" directory.
  \- Allwinner: H2-plus.arm, H3.arm, R40.arm
  \- NXP: iMX6.arm
  \- RPi: RPi.arm, RPi2.arm, RPiZero-GPiCase.arm, RPiZero2-GPiCase.arm
  \- Rockchip: RK3288.arm
  \- Samsung: Exynos.arm

### Note
I will create same content PR for devel branch later.

Thanks
ASAI, Shigeaki