### PR TITLE
Fix Exynos ODROID-XU4 audio issue

### DIFF
--- a/packages/audio/alsa-lib/package.mk
+++ b/packages/audio/alsa-lib/package.mk
@@ -41,4 +41,19 @@ post_install() {
     sed -e "s|^options snd-usb-audio index=.*$|options snd-usb-audio index=0|g" \
         -i ${INSTALL}/usr/lib/modprobe.d/alsa-base.conf
   fi
+  if [ "${DISTRO}" = "Lakka" ] && [ "${PROJECT}" = "Samsung" ] && [ "${DEVICE}" = "Exynos" ]; then
+    mkdir -p ${INSTALL}/etc
+    cat << 'EOF' > ${INSTALL}/etc/asound.conf
+pcm.!default {
+    type hw
+    card 0
+    device 2
+}
+
+ctl.!default {
+    type hw
+    card 0
+}
+EOF
+  fi
 }

--- a/packages/lakka/retroarch_base/retroarch/package.mk
+++ b/packages/lakka/retroarch_base/retroarch/package.mk
@@ -190,8 +190,8 @@ makeinstall_target() {
   fi
 
   if [ "${PROJECT}" = "Samsung" -a "${DEVICE}" = "Exynos" ]; then
-    # workaround the 55fps bug
-    sed -i ${ra_config} -e 's|^audio_out_rate = .*|audio_out_rate = "44100"|'
+    # it keeps this "if" block for the future update.
+    :
   fi
 
   # RK3326 - HARDKERNEL OdroidGoAdvance or compatible devices


### PR DESCRIPTION
## This PR fixes audio issue on Sumsung Exynos devices.
This PR is related with https://github.com/libretro/Lakka-LibreELEC/issues/2200

### Build
DISTRO=Lakka PROJECT=Samsung DEVICE=Exynos ARCH=arm make image
is passed.

### Test
The following tests are passed on ODROID-XU4.
- linux and retroarch is able to start
- HDMI audio is working (Tested by ShigeakiAsai)
- Headphone audio is working (Tested by [Kirilych](https://github.com/Kirilych))

Thanks,
ASAI, Shigeaki