### PR TITLE
retroarch: RPi5/4: add workaround patch for RPi5/4 vulkan retroarch.servise start failure

### DIFF
--- a/projects/RPi/devices/RPi4/patches/retroarch/retroarch-workaround-vulkan.patch
+++ b/projects/RPi/devices/RPi4/patches/retroarch/retroarch-workaround-vulkan.patch
@@ -1,0 +1,1 @@
+../../../RPi5/patches/retroarch/retroarch-workaround-vulkan.patch

--- a/projects/RPi/devices/RPi5/patches/retroarch/retroarch-workaround-vulkan.patch
+++ b/projects/RPi/devices/RPi5/patches/retroarch/retroarch-workaround-vulkan.patch
@@ -1,0 +1,30 @@
+diff -uNr a/gfx/common/vulkan_common.c b/gfx/common/vulkan_common.c
+--- a/gfx/common/vulkan_common.c	2026-01-17 09:26:07.000000000 +0900
++++ b/gfx/common/vulkan_common.c	2026-06-04 19:31:06.616335870 +0900
+@@ -2281,16 +2281,21 @@
+    info.pNext                  = NULL;
+    info.flags                  = 0;
+    info.surface                = vk->vk_surface;
+-   info.minImageCount          = desired_swapchain_images;
++   // info.minImageCount          = desired_swapchain_images;
++   if(desired_swapchain_images < 3)
++      info.minImageCount          = desired_swapchain_images;
++   else
++      info.minImageCount          = 2;
+    info.imageFormat            = format.format;
+    info.imageColorSpace        = format.colorSpace;
+    info.imageExtent.width      = swapchain_size.width;
+    info.imageExtent.height     = swapchain_size.height;
+    info.imageArrayLayers       = 1;
+-   info.imageUsage             =  VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+-                                | VK_IMAGE_USAGE_TRANSFER_SRC_BIT
+-                                | VK_IMAGE_USAGE_TRANSFER_DST_BIT
+-                                | VK_IMAGE_USAGE_SAMPLED_BIT;
++   // info.imageUsage             =  VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
++   //                              | VK_IMAGE_USAGE_TRANSFER_SRC_BIT
++   //                              | VK_IMAGE_USAGE_TRANSFER_DST_BIT
++   //                              | VK_IMAGE_USAGE_SAMPLED_BIT;
++   info.imageUsage             = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    info.imageSharingMode       = VK_SHARING_MODE_EXCLUSIVE;
+    info.queueFamilyIndexCount  = 0;
+    info.pQueueFamilyIndices    = NULL;


### PR DESCRIPTION
## This PR is workaround for issue #2217.
For more details, please see [#2217](https://github.com/libretro/Lakka-LibreELEC/issues/2217).
And, this workaround patch file was also good on RPi4 vulkan,

<BR>

### Build
The following RPi5/4 builds are passed.
- DISTRO=Lakka PROJECT=RPi DEVICE=RPi4               ARCH=aarch64 make image
- DISTRO=Lakka PROJECT=RPi DEVICE=RPi5               ARCH=aarch64 make image

<BR>

### Confirmation
- RPi5 vulkan: retroarch is started.
- RPi4 vulkan: retroarch is started.

<BR>

Thanks
ASAI, Shigeaki