### PR TITLE
RPi3/4/5-Composite: Add support RetroFlag cases

### DIFF
--- a/packages/lakka/lakka_tools/retroflag_picase_safeshutdown/package.mk
+++ b/packages/lakka/lakka_tools/retroflag_picase_safeshutdown/package.mk
@@ -1,5 +1,5 @@
 PKG_NAME="retroflag_picase_safeshutdown"
-PKG_VERSION="1.0"
+PKG_VERSION="1.1"
 PKG_ARCH="aarch64"
 PKG_DEPENDS_TARGET="Python3 lg-gpio"
 PKG_SECTION="system"
@@ -8,19 +8,19 @@ PKG_TOOLCHAIN="manual"
 
 makeinstall_target() {
   mkdir -p "${INSTALL}/usr/bin"
-    if [ "${DEVICE}" = "RPi3" -o "${DEVICE}" = "RPi4" ]; then
+    if [ "${DEVICE:0:4}" = "RPi3" -o "${DEVICE}" = "RPi4" -o "${DEVICE}" = "RPi4-Composite" ]; then
       cp -av "${PKG_DIR}/scripts/retroflag_picase_safeshutdown.py" "${INSTALL}/usr/bin"
       cp -av "${PKG_DIR}/scripts/retroflag_picase_check_gpio-poweroff_overlay.sh" "${INSTALL}/usr/bin"
       cp -av "${PKG_DIR}/scripts/retroflag_picase_install_gpio-poweroff_overlay.sh" "${INSTALL}/usr/bin"
-    elif [ "${DEVICE}" = "RPi5" ]; then
+    elif [ "${DEVICE:0:4}" = "RPi5" ]; then
       cp -av "${PKG_DIR}/scripts/retroflag_picase_safeshutdown_pi5.py" "${INSTALL}/usr/bin"
     fi
 }
 
 post_install() {
-  if [ "${DEVICE}" = "RPi3" -o "${DEVICE}" = "RPi4" ]; then
+  if [ "${DEVICE:0:4}" = "RPi3" -o "${DEVICE}" = "RPi4" -o "${DEVICE}" = "RPi4-Composite" ]; then
     enable_service retroflag_picase_safeshutdown.service
-  elif [ "${DEVICE}" = "RPi5" ]; then
+  elif [ "${DEVICE:0:4}" = "RPi5" ]; then
     enable_service retroflag_picase_safeshutdown_pi5.service
   fi
 }

--- a/projects/RPi/devices/RPi3-Composite/patches/retroarch/001_retroarch-retroflag_picase_safeshutdown_enable_disable.patch
+++ b/projects/RPi/devices/RPi3-Composite/patches/retroarch/001_retroarch-retroflag_picase_safeshutdown_enable_disable.patch
@@ -1,0 +1,1 @@
+../../../RPi4/patches/retroarch/001_retroarch-retroflag_picase_safeshutdown_enable_disable.patch

--- a/projects/RPi/devices/RPi3-Composite/patches/retroarch/002_retroarch-retroflag_picase_safeshutdown_gpio-poweroff_overlay.patch
+++ b/projects/RPi/devices/RPi3-Composite/patches/retroarch/002_retroarch-retroflag_picase_safeshutdown_gpio-poweroff_overlay.patch
@@ -1,0 +1,1 @@
+../../../RPi4/patches/retroarch/002_retroarch-retroflag_picase_safeshutdown_gpio-poweroff_overlay.patch

--- a/projects/RPi/devices/RPi3-Composite/patches/retroarch/003_retroarch-retroflag_picase_safeshutdown_reboot_is_required.patch
+++ b/projects/RPi/devices/RPi3-Composite/patches/retroarch/003_retroarch-retroflag_picase_safeshutdown_reboot_is_required.patch
@@ -1,0 +1,1 @@
+../../../RPi4/patches/retroarch/003_retroarch-retroflag_picase_safeshutdown_reboot_is_required.patch

--- a/projects/RPi/devices/RPi4-Composite/patches/retroarch/001_retroarch-retroflag_picase_safeshutdown_enable_disable.patch
+++ b/projects/RPi/devices/RPi4-Composite/patches/retroarch/001_retroarch-retroflag_picase_safeshutdown_enable_disable.patch
@@ -1,0 +1,1 @@
+../../../RPi4/patches/retroarch/001_retroarch-retroflag_picase_safeshutdown_enable_disable.patch

--- a/projects/RPi/devices/RPi4-Composite/patches/retroarch/002_retroarch-retroflag_picase_safeshutdown_gpio-poweroff_overlay.patch
+++ b/projects/RPi/devices/RPi4-Composite/patches/retroarch/002_retroarch-retroflag_picase_safeshutdown_gpio-poweroff_overlay.patch
@@ -1,0 +1,1 @@
+../../../RPi4/patches/retroarch/002_retroarch-retroflag_picase_safeshutdown_gpio-poweroff_overlay.patch

--- a/projects/RPi/devices/RPi4-Composite/patches/retroarch/003_retroarch-retroflag_picase_safeshutdown_reboot_is_required.patch
+++ b/projects/RPi/devices/RPi4-Composite/patches/retroarch/003_retroarch-retroflag_picase_safeshutdown_reboot_is_required.patch
@@ -1,0 +1,1 @@
+../../../RPi4/patches/retroarch/003_retroarch-retroflag_picase_safeshutdown_reboot_is_required.patch


### PR DESCRIPTION
## This PR fixes https://github.com/libretro/Lakka-LibreELEC/issues/2235
RPI3-Composite and RPI4-Composite both do not include the RetroFlag cases support.
So this PR add to use the RetroFlag cases support patch in puth devices.
The patch files are symlink to RPi4 and RPi3 patch file.


### Build
- DISTRO=Lakka PROJECT=RPi DEVICE=RPi3-Composite     ARCH=aarch64 make image
- DISTRO=Lakka PROJECT=RPi DEVICE=RPi4-Composite     ARCH=aarch64 make image
- DISTRO=Lakka PROJECT=RPi DEVICE=RPi5-Composite     ARCH=aarch64 make image

above 3 builds are passed.


### Test
I can't test it because I have no Composite divece,
<s> I'm wating result for test in issue #2235. </s> 


Thanks,
ASAI, Shigeaki