### PR TITLE
bcm2835-bootloader: Fix Bluetooth on RPi3/4 Composite builds

### DIFF
--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -52,5 +52,8 @@ makeinstall_target() {
       echo "hdmi_max_pixel_freq:0=200000000" >> ${INSTALL}/usr/share/bootloader/distroconfig.txt
       echo "hdmi_max_pixel_freq:1=200000000" >> ${INSTALL}/usr/share/bootloader/distroconfig.txt
       echo "force_turbo=0" >> ${INSTALL}/usr/share/bootloader/config.txt
+      if [ "${DEVICE}" = "RPi3-Composite" ] || [ "${DEVICE}" = "RPi4-Composite" ]; then
+        echo "dtparam=krnbt=on" >> ${INSTALL}/usr/share/bootloader/distroconfig.txt
+      fi
     fi
 }


### PR DESCRIPTION
## Description:

### This PR fixes issue #2234

On RPi Composite builds, the onboard Bluetooth controller is not recognized by BlueZ (No default controller available), while the standard HDMI builds work correctly on the same hardware.

### Root cause:

Composite builds use the Linux 5.10 kernel to maintain analog video output. With newer versions of BlueZ, the kernel does not hand off the onboard Bluetooth HCI device to BlueZ without explicitly enabling kernel-side Bluetooth management via "dtparam=krnbt=on".

### Fix:

Append "dtparam=krnbt=on" to distroconfig.txt when building for RPi3-Composite or RPi4-Composite.

### Testing:

- RPi3-Composite: confirmed Bluetooth controller recognized after fix ✅
- RPi4-Composite: confirmed Bluetooth controller recognized after fix ✅

### Notes:

- No impact on standard HDMI builds
- RPi5 Composite builds use the Linux 6.12.77 kernel is likely unaffected as it ships with a newer kernel where this issue does not occur.


Thanks
ASAI, Shigeaki